### PR TITLE
genstub fix - use bash to ensure pushd is available

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -23,7 +23,7 @@ task delstubs(type: Delete) {
 // Details can be found at https://blog.gradle.org/introducing-incremental-build-support
 task genstubs(type: Exec) {
   dependsOn 'delstubs', 'build'
-  executable "sh"
+  executable "bash"
   args "-c", "pushd ../../generators && python generate_policy_stubs_on_host.py && popd"
 }
 


### PR DESCRIPTION
## pushd was not available in sh(dash) #3 
on some build machines gradle sapphire-core genstubs fails with "sh pushd is not found".
<br> explicit use of bash to ensure its presence