### PR TITLE
DCAP distributed transaction DM minor: order of compared objects rearranged 

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/ExtResourceTransactionManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/ExtResourceTransactionManager.java
@@ -48,7 +48,7 @@ public class ExtResourceTransactionManager implements TransactionManager, Serial
         if (vote.equals(Vote.YES)) {
             Vote voteExtResource = this.getBusinessObject(transactionId).vote(transactionId);
 
-            if (!voteExtResource.equals(Vote.YES)) {
+            if (!Vote.YES.equals(voteExtResource)) {
                 logger.log(Level.WARNING, "inconsistent resource state; transaction aborted.");
                 this.internalTransactionManager.abort(transactionId);
                 vote = Vote.NO;


### PR DESCRIPTION
very trivial: switch the object comparison order to avoid null reference noise