### PR TITLE
DCAP distributed transaction DM part 13: transaction re-entrance, avoids infinite primitive message propagating 

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/NonconcurrentTransactionValidator.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/NonconcurrentTransactionValidator.java
@@ -32,6 +32,10 @@ public class NonconcurrentTransactionValidator implements TransactionValidator, 
                 return false;
             }
 
+            if (this.promised.size() == 1 && this.promised.iterator().next() == transactionId) {
+                return true;
+            }
+
             if (!this.promised.isEmpty()) {
                 return false;
             }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TLS2PCCoordinator.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TLS2PCCoordinator.java
@@ -63,6 +63,9 @@ public class TLS2PCCoordinator implements TwoPCCoordinator{
             return Vote.NO;
         }
 
+        // clears the processed SO client list for the subsequent vote propagation
+        TransactionContext.initPrecessed();
+
         if (this.localParticipantsManager.allParticipantsVotedYes(transactionId)) {
             return Vote.YES;
         } else {
@@ -75,6 +78,9 @@ public class TLS2PCCoordinator implements TwoPCCoordinator{
     public void commit(UUID transactionId) {
         this.validator.onCommit(transactionId);
         try {
+            // clears the processed SO client list for the subsequent commit propagation
+            TransactionContext.initPrecessed();
+
             this.localParticipantsManager.fanOutTransactionPrimitive(transactionId, TwoPCPrimitive.Commit);
         } catch (TransactionExecutionException e) {
             // todo: proper error handling - commit itself should always succeed
@@ -87,6 +93,9 @@ public class TLS2PCCoordinator implements TwoPCCoordinator{
     public void abort(UUID transactionId) {
         this.validator.onAbort(transactionId);
         try {
+            // clears the processed SO client list for the subsequent abort propagation
+            TransactionContext.initPrecessed();
+
             this.localParticipantsManager.fanOutTransactionPrimitive(transactionId, TwoPCPrimitive.Abort);
         } catch (TransactionExecutionException e) {
             // todo: proper error handling - abort itself should always succeed

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TransactionContext.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TransactionContext.java
@@ -1,5 +1,9 @@
 package sapphire.policy.transaction;
 
+import sapphire.policy.SapphirePolicy;
+
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -8,6 +12,28 @@ import java.util.UUID;
 public class TransactionContext {
     private static final ThreadLocal<UUID> transactionID = new ThreadLocal<UUID>();
     private static final ThreadLocal<TwoPCParticipants> participants = new ThreadLocal<TwoPCParticipants>();
+
+    // nested level of the current transaction
+    private static final ThreadLocal<Integer> transactionEnterCount = new ThreadLocal<Integer>();
+
+    // to keep track of SO objects been processed in the current  transaction primitive op
+    private static final ThreadLocal<Set<SapphirePolicy.SapphireClientPolicy>> processedClients = new ThreadLocal<Set<SapphirePolicy.SapphireClientPolicy>>();
+
+    /**
+     * gets the clients of SO objects that haven been processed so far in the current transaction primitive op
+     * @return the clients of SO objects been processed
+     */
+    public static Set<SapphirePolicy.SapphireClientPolicy> getProcessedClients() {
+        return processedClients.get();
+    }
+
+    /**
+     * resets the processed SO clients
+     */
+    public static void initPrecessed() {
+        HashSet<SapphirePolicy.SapphireClientPolicy> emptyClients = new HashSet<SapphirePolicy.SapphireClientPolicy>();
+        processedClients.set(emptyClients);
+    }
 
     /**
      * gets the transaction ID of the active transaction if present
@@ -29,15 +55,26 @@ public class TransactionContext {
      * @param participantManager the participants manager object that manages transaction participants
      */
     public static void enterTransaction(UUID transactionId, TwoPCParticipants participantManager) {
-        transactionID.set(transactionId);
-        participants.set(participantManager);
+        if (transactionId.equals(getCurrentTransaction())){
+            transactionEnterCount.set(transactionEnterCount.get() + 1);
+        }else{
+            transactionID.set(transactionId);
+            participants.set(participantManager);
+            transactionEnterCount.set(1);
+            initPrecessed();
+        }
     }
 
     /**
      * leaves the transaction after clean up the transaction related data
      */
     public static void leaveTransaction() {
-        transactionID.remove();
-        participants.remove();
+        if (transactionEnterCount.get() != null) {
+            transactionEnterCount.set(transactionEnterCount.get() - 1);
+            if (transactionEnterCount.get() == 0) {
+                transactionID.remove();
+                participants.remove();
+            }
+        }
     }
 }


### PR DESCRIPTION
Features:
* transaction may be entered/left multiple times in one thread  
* infinite loop of propagating vote/commit/abort was avoided 
* 2pc preparation admits the idempotent fashion
