### PR TITLE
Update to OMS KernerServerManager and Sapphire ShiftPolicy (demo DM).

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/ShiftPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/ShiftPolicy.java
@@ -69,7 +69,13 @@ public class ShiftPolicy extends SapphirePolicy {
 			if (this.shiftRPCLoad > 0 && this.shiftRPCLoad % this.LOAD == 0) {
 				logger.info("[ShiftPolicy] Limit reached at " + this.LOAD + ". Shift policy triggered.");
 				OMSServer oms = GlobalKernelReferences.nodeServer.oms;
-				ArrayList<InetSocketAddress> servers = oms.getServers();
+
+				ArrayList<String> regions = oms.getRegions();
+				ArrayList<InetSocketAddress> servers = new ArrayList<InetSocketAddress>();
+
+				for (String region : regions) {
+					servers.add(oms.getServerInRegion(region));
+				}
 
 				KernelServerImpl localKernel = GlobalKernelReferences.nodeServer;
 				InetSocketAddress localAddress = localKernel.getLocalHost();


### PR DESCRIPTION
1. Reverted getServers() in KernelServerManager to previous one.
2. Updated ShiftPolicy to use getRegions instead of getServers.
3. Added TODO comments regarding regions and servers.
4. Added a registerKernelServer that uses region value.

This commit addresses Quinton's comments regarding the previously merged pull request:
https://github.com/Huawei-PaaS/DCAP-Sapphire/pull/32#pullrequestreview-88289601