### PR TITLE
Fixed a few bugs in TwitterActivityOne and TwitterActityTwo

### DIFF
--- a/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/device/TwitterActivityOne.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/device/TwitterActivityOne.java
@@ -25,12 +25,13 @@ public class TwitterActivityOne {
 
 			System.out.println("Connected to the OMS: " + server);
 			
-            KernelServer nodeServer = new KernelServerImpl(new InetSocketAddress("192.168.10.191", Integer.parseInt(args[1])), new InetSocketAddress(args[2], Integer.parseInt(args[3])));
+            KernelServer nodeServer = new KernelServerImpl(new InetSocketAddress(args[0], Integer.parseInt(args[1])), new InetSocketAddress(args[2], Integer.parseInt(args[3])));
             
 			TwitterManager tm = (TwitterManager) server.getAppEntryPoint();
             System.out.println("Received Twitter Manager Stub: " + tm);
             
             UserManager userManger = tm.getUserManager();
+            userManger.addUser("user12", "pwd");
             User u = userManger.getUser("user12");
             Timeline timeline = u.getTimeline();
             

--- a/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/device/TwitterActivityTwo.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/device/TwitterActivityTwo.java
@@ -22,7 +22,7 @@ public class TwitterActivityTwo {
 			registry = LocateRegistry.getRegistry(args[0],Integer.parseInt(args[1]));
 			OMSServer server = (OMSServer) registry.lookup("SapphireOMS");
 
-            KernelServer nodeServer = new KernelServerImpl(new InetSocketAddress("192.168.10.191", Integer.parseInt(args[1])), new InetSocketAddress(args[2], Integer.parseInt(args[3])));
+            KernelServer nodeServer = new KernelServerImpl(new InetSocketAddress(args[0], Integer.parseInt(args[1])), new InetSocketAddress(args[2], Integer.parseInt(args[3])));
             
 			TwitterManager tm = (TwitterManager) server.getAppEntryPoint();
             System.out.println("Received Twitter Manager Stub: " + tm);
@@ -30,20 +30,22 @@ public class TwitterActivityTwo {
             UserManager userManger = tm.getUserManager();
             TagManager tagManager = tm.getTagManager();
             
-            User me = userManger.addUser("aaasz", "aaasz");
+            User me = userManger.addUser("user1", "user1_password");
             Timeline myTimeline = me.getTimeline();
-            User peer = userManger.getUser("iyzhang");
+            User peer = userManger.getUser("user1");
             
             peer.addFollowing(me);
             me.addFollower(peer);
             
             Timeline peerTimeline = peer.getTimeline();
+            peerTimeline.tweet("peer hello");
             List<Tweet> peerTweets = peerTimeline.getTweets(0, 1);
             myTimeline.retweet(peerTweets.get(0));
 
             List<Tweet> myTweets = myTimeline.getTweets(0, 1);
             System.out.println("My tweet:" + myTweets.get(0).getText());
-            
+
+            tagManager.addTag("#goodlife", myTweets.get(0));
             List<Tweet> tweetsForTag = tagManager.getTweetsForTag("#goodlife", 0, 1);
             System.out.println(tweetsForTag.get(0).getText());
 


### PR DESCRIPTION
This commit fixes a few bugs in `TwitterActivityOne` and `TwitterActivityTwo`. 

`TwitterActivityOne` and `TwitterActivityTwo` are two standalone Java applications. They do not require Android simulator. Therefore It is very convenient to use them for integration tests. Today these two applications don't work because of some minor bugs. With this PR, you should be able to run them again.