### PR TITLE
+ DM: explicit caching

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/explicitcaching/ExplicitCacher.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/explicitcaching/ExplicitCacher.java
@@ -1,0 +1,6 @@
+package sapphire.policy.explicitcaching;
+
+public interface ExplicitCacher {
+    public void pull();
+    public void push();
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/explicitcaching/ExplicitCachingPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/explicitcaching/ExplicitCachingPolicy.java
@@ -1,0 +1,84 @@
+package sapphire.policy.explicitcaching;
+
+import sapphire.common.AppObject;
+import sapphire.policy.DefaultSapphirePolicy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+// caching with explicit push and pull calls from the application
+// The guarded SO MUST provide pull/push method body (placeholder) of ExplicitCacher interface
+// TODO: stub generator to generate related methods
+// TODO: inherit from a common caching base class which has getCopy/syncCopy methods
+public class ExplicitCachingPolicy extends DefaultSapphirePolicy{
+    public static class ExplicitCachingClientPolicy extends DefaultClientPolicy {
+        private AppObject cachedCopy = null;
+
+        private void pull() {
+            this.cachedCopy = ((ExplicitCachingServerPolicy)this.getServer()).getCopy();
+        }
+
+        private void push() {
+            ((ExplicitCachingServerPolicy)this.getServer()).syncCopy(this.cachedCopy);
+        }
+
+        // for unit test use
+        public void setCopy(AppObject copy) {
+            this.cachedCopy = copy;
+        }
+
+        // for unit test use
+        public AppObject getCachedCopy() {
+            return cachedCopy;
+        }
+
+        private Boolean isPull(String method) {
+            // todo: stringent check more than simple base name
+            return method.endsWith(".pull()");
+        }
+
+        private Boolean isPush(String method) {
+            // todo: stringent check more than simple base name
+            return method.endsWith(".push()");
+        }
+
+        @Override
+        public Object onRPC(String method, ArrayList<Object> params) throws Exception {
+            // almost every op goes against local cache, except for pull/push
+            if (this.isPull(method)) {
+                this.cachedCopy = ((ExplicitCachingServerPolicy)this.getServer()).getCopy();
+                return null;
+            }
+
+            if (this.isPush(method)) {
+                if (this.cachedCopy != null){
+                    ((ExplicitCachingServerPolicy)this.getServer()).syncCopy(this.cachedCopy.getObject());
+                }
+                return null;
+            }
+
+            if (this.cachedCopy == null) {
+                this.cachedCopy = ((ExplicitCachingServerPolicy)this.getServer()).getCopy();
+            }
+
+            if (!((Object)this.cachedCopy.getObject() instanceof ExplicitCacher)) {
+                throw new IllegalArgumentException("should be subclass of ExcplicitCacher");
+            }
+
+            return this.cachedCopy.invoke(method, params);
+        }
+    }
+
+    public static class ExplicitCachingServerPolicy extends DefaultServerPolicy {
+        public AppObject getCopy(){
+            return this.appObject;
+        }
+
+        public void syncCopy(Serializable object) {
+            appObject.setObject(object);
+        }
+    }
+
+    public static class ExplicitCachingGroupPolicy extends DefaultGroupPolicy {}
+
+}

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/explicitcaching/ExplicitCachingPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/explicitcaching/ExplicitCachingPolicyTest.java
@@ -1,0 +1,89 @@
+package sapphire.policy.explicitcaching;
+
+import org.junit.Before;
+import org.junit.Test;
+import sapphire.common.AppObject;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
+public class ExplicitCachingPolicyTest {
+    ExplicitCachingPolicy.ExplicitCachingClientPolicy client;
+    ExplicitCachingPolicy.ExplicitCachingServerPolicy server;
+
+    @Before
+    public void setUp() throws Exception {
+        this.client = new ExplicitCachingPolicy.ExplicitCachingClientPolicy();
+        this.server = mock(ExplicitCachingPolicy.ExplicitCachingServerPolicy.class);
+        this.client.setServer(this.server);
+    }
+
+    @Test
+    public void firstRPCPulls() throws Exception {
+        Serializable so = mock(Serializable.class, withSettings().extraInterfaces(ExplicitCacher.class));
+        AppObject appObject = mock(AppObject.class);
+        when(appObject.getObject()).thenReturn(so);
+        when(this.server.getCopy()).thenReturn(appObject);
+
+        assertNull(this.client.getCachedCopy());
+
+        ArrayList<Object> params = new ArrayList<Object>();
+        this.client.onRPC("foo", params);
+
+        assertEquals(so, this.client.getCachedCopy().getObject());
+        verify(this.server, times(1)).getCopy();
+    }
+
+    @Test
+    public void regularRPC() throws Exception {
+        ArrayList<Object> params = new ArrayList<Object>();
+        Serializable so = mock(Serializable.class, withSettings().extraInterfaces(ExplicitCacher.class));
+        AppObject localCopy = mock(AppObject.class);
+        when(localCopy.getObject()).thenReturn(so);
+        this.client.setCopy(localCopy);
+
+        this.client.onRPC("foo", params);
+
+        verify(localCopy, times(1)).invoke("foo", params);
+        verifyZeroInteractions(this.server);
+    }
+
+    @Test
+    public void pull() throws Exception{
+        String methodPull = "public void sapphire.appexamples.minnietwitter.app.UserManager.pull()";
+
+        Serializable latestSO = mock(Serializable.class, withSettings().extraInterfaces(ExplicitCacher.class));
+        AppObject remoteCopy = mock(AppObject.class);
+        when(remoteCopy.getObject()).thenReturn(latestSO);
+        when(this.server.getCopy()).thenReturn(remoteCopy);
+
+        AppObject staleLocalCopy = mock(AppObject.class);
+        this.client.setCopy(staleLocalCopy);
+
+        this.client.onRPC(methodPull, new ArrayList<Object>());
+
+        verifyZeroInteractions(staleLocalCopy);
+        AppObject localCopy = this.client.getCachedCopy();
+        assertEquals(latestSO, localCopy.getObject());
+    }
+
+    @Test
+    public void push() throws Exception{
+        String methodPush = "public void sapphire.appexamples.minnietwitter.app.UserManager.push()";
+
+        Serializable latestSO = mock(Serializable.class);
+        AppObject localCopy = mock(AppObject.class);
+        when(localCopy.getObject()).thenReturn(latestSO);
+        this.client.setCopy(localCopy);
+
+        this.client.onRPC(methodPush, new ArrayList<Object>());
+
+        verifyZeroInteractions(latestSO);
+        verify(this.server, times(1)).syncCopy(latestSO);
+        assertEquals(latestSO, this.client.getCachedCopy().getObject());
+    }
+}


### PR DESCRIPTION
## explicit caching DM
### implementation
Expecting the SO provide ExplicitCacher method skeletal body for pull/push method.   
### unit test cases
* firstRPCPulls: pull object from remote server before the first op on SO 
* regularRPC: all ops go for local cache only
* pull: explicit invalidate local cache and get fresh from remote
* push: explicit update the remote SO with the local cached copy