### PR TITLE
Remove "checkpoint.dat" after unit tests

### DIFF
--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/checkpoint/explicitcheckpoint/ExplicitCheckpointPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/checkpoint/explicitcheckpoint/ExplicitCheckpointPolicyTest.java
@@ -1,42 +1,35 @@
 package sapphire.policy.checkpoint.explicitcheckpoint;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 
 import sapphire.common.AppObject;
-import sapphire.policy.checkpoint.explicitcheckpoint.ExplicitCheckpointer;
-import sapphire.policy.checkpoint.explicitcheckpoint.ExplicitCheckpointPolicy;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-
-import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static sapphire.policy.checkpoint.explicitcheckpoint.ExplicitCheckpointPolicy.ClientPolicy;
+import static sapphire.policy.checkpoint.explicitcheckpoint.ExplicitCheckpointPolicy.ServerPolicy;
 
 /**
  * Created by quinton on 1/16/18.
  */
 
 public class ExplicitCheckpointPolicyTest {
-    ExplicitCheckpointPolicy.ClientPolicy client;
-    ExplicitCheckpointPolicy.ServerPolicy server;
+    ClientPolicy client;
+    ServerPolicy server;
     private ExplicitCheckpointerTest so;
     private AppObject appObject;
     private ArrayList<Object> noParams, oneParam, twoParam;
-
+    private File snapshot;
 
     @Before
     public void setUp() throws Exception {
@@ -51,6 +44,16 @@ public class ExplicitCheckpointPolicyTest {
         oneParam.add(new Integer(1));
         twoParam = new ArrayList<Object>();
         twoParam.add(new Integer(2));
+        snapshot = File.createTempFile("ExplicitCheckpointPolicyTest","tmp");
+        snapshot.deleteOnExit();
+        setSnapshotFilePath(server, snapshot.getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (snapshot != null) {
+            snapshot.delete();
+        }
     }
 
     @Test
@@ -104,6 +107,12 @@ public class ExplicitCheckpointPolicyTest {
         this.client.onRPC(getMethodName, noParams);
         verify(this.server).onRPC(getMethodName, noParams);
         assertEquals(((ExplicitCheckpointerTest)appObject.getObject()).getI(), 1);
+    }
+
+    private void setSnapshotFilePath(ServerPolicy server, String filePath) throws Exception {
+        Field f = server.getClass().getSuperclass().getSuperclass().getDeclaredField("checkPointFileName");
+        f.setAccessible(true);
+        f.set(server, filePath);
     }
 }
 

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/checkpoint/periodiccheckpoint/PeriodicCheckpointPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/checkpoint/periodiccheckpoint/PeriodicCheckpointPolicyTest.java
@@ -1,19 +1,23 @@
 package sapphire.policy.checkpoint.periodiccheckpoint;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 import sapphire.common.AppObject;
-import sapphire.policy.checkpoint.periodiccheckpoint.PeriodicCheckpointPolicy;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static sapphire.policy.checkpoint.periodiccheckpoint.PeriodicCheckpointPolicy.ServerPolicy;
 
 /**
  * Created by quinton on 1/16/18.
@@ -25,7 +29,7 @@ public class PeriodicCheckpointPolicyTest {
     private PeriodicCheckpointerTest so;
     private AppObject appObject;
     private ArrayList<Object> noParams, oneParam, twoParam;
-
+    private File snapshot;
 
     @Before
     public void setUp() throws Exception {
@@ -40,6 +44,16 @@ public class PeriodicCheckpointPolicyTest {
         oneParam.add(new Integer(1));
         twoParam = new ArrayList<Object>();
         twoParam.add(new Integer(2));
+        snapshot = File.createTempFile("ExplicitCheckpointPolicyTest","tmp");
+        snapshot.deleteOnExit();
+        setSnapshotFilePath(server, snapshot.getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (snapshot != null) {
+            snapshot.delete();
+        }
     }
 
     @Test
@@ -107,6 +121,13 @@ public class PeriodicCheckpointPolicyTest {
             throw new Exception("Set i to " + i + " and then threw an exception");
         }
     }
+
+    private void setSnapshotFilePath(ServerPolicy server, String filePath) throws Exception {
+        Field f = server.getClass().getSuperclass().getSuperclass().getDeclaredField("checkPointFileName");
+        f.setAccessible(true);
+        f.set(server, filePath);
+    }
+
     // Stub because AppObject expects a stub/subclass of the original class.
     public static class PeriodicCheckpointerTestStub extends PeriodicCheckpointPolicyTest.PeriodicCheckpointerTest implements Serializable {}
 }


### PR DESCRIPTION
File `checkpoint.dat` is generated every time when we run unit tests. We have to manually delete this file which is inconvenient.

This PR modifies the unit tests so that `checkpoint.dat` will be removed after unit tests.