### PR TITLE
Added a new constructor in KernerlServerImpl which takes OMS as a parameter.

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/client/KernelClient.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/client/KernelClient.java
@@ -5,6 +5,7 @@ import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.util.Hashtable;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import sapphire.kernel.common.GlobalKernelReferences;
@@ -105,7 +106,7 @@ public class KernelClient {
 	 */
 	public Object makeKernelRPC(KernelObjectStub stub, KernelRPC rpc) throws KernelObjectNotFoundException, Exception {
 		InetSocketAddress host = stub.$__getHostname();
-		logger.info("Making RPC to " + host.toString() + " RPC: " + rpc.toString());
+		logger.log(Level.FINE,"Making RPC to " + host.toString() + " RPC: " + rpc.toString());
 
 		// Check whether this object is local.
 		KernelServer server;

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -45,20 +45,28 @@ public class KernelServerImpl implements KernelServer{
 	private KernelClient client;
 	
 	public KernelServerImpl(InetSocketAddress host, InetSocketAddress omsHost) {
-		objectManager = new KernelObjectManager();
-	    Registry registry;
+		OMSServer oms = null;
 		try {
-			registry = LocateRegistry.getRegistry(omsHost.getHostName(), omsHost.getPort());
+			Registry registry = LocateRegistry.getRegistry(omsHost.getHostName(), omsHost.getPort());
 			oms = (OMSServer) registry.lookup("SapphireOMS");
 		} catch (Exception e) {
 			logger.severe("Could not find OMS: " + e.toString());
 		}
+		init(host, oms);
+	}
 
+	public KernelServerImpl(InetSocketAddress host, OMSServer oms) {
+		init(host, oms);
+	}
+
+	private void init(InetSocketAddress host, OMSServer oms) {
+		this.oms = oms;
 		this.host = host;
+		objectManager = new KernelObjectManager();
 		client = new KernelClient(oms);
 		GlobalKernelReferences.nodeServer = this;
 	}
-	
+
 	public void setRegion(String region) {
 		this.region = region;
 	}
@@ -80,7 +88,7 @@ public class KernelServerImpl implements KernelServer{
 		KernelObject object = null;
 		object = objectManager.lookupObject(rpc.getOID());
 		
-		logger.info("Invoking RPC on Kernel Object with OID: " + rpc.getOID() + "with rpc:" + rpc.getMethod() + " params: " + rpc.getParams().toString());
+		logger.log(Level.FINE, "Invoking RPC on Kernel Object with OID: " + rpc.getOID() + "with rpc:" + rpc.getMethod() + " params: " + rpc.getParams().toString());
 		Object ret = null;
 		try {
 			ret = object.invoke(rpc.getMethod(), rpc.getParams());


### PR DESCRIPTION
To make code review easier, I moved changes related to sapphire core from PR https://github.com/Huawei-PaaS/DCAP-Sapphire/pull/71/files to this PR.

Key changes is:
* Added a new constructor in KernerlServerImpl which takes OMS as a parameter. It allows us to inject a mocked OMS in unit tests
