### PR TITLE
Removed redundant addServer calls in ConsensusDM and LoadBalancedFrontendDM

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
@@ -114,7 +114,6 @@ public class ConsensusRSMPolicy extends DefaultSapphirePolicy {
                     ServerPolicy replica = (ServerPolicy)consensusServer.sapphire_replicate();
                     replica.sapphire_pin(regions.get(i));
                     replica.initializeRaftServer();
-                    addServer(replica);
                 }
                 consensusServer.sapphire_pin(regions.get(0));
                 consensusServer.initializeRaftServer();

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedFrontendPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedFrontendPolicy.java
@@ -133,7 +133,6 @@ public class LoadBalancedFrontendPolicy extends DefaultSapphirePolicy {
 						ServerPolicy replica = ((ServerPolicy) server).onSapphireObjectReplicate();
 						replica.onSapphirePin(kernelServers.get(count));
 						((KernelObjectStub) replica).$__updateHostname(kernelServers.get(count));
-						addServer(replica);
 					}
 				}
 


### PR DESCRIPTION
Method `sapphire_replicate` calls `group.addServer`. Therefore we do not need to call `addServer` in ConsensusDM and LoadBalancedFronendDM explicitly. 

The PR removed the redundant `addServer` calls in ConsensusDM and LoadBalancedFronendDM.