### PR TITLE
Added a remote server rpc invocation class and injected it as dependency to this raft server. 

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/RemoteRaftServerInvoker.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/RemoteRaftServerInvoker.java
@@ -1,0 +1,54 @@
+package sapphire.policy.util.consensus.raft;
+
+import java.lang.*;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by Venugopal Reddy K on 4/20/18.
+ * Interface to execute calls on remote raft servers
+ */
+
+/*TODO: Currently policy stubs swallows all the exceptions and no exceptions are thrown to client.
+When stub generation code is modified not to catch client exceptions, below methods can catch these
+specific exceptions. And, need to remove the generic exception thrown from these methods.
+ */
+public interface RemoteRaftServerInvoker {
+	/**
+	 * Invoked by candidate to gather votes from remote servers.
+	 * @param remoteServer Remote server on which this call will be invoked
+	 * @param term candidate’s term
+	 * @param candidate candidate requesting vote
+	 * @param lastLogIndex index of candidate’s last log entry
+	 * @param lastLogTerm term of candidate’s last log entry
+	 * @return currentTerm, for candidate to update itself
+	 * @throws sapphire.policy.util.consensus.raft.Server.InvalidTermException
+	 * @throws sapphire.policy.util.consensus.raft.Server.AlreadyVotedException
+	 * @throws sapphire.policy.util.consensus.raft.Server.CandidateBehindException
+	 */
+	int requestVote(Object remoteServer, int term, UUID candidate, int lastLogIndex, int lastLogTerm) throws Server.InvalidTermException, Server.AlreadyVotedException, Server.CandidateBehindException, java.lang.Exception;
+
+	/**
+	 * Invoked by leader to replicate log entries to remote servers
+	 * @param remoteServer Remote server on which this call will be invoked
+	 * @param term leaders' term
+	 * @param leader so follower can redirect clients
+	 * @param prevLogIndex index of log entry immediately preceding new ones
+	 * @param prevLogTerm term of prevLogIndex entry
+	 * @param entries log entries to store (empty for heartbeat; may send more than one for efficiency)
+	 * @param leaderCommit leader’s commitIndex
+	 * @return currentTerm, for leader to update itself
+	 * @throws sapphire.policy.util.consensus.raft.Server.InvalidTermException
+	 * @throws sapphire.policy.util.consensus.raft.Server.PrevLogTermMismatch
+	 * @throws sapphire.policy.util.consensus.raft.Server.InvalidLogIndex
+	 */
+	int appendEntries(Object remoteServer, int term, UUID leader, int prevLogIndex, int prevLogTerm, List<Object> entries, int leaderCommit) throws Server.InvalidTermException, Server.PrevLogTermMismatch, Server.InvalidLogIndex, java.lang.Exception;
+
+	/**
+ 	 * Invoked by followers to redirect the client's operation invoked them to get applied on leader
+ 	 * @param remoteServer Remote server on which this call will be invoked(i.e., leader)
+	 * @param operation Client's operation
+	 * @throws java.lang.Exception
+ 	 */
+	Object applyToStateMachine(Object remoteServer, Object operation) throws java.lang.Exception;
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/VolatileState.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/VolatileState.java
@@ -21,7 +21,7 @@ class VolatileState {
      * All the other servers.  Just make it public to avoid having to re-implement the whole Map interface.
      * ConcurrentMap is already thread-safe, so can be accessed directly.
      */
-    public ConcurrentMap<UUID, Server> otherServers = new ConcurrentHashMap<UUID, Server>();
+    public ConcurrentMap<UUID, Object> otherServers = new ConcurrentHashMap<UUID, Object>();
     Integer commitIndex = INVALID_INDEX;
     Integer lastApplied = INVALID_INDEX;
     /**


### PR DESCRIPTION
Added a remote server rpc invocation class and injected it as dependency to this raft server.
1. Defined a new in interface to handle rpc calls and implemented the interface in DM.
2. Changed the access modified of the server methods being called from DM as public. So that they can be called from DM. Invocation points at raft server is modified accordingly.
3. Changed raft server instance field access modifier to private in the ServerPolicy
4. VolatileState otherServers map hold the remote server stub object instead of remote raft server. Server stub in the map is stored as opaque object to avoid DM specific package import to raft server package.