### PR TITLE
Distributed transaction part 2:  2PC component server policy type (skeletal)

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/SandboxProvider.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/SandboxProvider.java
@@ -1,0 +1,19 @@
+package sapphire.policy.transaction;
+
+import java.util.UUID;
+
+import static sapphire.policy.SapphirePolicyUpcalls.SapphireServerPolicyUpcalls;
+import static sapphire.policy.transaction.TwoPCCohortPolicy.TwoPCCohortServerPolicy;
+
+/**
+ * type to provide sandbox
+ */
+public interface SandboxProvider {
+    /**
+     * gets the sandbox of the origin thing associated with specified transaction
+     * @param origin the origin of thing
+     * @param transactionId id of the transaction
+     * @return sandbox associated with the transaction
+     */
+    SapphireServerPolicyUpcalls getSandbox(TwoPCCohortServerPolicy origin, UUID transactionId);
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TransactionManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TransactionManager.java
@@ -1,0 +1,46 @@
+package sapphire.policy.transaction;
+
+import java.util.UUID;
+
+/**
+ * abstraction of transaction status management
+ */
+public interface TransactionManager {
+    /**
+     * type of vote response as defined in 2PC protocol
+     */
+    enum Vote {
+        UNCERTIAN, YES, NO,
+    }
+
+    /**
+     * joins the transaction
+      * @param transactionId id of the effective transaction
+     */
+    void join(UUID transactionId);
+
+    /**
+     * leaves the transaction while the transaction is still active/effective
+     * @param transactionId id of the effective transaction
+     */
+    void leave(UUID transactionId);
+
+    /**
+     * reports the vote of the effective transaction based on local status
+     * @param transactionId id of the effective transaction
+     * @return
+     */
+    Vote vote(UUID transactionId);
+
+    /**
+     * commits the transaction
+     * @param transactionId id of the effective transaction
+     */
+    void commit(UUID transactionId);
+
+    /**
+     * aborts the transaction
+     * @param transactionId id of the effective transaction
+     */
+    void abort(UUID transactionId);
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCPrimitive.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCPrimitive.java
@@ -1,0 +1,39 @@
+package sapphire.policy.transaction;
+
+import java.util.Objects;
+
+/**
+ * utility class for 2PC primitive verbs
+ */
+class TwoPCPrimitive {
+    final static String VoteReq = "tx_vote_req";
+    final static String Commit = "tx_commit";
+    final static String Abort = "tx_abort";
+
+    /**
+     * checks for the vote_req promitive verb
+     * @param methodName the input to be checked
+     * @return the check result
+     */
+    static boolean isVoteRequest(String methodName) {
+        return Objects.equals(methodName, VoteReq);
+    }
+
+    /**
+     * checks for transaction commit verb
+     * @param methodName the input to be checked
+     * @return the check result
+     */
+    static boolean isCommit(String methodName) {
+        return Objects.equals(methodName, Commit);
+    }
+
+    /**
+     * checks for transaction abort verb
+     * @param methodName the input to be checked
+     * @return the check result
+     */
+    static boolean isAbort(String methodName) {
+        return Objects.equals(methodName, Abort);
+    }
+}

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/TwoPCCohortServerPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/TwoPCCohortServerPolicyTest.java
@@ -1,0 +1,70 @@
+package sapphire.policy.transaction;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import sapphire.common.AppObject;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+import static sapphire.policy.transaction.TwoPCCohortPolicy.TwoPCCohortServerPolicy;
+import static sapphire.policy.SapphirePolicyUpcalls.SapphireServerPolicyUpcalls;
+
+public class TwoPCCohortServerPolicyTest {
+    private SandboxProvider sandboxProvider = mock(SandboxProvider.class);
+    private TransactionManager transactionManager = mock(TransactionManager.class);
+    private TwoPCCohortServerPolicy serverPolicy = new TwoPCCohortServerPolicy();
+
+    @Before
+    public void Setup() {
+        this.serverPolicy.setSandboxProvider(sandboxProvider);
+        this.serverPolicy.setTransactionManager(transactionManager);
+    }
+
+    @After
+    public void clean(){
+        TransactionContext.leaveTransaction();
+    }
+
+    @Test
+    public void test_none_transaction_rpc_passes_though() throws Exception {
+        AppObject appObject = mock(AppObject.class);
+        when(appObject.invoke("foo", null)).thenReturn("bar");
+        serverPolicy.$__initialize(appObject);
+
+        Object result = serverPolicy.onRPC("foo", null);
+
+        verifyNoMoreInteractions(sandboxProvider);
+        verifyZeroInteractions(transactionManager);
+        verify(appObject).invoke("foo", null);
+        assertEquals("bar", result);
+    }
+
+    @Test
+    public void test_transaction_rpc_engages_sandbox() throws Exception {
+        UUID transactionId = UUID.randomUUID();
+        TransactionWrapper wrapper = new TransactionWrapper(transactionId, "foo", null);
+
+        SapphireServerPolicyUpcalls sandbox = mock(SapphireServerPolicyUpcalls.class);
+        when(this.sandboxProvider.getSandbox(this.serverPolicy, transactionId)).thenReturn(sandbox);
+
+        Object result = serverPolicy.onRPC("tx_rpc", wrapper.getRPCParams());
+
+        verify(transactionManager).join(transactionId);
+        verify(sandboxProvider).getSandbox(this.serverPolicy, transactionId);
+        verify(sandbox).onRPC("foo", null);
+        verify(transactionManager).leave(transactionId);
+    }
+
+    @Test
+    public void test_transaction_primitive_vote_req() throws Exception {
+        UUID transactionId = UUID.randomUUID();
+        TransactionWrapper wrapper = new TransactionWrapper(transactionId, "tx_vote_req", null);
+
+        Object result = this.serverPolicy.onRPC("tx_rpc", wrapper.getRPCParams());
+
+        verify(this.transactionManager).vote(transactionId);
+    }
+}


### PR DESCRIPTION
## skeletal structure of 2PC participant server policy
* it behaves as normal DM if transaction is absent;
* it calls into "sandbox" if transaction is present

## accompanying unit tests