### PR TITLE
DCAP distributed transaction part 4: AppObject Shim Sandbox provider

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/AppObjectSandboxProvider.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/AppObjectSandboxProvider.java
@@ -1,0 +1,29 @@
+package sapphire.policy.transaction;
+
+import sapphire.policy.SapphirePolicyUpcalls.SapphireServerPolicyUpcalls;
+import static sapphire.policy.transaction.TwoPCCohortPolicy.TwoPCCohortServerPolicy;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * sandbox provider that manages sandbox containing the enclosed app object only
+ */
+public class AppObjectSandboxProvider implements SandboxProvider {
+    private ConcurrentHashMap<UUID, AppObjectShimServerPolicy> sandboxes = new ConcurrentHashMap<UUID, AppObjectShimServerPolicy>();
+
+    @Override
+    public SapphireServerPolicyUpcalls getSandbox(TwoPCCohortServerPolicy origin, UUID transactionId) throws Exception {
+        if (!this.sandboxes.containsKey(transactionId)) {
+            AppObjectShimServerPolicy sandbox = AppObjectShimServerPolicy.cloneInShimServerPolicy(origin.sapphire_getAppObject());
+            this.sandboxes.put(transactionId, sandbox);
+        }
+
+        return this.sandboxes.get(transactionId);
+    }
+
+    @Override
+    public void removeSandbox(TwoPCCohortServerPolicy origin, UUID transactionId) {
+        this.sandboxes.remove(transactionId);
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/AppObjectShimServerPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/AppObjectShimServerPolicy.java
@@ -1,0 +1,57 @@
+package sapphire.policy.transaction;
+
+import sapphire.common.AppObject;
+import sapphire.common.Utils;
+import sapphire.policy.SapphirePolicy;
+import sapphire.policy.SapphirePolicyUpcalls.SapphireServerPolicyUpcalls;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+/**
+ * server policy that directly works on the deep-cloned copy of an AppObject
+ */
+public class AppObjectShimServerPolicy implements SapphireServerPolicyUpcalls{
+    private AppObject appObject;
+
+    @Override
+    public void onCreate(SapphirePolicy.SapphireGroupPolicy group) {
+
+    }
+
+    @Override
+    public SapphirePolicy.SapphireGroupPolicy getGroup() {
+        return null;
+    }
+
+    @Override
+    public Object onRPC(String method, ArrayList<Object> params) throws Exception {
+        return appObject.invoke(method, params);
+    }
+
+    @Override
+    public void onMembershipChange() {
+
+    }
+
+    /**
+     * gets the app object referenced by the server policy
+     * @return the app object
+     */
+    public AppObject getAppObject() {
+        return this.appObject;
+    }
+
+    private AppObjectShimServerPolicy(AppObject appObject) {
+        this.appObject = appObject;
+    }
+
+    /**
+     *  creates server policy which contains deep copy of the input app object
+     * @param appObject the origin app object
+     */
+    public static AppObjectShimServerPolicy cloneInShimServerPolicy(AppObject appObject) throws Exception {
+        AppObject deepCloneAppObject = (AppObject)Utils.ObjectCloner.deepCopy(appObject);
+        return new AppObjectShimServerPolicy(deepCloneAppObject);
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/SandboxProvider.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/SandboxProvider.java
@@ -15,7 +15,7 @@ public interface SandboxProvider {
      * @param transactionId id of the transaction
      * @return sandbox associated with the transaction
      */
-    SapphireServerPolicyUpcalls getSandbox(TwoPCCohortServerPolicy origin, UUID transactionId);
+    SapphireServerPolicyUpcalls getSandbox(TwoPCCohortServerPolicy origin, UUID transactionId) throws Exception;
 
     /**
      * removes the sandbox of the origin thing associated with the specified transaction

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCCohortPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCCohortPolicy.java
@@ -47,7 +47,7 @@ public class TwoPCCohortPolicy extends DefaultSapphirePolicy {
      * DCAP distributed transaction default server policy
      */
     public static class TwoPCCohortServerPolicy extends DefaultServerPolicy {
-        private SandboxProvider sandboxProvider;
+        private final SandboxProvider sandboxProvider = new AppObjectSandboxProvider();
         private final TransactionManager transactionManager = new TLSTransactionManager();
 
         @Override

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/AppObjectSandboxProviderTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/AppObjectSandboxProviderTest.java
@@ -1,0 +1,26 @@
+package sapphire.policy.transaction;
+
+import org.junit.Test;
+import sapphire.common.AppObject;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotSame;
+
+public class AppObjectSandboxProviderTest {
+    @Test
+    public void test_get_copy_of_appObject() throws Exception {
+        UUID txId = UUID.randomUUID();
+        Serializable coreOrigin = "aaa";
+        AppObject originAppObject = new AppObject(coreOrigin);
+        TwoPCCohortPolicy.TwoPCCohortServerPolicy origin = new TwoPCCohortPolicy.TwoPCCohortServerPolicy();
+        origin.$__initialize(originAppObject);
+
+        AppObjectSandboxProvider provider = new AppObjectSandboxProvider();
+        AppObjectShimServerPolicy sandbox = (AppObjectShimServerPolicy)provider.getSandbox(origin, txId);
+
+        AppObject sandboxAppObject = sandbox.getAppObject();
+        assertNotSame(sandboxAppObject, originAppObject);
+    }
+}

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/AppObjectShimServerPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/AppObjectShimServerPolicyTest.java
@@ -1,0 +1,24 @@
+package sapphire.policy.transaction;
+
+import org.junit.Test;
+import sapphire.common.AppObject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+public class AppObjectShimServerPolicyTest {
+    @Test
+    public void test_policy_saves_copy() throws Exception {
+        Integer[] originCore = new Integer[] {1,2,3};
+        AppObject origin = new AppObject(originCore);
+
+        AppObjectShimServerPolicy policy = AppObjectShimServerPolicy.cloneInShimServerPolicy(origin);
+        AppObject retrieved = policy.getAppObject();
+
+        assertNotSame("AppObject retrieved is a brand new one", origin, retrieved);
+        assertNotSame("Core of AppObject retrieved is a deep copy", origin.getObject(), retrieved.getObject());
+        Integer[] retrievedCore = (Integer[]) retrieved.getObject();
+        retrievedCore[0] = 777;
+        assertEquals("original value should not affected", 1, (long)originCore[0]);
+    }
+}


### PR DESCRIPTION
## features
* the default sandbox provider - server policies containing appObject is in the sandbox
* appObj shim server policy - server policy  keeps deep-cloned copy of an appObject
## accompany unit tests