### PR TITLE
Revert "upgrade JDK from 1.6 to 1.8"

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -36,5 +36,5 @@ task createJar(type: Copy) {
 
 createJar.dependsOn(deleteJar, build)
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+sourceCompatibility = "1.6"
+targetCompatibility = "1.6"

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCCohortPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCCohortPolicy.java
@@ -20,7 +20,12 @@ public class TwoPCCohortPolicy extends DefaultSapphirePolicy {
         private TwoPCParticipants participantManager;
 
         // the default participants provider
-        private ParticipantManagerProvider participantManagerProvider = TransactionContext::getParticipants;
+        private ParticipantManagerProvider participantManagerProvider = new ParticipantManagerProvider() {
+            @Override
+            public TwoPCParticipants Get() {
+                return TransactionContext.getParticipants();
+            }
+        };
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/TwoPCCohortClientPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/TwoPCCohortClientPolicyTest.java
@@ -27,7 +27,12 @@ public class TwoPCCohortClientPolicyTest {
 
         TwoPCCohortClientPolicy clientPolicy = new TwoPCCohortClientPolicy();
         clientPolicy.setServer(serverPolicy);
-        clientPolicy.setParticipantManagerProvider( () -> participants );
+        clientPolicy.setParticipantManagerProvider( new TwoPCCohortClientPolicy.ParticipantManagerProvider() {
+            @Override
+            public TwoPCParticipants Get() {
+                return participants;
+            }
+        });
 
         clientPolicy.onRPC("foo", null);
 
@@ -42,7 +47,12 @@ public class TwoPCCohortClientPolicyTest {
 
         TwoPCCohortClientPolicy clientPolicy = new TwoPCCohortClientPolicy();
         clientPolicy.setServer(serverPolicy);
-        clientPolicy.setParticipantManagerProvider( () -> participants );
+        clientPolicy.setParticipantManagerProvider(new TwoPCCohortClientPolicy.ParticipantManagerProvider() {
+            @Override
+            public TwoPCParticipants Get() {
+                return participants;
+            }
+        });
 
         UUID txnId = UUID.randomUUID();
         TransactionContext.enterTransaction(txnId);


### PR DESCRIPTION
Reverts Huawei-PaaS/DCAP-Sapphire#89.

Upgrading JDK from 1.6 to 1.8 will force us to upgrade android SDK to version 26+. Some features in JDK 1.8 requires android `--min-sdk-version >= 26`. Since most mobile apps are still on android version 21+. We decide not to move to 1.8 for now. 