### PR TITLE
Modified sapphire stub generation code to not swallow user exceptions

### DIFF
--- a/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/TagManager_Stub.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/TagManager_Stub.java
@@ -32,23 +32,30 @@ public final class TagManager_Stub extends sapphire.appexamples.minnietwitter.ap
     // Implementation of getTweetsForTag(String, int, int)
     public java.util.List getTweetsForTag(java.lang.String $param_String_1, int $param_int_2, int $param_int_3) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getTweetsForTag( $param_String_1,  $param_int_2,  $param_int_3);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.Tweet> sapphire.appexamples.minnietwitter.app.TagManager.getTweetsForTag(java.lang.String,int,int)";
-                $__params.add($param_String_1);
-                $__params.add($param_int_2);
-                $__params.add($param_int_3);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.Tweet> sapphire.appexamples.minnietwitter.app.TagManager.getTweetsForTag(java.lang.String,int,int)";
+            $__params.add($param_String_1);
+            $__params.add($param_int_2);
+            $__params.add($param_int_3);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((java.util.List) $__result);
     }
@@ -56,22 +63,29 @@ public final class TagManager_Stub extends sapphire.appexamples.minnietwitter.ap
     // Implementation of addTag(String, Tweet)
     public void addTag(java.lang.String $param_String_1, sapphire.appexamples.minnietwitter.app.Tweet $param_Tweet_2) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.addTag( $param_String_1,  $param_Tweet_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.TagManager.addTag(java.lang.String,sapphire.appexamples.minnietwitter.app.Tweet)";
-                $__params.add($param_String_1);
-                $__params.add($param_Tweet_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.TagManager.addTag(java.lang.String,sapphire.appexamples.minnietwitter.app.Tweet)";
+            $__params.add($param_String_1);
+            $__params.add($param_Tweet_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 }

--- a/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/Timeline_Stub.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/Timeline_Stub.java
@@ -32,107 +32,142 @@ public final class Timeline_Stub extends sapphire.appexamples.minnietwitter.app.
     // Implementation of tweet(String)
     public void tweet(java.lang.String $param_String_1) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.tweet( $param_String_1);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.tweet(java.lang.String)";
-                $__params.add($param_String_1);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.tweet(java.lang.String)";
+            $__params.add($param_String_1);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 
     // Implementation of retweetedBy(int, String)
     public void retweetedBy(int $param_int_1, java.lang.String $param_String_2) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.retweetedBy( $param_int_1,  $param_String_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.retweetedBy(int,java.lang.String)";
-                $__params.add($param_int_1);
-                $__params.add($param_String_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.retweetedBy(int,java.lang.String)";
+            $__params.add($param_int_1);
+            $__params.add($param_String_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 
     // Implementation of retweet(Tweet)
     public void retweet(sapphire.appexamples.minnietwitter.app.Tweet $param_Tweet_1) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.retweet( $param_Tweet_1);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.retweet(sapphire.appexamples.minnietwitter.app.Tweet)";
-                $__params.add($param_Tweet_1);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.retweet(sapphire.appexamples.minnietwitter.app.Tweet)";
+            $__params.add($param_Tweet_1);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 
     // Implementation of initialize(Timeline)
     public void initialize(sapphire.appexamples.minnietwitter.app.Timeline $param_Timeline_1) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.initialize( $param_Timeline_1);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.initialize(sapphire.appexamples.minnietwitter.app.Timeline)";
-                $__params.add($param_Timeline_1);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.initialize(sapphire.appexamples.minnietwitter.app.Timeline)";
+            $__params.add($param_Timeline_1);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 
     // Implementation of getTweets(int, int)
     public java.util.List getTweets(int $param_int_1, int $param_int_2) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getTweets( $param_int_1,  $param_int_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.Tweet> sapphire.appexamples.minnietwitter.app.Timeline.getTweets(int,int)";
-                $__params.add($param_int_1);
-                $__params.add($param_int_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.Tweet> sapphire.appexamples.minnietwitter.app.Timeline.getTweets(int,int)";
+            $__params.add($param_int_1);
+            $__params.add($param_int_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((java.util.List) $__result);
     }
@@ -140,23 +175,30 @@ public final class Timeline_Stub extends sapphire.appexamples.minnietwitter.app.
     // Implementation of getRetweets(int, int, int)
     public java.util.List getRetweets(int $param_int_1, int $param_int_2, int $param_int_3) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getRetweets( $param_int_1,  $param_int_2,  $param_int_3);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public java.util.List<java.lang.String> sapphire.appexamples.minnietwitter.app.Timeline.getRetweets(int,int,int)";
-                $__params.add($param_int_1);
-                $__params.add($param_int_2);
-                $__params.add($param_int_3);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public java.util.List<java.lang.String> sapphire.appexamples.minnietwitter.app.Timeline.getRetweets(int,int,int)";
+            $__params.add($param_int_1);
+            $__params.add($param_int_2);
+            $__params.add($param_int_3);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((java.util.List) $__result);
     }
@@ -164,23 +206,30 @@ public final class Timeline_Stub extends sapphire.appexamples.minnietwitter.app.
     // Implementation of getFavorites(int, int, int)
     public java.util.List getFavorites(int $param_int_1, int $param_int_2, int $param_int_3) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getFavorites( $param_int_1,  $param_int_2,  $param_int_3);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public java.util.List<java.lang.String> sapphire.appexamples.minnietwitter.app.Timeline.getFavorites(int,int,int)";
-                $__params.add($param_int_1);
-                $__params.add($param_int_2);
-                $__params.add($param_int_3);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public java.util.List<java.lang.String> sapphire.appexamples.minnietwitter.app.Timeline.getFavorites(int,int,int)";
+            $__params.add($param_int_1);
+            $__params.add($param_int_2);
+            $__params.add($param_int_3);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((java.util.List) $__result);
     }
@@ -188,22 +237,29 @@ public final class Timeline_Stub extends sapphire.appexamples.minnietwitter.app.
     // Implementation of favorite(int, String)
     public void favorite(int $param_int_1, java.lang.String $param_String_2) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.favorite( $param_int_1,  $param_String_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.favorite(int,java.lang.String)";
-                $__params.add($param_int_1);
-                $__params.add($param_String_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.Timeline.favorite(int,java.lang.String)";
+            $__params.add($param_int_1);
+            $__params.add($param_String_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 }

--- a/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/TwitterManager_Stub.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/TwitterManager_Stub.java
@@ -32,20 +32,27 @@ public final class TwitterManager_Stub extends sapphire.appexamples.minnietwitte
     // Implementation of getUserManager()
     public sapphire.appexamples.minnietwitter.app.UserManager getUserManager() {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getUserManager();
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public sapphire.appexamples.minnietwitter.app.UserManager sapphire.appexamples.minnietwitter.app.TwitterManager.getUserManager()";
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public sapphire.appexamples.minnietwitter.app.UserManager sapphire.appexamples.minnietwitter.app.TwitterManager.getUserManager()";
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((sapphire.appexamples.minnietwitter.app.UserManager) $__result);
     }
@@ -53,20 +60,27 @@ public final class TwitterManager_Stub extends sapphire.appexamples.minnietwitte
     // Implementation of getTagManager()
     public sapphire.appexamples.minnietwitter.app.TagManager getTagManager() {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getTagManager();
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public sapphire.appexamples.minnietwitter.app.TagManager sapphire.appexamples.minnietwitter.app.TwitterManager.getTagManager()";
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public sapphire.appexamples.minnietwitter.app.TagManager sapphire.appexamples.minnietwitter.app.TwitterManager.getTagManager()";
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((sapphire.appexamples.minnietwitter.app.TagManager) $__result);
     }

--- a/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/UserManager_Stub.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/UserManager_Stub.java
@@ -32,22 +32,29 @@ public final class UserManager_Stub extends sapphire.appexamples.minnietwitter.a
     // Implementation of login(String, String)
     public sapphire.appexamples.minnietwitter.app.User login(java.lang.String $param_String_1, java.lang.String $param_String_2) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.login( $param_String_1,  $param_String_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public sapphire.appexamples.minnietwitter.app.User sapphire.appexamples.minnietwitter.app.UserManager.login(java.lang.String,java.lang.String)";
-                $__params.add($param_String_1);
-                $__params.add($param_String_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public sapphire.appexamples.minnietwitter.app.User sapphire.appexamples.minnietwitter.app.UserManager.login(java.lang.String,java.lang.String)";
+            $__params.add($param_String_1);
+            $__params.add($param_String_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((sapphire.appexamples.minnietwitter.app.User) $__result);
     }
@@ -55,21 +62,28 @@ public final class UserManager_Stub extends sapphire.appexamples.minnietwitter.a
     // Implementation of getUser(String)
     public sapphire.appexamples.minnietwitter.app.User getUser(java.lang.String $param_String_1) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getUser( $param_String_1);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public sapphire.appexamples.minnietwitter.app.User sapphire.appexamples.minnietwitter.app.UserManager.getUser(java.lang.String)";
-                $__params.add($param_String_1);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public sapphire.appexamples.minnietwitter.app.User sapphire.appexamples.minnietwitter.app.UserManager.getUser(java.lang.String)";
+            $__params.add($param_String_1);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((sapphire.appexamples.minnietwitter.app.User) $__result);
     }
@@ -77,20 +91,27 @@ public final class UserManager_Stub extends sapphire.appexamples.minnietwitter.a
     // Implementation of dhtGetData()
     public java.util.Map dhtGetData() {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.dhtGetData();
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public java.util.Map<sapphire.policy.interfaces.dht.DHTKey, ?> sapphire.appexamples.minnietwitter.app.UserManager.dhtGetData()";
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public java.util.Map<sapphire.policy.interfaces.dht.DHTKey, ?> sapphire.appexamples.minnietwitter.app.UserManager.dhtGetData()";
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((java.util.Map) $__result);
     }
@@ -99,24 +120,31 @@ public final class UserManager_Stub extends sapphire.appexamples.minnietwitter.a
     public sapphire.appexamples.minnietwitter.app.User addUser(java.lang.String $param_String_1, java.lang.String $param_String_2)
             throws sapphire.app.AppObjectNotCreatedException {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.addUser( $param_String_1,  $param_String_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public sapphire.appexamples.minnietwitter.app.User sapphire.appexamples.minnietwitter.app.UserManager.addUser(java.lang.String,java.lang.String) throws sapphire.app.AppObjectNotCreatedException";
-                $__params.add($param_String_1);
-                $__params.add($param_String_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (sapphire.app.AppObjectNotCreatedException e) {
-            throw e;
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public sapphire.appexamples.minnietwitter.app.User sapphire.appexamples.minnietwitter.app.UserManager.addUser(java.lang.String,java.lang.String) throws sapphire.app.AppObjectNotCreatedException";
+            $__params.add($param_String_1);
+            $__params.add($param_String_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof sapphire.app.AppObjectNotCreatedException) {
+                    throw (sapphire.app.AppObjectNotCreatedException)ex;
+                } else if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((sapphire.appexamples.minnietwitter.app.User) $__result);
     }

--- a/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/User_Stub.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/app/stubs/User_Stub.java
@@ -32,41 +32,55 @@ public final class User_Stub extends sapphire.appexamples.minnietwitter.app.User
     // Implementation of initialize(User)
     public void initialize(sapphire.appexamples.minnietwitter.app.User $param_User_1) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.initialize( $param_User_1);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.User.initialize(sapphire.appexamples.minnietwitter.app.User)";
-                $__params.add($param_User_1);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.User.initialize(sapphire.appexamples.minnietwitter.app.User)";
+            $__params.add($param_User_1);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 
     // Implementation of getUserInfo()
     public sapphire.appexamples.minnietwitter.app.UserInfo getUserInfo() {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getUserInfo();
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public sapphire.appexamples.minnietwitter.app.UserInfo sapphire.appexamples.minnietwitter.app.User.getUserInfo()";
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public sapphire.appexamples.minnietwitter.app.UserInfo sapphire.appexamples.minnietwitter.app.User.getUserInfo()";
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((sapphire.appexamples.minnietwitter.app.UserInfo) $__result);
     }
@@ -74,20 +88,27 @@ public final class User_Stub extends sapphire.appexamples.minnietwitter.app.User
     // Implementation of getTimeline()
     public sapphire.appexamples.minnietwitter.app.Timeline getTimeline() {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getTimeline();
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public sapphire.appexamples.minnietwitter.app.Timeline sapphire.appexamples.minnietwitter.app.User.getTimeline()";
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public sapphire.appexamples.minnietwitter.app.Timeline sapphire.appexamples.minnietwitter.app.User.getTimeline()";
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((sapphire.appexamples.minnietwitter.app.Timeline) $__result);
     }
@@ -95,22 +116,29 @@ public final class User_Stub extends sapphire.appexamples.minnietwitter.app.User
     // Implementation of getFollowing(int, int)
     public java.util.List getFollowing(int $param_int_1, int $param_int_2) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getFollowing( $param_int_1,  $param_int_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.User> sapphire.appexamples.minnietwitter.app.User.getFollowing(int,int)";
-                $__params.add($param_int_1);
-                $__params.add($param_int_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.User> sapphire.appexamples.minnietwitter.app.User.getFollowing(int,int)";
+            $__params.add($param_int_1);
+            $__params.add($param_int_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((java.util.List) $__result);
     }
@@ -118,22 +146,29 @@ public final class User_Stub extends sapphire.appexamples.minnietwitter.app.User
     // Implementation of getFollowers(int, int)
     public java.util.List getFollowers(int $param_int_1, int $param_int_2) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 $__result = super.getFollowers( $param_int_1,  $param_int_2);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.User> sapphire.appexamples.minnietwitter.app.User.getFollowers(int,int)";
-                $__params.add($param_int_1);
-                $__params.add($param_int_2);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public java.util.List<sapphire.appexamples.minnietwitter.app.User> sapphire.appexamples.minnietwitter.app.User.getFollowers(int,int)";
+            $__params.add($param_int_1);
+            $__params.add($param_int_2);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
         return ((java.util.List) $__result);
     }
@@ -141,42 +176,56 @@ public final class User_Stub extends sapphire.appexamples.minnietwitter.app.User
     // Implementation of addFollowing(User)
     public void addFollowing(sapphire.appexamples.minnietwitter.app.User $param_User_1) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.addFollowing( $param_User_1);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.User.addFollowing(sapphire.appexamples.minnietwitter.app.User)";
-                $__params.add($param_User_1);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.User.addFollowing(sapphire.appexamples.minnietwitter.app.User)";
+            $__params.add($param_User_1);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 
     // Implementation of addFollower(User)
     public void addFollower(sapphire.appexamples.minnietwitter.app.User $param_User_1) {
         java.lang.Object $__result = null;
-        try {
-            if ($__directInvocation)
+        if ($__directInvocation) {
+            try {
                 super.addFollower( $param_User_1);
-            else {
-                java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
-                String $__method = "public void sapphire.appexamples.minnietwitter.app.User.addFollower(sapphire.appexamples.minnietwitter.app.User)";
-                $__params.add($param_User_1);
-                $__result = $__client.onRPC($__method, $__params);
+            } catch (java.lang.Exception e) {
+                throw new sapphire.common.AppExceptionWrapper(e);
             }
-        } catch (java.lang.RuntimeException e) {
-            throw e;
-        } catch (java.rmi.RemoteException e) {
-            throw new java.lang.RuntimeException(e);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } else {
+            java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
+            String $__method = "public void sapphire.appexamples.minnietwitter.app.User.addFollower(sapphire.appexamples.minnietwitter.app.User)";
+            $__params.add($param_User_1);
+            try {
+                $__result = $__client.onRPC($__method, $__params);
+            } catch (sapphire.common.AppExceptionWrapper e) {
+                Exception ex = e.getException();
+                if (ex instanceof java.lang.RuntimeException) {
+                    throw (java.lang.RuntimeException)ex;
+                } else {
+                    throw new java.lang.RuntimeException(ex);
+                }
+            } catch (java.lang.Exception e) {
+                throw new java.lang.RuntimeException(e);
+            }
         }
     }
 }

--- a/sapphire/sapphire-core/src/main/java/sapphire/common/AppExceptionWrapper.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/AppExceptionWrapper.java
@@ -1,0 +1,18 @@
+package sapphire.common;
+
+/** Created by Venugopal Reddy K 00900280 on 11/8/18. */
+/**
+ * Sapphire object exceptions are wrapped into this runtime exception to isolate them from sapphire
+ * framework exceptions
+ */
+public class AppExceptionWrapper extends RuntimeException {
+    private Exception e;
+
+    public AppExceptionWrapper(Exception e) {
+        this.e = e;
+    }
+
+    public Exception getException() {
+        return e;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/compiler/PolicyStub.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/compiler/PolicyStub.java
@@ -2,7 +2,6 @@ package sapphire.compiler;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.rmi.RemoteException;
 import java.util.Iterator;
 import java.util.TreeSet;
 import org.apache.harmony.rmi.compiler.RmicUtil;
@@ -227,8 +226,8 @@ public class PolicyStub extends Stub {
         buffer.append(indenter.indent() + "java.lang.Object $__result = null;" + EOLN);
 
         /* If method do not throw generic exception. Catch all the exceptions in the stub and rethrow
-        them based on exceptions method is allowed to throw. And for the rest of the exceptions,
-        just print stack trace. Runtime exceptions are also thrown. */
+        them based on exceptions method is allowed to throw. Runtime exceptions are thrown to app
+        as is. And rest of the exceptions are wrapped into runtime exceptions and thrown to app */
         if (!m.exceptions.contains(Exception.class)) {
             /* Append try catch block for this case */
             buffer.append(indenter.indent() + "try {" + EOLN);
@@ -247,11 +246,6 @@ public class PolicyStub extends Stub {
         if (!m.exceptions.contains(Exception.class)) {
             for (Iterator i = m.catches.iterator(); i.hasNext(); ) {
                 Class clz = (Class) i.next();
-                if ((clz == RemoteException.class)
-                        && (!m.exceptions.contains(RemoteException.class))) {
-                    continue;
-                }
-
                 buffer.append(
                         indenter.indent()
                                 + "} catch (" //$NON-NLS-1$
@@ -268,7 +262,7 @@ public class PolicyStub extends Stub {
                             + "} catch (java.lang.Exception e) {"
                             + EOLN //$NON-NLS-1$
                             + indenter.tIncrease()
-                            + "e.printStackTrace();" //$NON-NLS-1$
+                            + "throw new java.lang.RuntimeException(e);" //$NON-NLS-1$
                             + EOLN //$NON-NLS-1$
                             + indenter.indent()
                             + '}'

--- a/sapphire/sapphire-core/src/main/java/sapphire/compiler/Stub.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/compiler/Stub.java
@@ -1,7 +1,6 @@
 package sapphire.compiler;
 
 import java.lang.reflect.Method;
-import java.rmi.RemoteException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.TreeSet;
@@ -210,14 +209,14 @@ public abstract class Stub implements RmicConstants {
             exceptions.addAll(Arrays.asList(exceptionsArray));
 
             // Create list of exceptions to be caught.
-            catches = new ClassList(true);
-
-            // Add standard exceptions to make sure they are first in the list.
-            catches.add(RuntimeException.class);
-            catches.add(RemoteException.class);
+            catches = new ClassList(false);
 
             // Add declared thrown exceptions.
             catches.addAll(exceptions);
+
+            /* Add the runtime exception at the end such that all the more specific exceptions of
+            runtime are added before it */
+            catches.add(RuntimeException.class);
         }
 
         /**

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/client/KernelClient.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/client/KernelClient.java
@@ -78,6 +78,10 @@ public class KernelClient {
             /* If invocation exception is with any exception,including runtime, app exceptions, unwrap it
             and throw. Else it is invocation exception with error. Throw the invocation exception as is */
             Throwable cause = e.getException().getCause();
+            if (cause instanceof InvocationTargetException) {
+                cause = cause.getCause();
+            }
+
             throw (cause instanceof Exception) ? ((Exception) cause) : e.getException();
 
         } catch (KernelObjectMigratingException e) {


### PR DESCRIPTION
Modified sapphire stub generation code for policy and app stubs to not swallow user exceptions. Changes are as follows:
1. In case, app/policy method do not throw generic exception and throw some exception OR no exception at all, Catch all the exceptions in the stub and re-throw based on exceptions method is allowed to throw. And for the rest of the exceptions, Runtime exceptions are thrown to app as is. Other exceptions are wrapped into runtime exceptions and thrown.
2. If method throws generic exception, app/policy handle all the exceptions. Stub do not catch any exception.
3. Invocation target exception wraps exception thrown by an invoked method or constructor. If invocation exception is with any exception, unwrap it and re-throw. Else it is invocation exception with error. Throw the invocation exception as it is.
4. AppExceptionWrapper class(extending runtime exception) is added to wrap SO exceptions into it. It is used to isolate user exceptions from sapphire framework exceptions. So that sapphire framework exceptions are dealt inside DM and app exceptions are handled at app.
5. Twitter Manager APP stubs are regenerated with new app stub generator and committed along with this PR.