### PR TITLE
Add delstubs and genstubs in build.gradle

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -12,6 +12,21 @@ task deleteJar(type: Delete) {
     delete 'libs/sapphire-core.jar'
 }
 
+// run `gradle delstubs` to remove stub java files
+task delstubs(type: Delete) {
+    delete fileTree('src/main/java/sapphire/policy/stubs') {
+        include '**/*_Stub.java'
+    }
+}
+
+// TODO: We could use gradle to do automatic incremental builds.  
+// Details can be found at https://blog.gradle.org/introducing-incremental-build-support
+task genstubs(type: Exec) {
+  dependsOn 'delstubs', 'build'
+  executable "sh"
+  args "-c", "pushd ../../generators && python generate_policy_stubs_on_host.py && popd"
+}
+
 task createJar(type: Copy) {
     from('build/intermediates/bundles/release/')
     into('libs/jars/')


### PR DESCRIPTION
With this change, we will be able to delete existing stub java files
with `gradle delstubs` and generate stub java files with `gradle
genstubs`.