### PR TITLE
DCAP distributed transaction part 7: 2PC coordinator hooks with concrete sandbox provider (trivial)

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCCoordinatorPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TwoPCCoordinatorPolicy.java
@@ -19,7 +19,7 @@ public class TwoPCCoordinatorPolicy extends DefaultSapphirePolicy {
      */
     public static class TwoPCCoordinatorServerPolicy extends DefaultServerPolicy {
         private TwoPCCoordinator coordinator;
-        private SandboxProvider sandboxProvider;
+        private final SandboxProvider sandboxProvider = new AppObjectSandboxProvider();
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
@@ -50,7 +50,8 @@ public class TwoPCCoordinatorPolicy extends DefaultSapphirePolicy {
         }
 
         private void makeUpdateDurable(SapphireServerPolicyUpcalls sandbox) {
-            // todo: replace appobject etc w/ that of sandbox
+            AppObjectShimServerPolicy shimServerPolicy = (AppObjectShimServerPolicy)sandbox;
+            this.appObject = shimServerPolicy.getAppObject();
         }
     }
 

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/TwoPCCoordinatorServerPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/transaction/TwoPCCoordinatorServerPolicyTest.java
@@ -23,7 +23,7 @@ public class TwoPCCoordinatorServerPolicyTest {
     private TwoPCCoordinatorServerPolicy coordinatorServerPolicy = new TwoPCCoordinatorServerPolicy();
     private TwoPCCoordinator coordinator = mock(TwoPCCoordinator.class);
     private SandboxProvider sandboxProvider = mock(SandboxProvider.class);
-    private SapphireServerPolicyUpcalls sandbox = mock(SapphireServerPolicyUpcalls.class);
+    private AppObjectShimServerPolicy sandbox = mock(AppObjectShimServerPolicy.class);
 
     @Before
     public void Setup() throws Exception{
@@ -79,7 +79,8 @@ public class TwoPCCoordinatorServerPolicyTest {
     public void test_noupdate_on_tx_aborted() throws Exception{
         when(coordinator.vote(any(UUID.class))).thenReturn(TransactionManager.Vote.NO);
 
-        Object originalAppObject = this.coordinatorServerPolicy.sapphire_getAppObject();
+        AppObject originalAppObject = new AppObject("bar");
+        this.coordinatorServerPolicy.$__initialize(originalAppObject);
 
         try {
             coordinatorServerPolicy.onRPC("foo", null);
@@ -93,11 +94,11 @@ public class TwoPCCoordinatorServerPolicyTest {
     }
 
     @Test
-    @Ignore("not ready yet - needs proper makeUpdateDurable in place")
     public void test_content_changed_on_tx_commit() throws Exception {
         when(coordinator.vote(any(UUID.class))).thenReturn(TransactionManager.Vote.YES);
 
-        Object originalAppObject = this.coordinatorServerPolicy.sapphire_getAppObject();
+        AppObject originalAppObject = new AppObject("bar");
+        this.coordinatorServerPolicy.$__initialize(originalAppObject);
 
         coordinatorServerPolicy.onRPC("foo", null);
 


### PR DESCRIPTION
## feature
put sandbox provider of 2PC coordinator in place

## unit test
enabled the test case test_content_changed_on_tx_commit