### PR TITLE
Consensus issues fixes

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/AlreadyVotedException.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/AlreadyVotedException.java
@@ -1,0 +1,14 @@
+package sapphire.policy.util.consensus.raft;
+
+/**
+ * Created by quinton on 5/25/18.
+ */
+
+/**
+ * If member has already voted for a different leader when receiving requestVote RPC
+ */
+public class AlreadyVotedException extends VotingException {
+	public AlreadyVotedException(String s, int currentTerm) {
+		super(s, currentTerm);
+	}
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/CandidateBehindException.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/CandidateBehindException.java
@@ -1,0 +1,14 @@
+package sapphire.policy.util.consensus.raft;
+
+/**
+ * Created by quinton on 5/25/18.
+ */
+
+/**
+ * If candidate’s log is not at least as up-to-date as receiver’s log on requestVote RPC
+ */
+public class CandidateBehindException extends VotingException {
+	public CandidateBehindException(String s, int currentTerm) {
+		super(s, currentTerm);
+	}
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/InvalidLogIndex.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/InvalidLogIndex.java
@@ -1,0 +1,16 @@
+package sapphire.policy.util.consensus.raft;
+
+/**
+ * Created by quinton on 5/25/18.
+ */
+
+/**
+ * If log doesn’t contain an entry at specified logIndex on appendEntries RPC
+ */
+public class InvalidLogIndex extends RaftRuntimeException {
+	int invalidIndex;
+	public InvalidLogIndex(String s, int invalidIndex) {
+		super(s);
+		this.invalidIndex = invalidIndex;
+	}
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/InvalidTermException.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/InvalidTermException.java
@@ -1,0 +1,14 @@
+package sapphire.policy.util.consensus.raft;
+
+/**
+ * Created by quinton on 5/25/18.
+ */
+
+/**
+ * If term < currentTerm on appendEntries or requestVote RPC
+ */
+public class InvalidTermException extends VotingException {
+	public InvalidTermException(String s, int currentTerm) {
+		super(s, currentTerm);
+	}
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/LeaderException.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/LeaderException.java
@@ -1,0 +1,18 @@
+package sapphire.policy.util.consensus.raft;
+
+/**
+ * Created by Venugopal Reddy K on 5/25/18.
+ */
+
+/**
+ * Leader exception is thrown when onRPC is invoked to raft follower servers
+ */
+public class LeaderException extends Exception {
+	RemoteRaftServer leader;
+	public LeaderException(String s, RemoteRaftServer leader) {
+		super(s);
+		this.leader = leader;
+	}
+
+	public RemoteRaftServer getLeader() { return leader;}
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/PrevLogTermMismatch.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/PrevLogTermMismatch.java
@@ -1,0 +1,18 @@
+package sapphire.policy.util.consensus.raft;
+
+/**
+ * Created by quinton on 5/25/18.
+ */
+
+/**
+ * If log doesn’t contain an entry at prevLogIndex whose term matches prevLogTerm on appendEntries RPC
+ */
+public class PrevLogTermMismatch extends Exception {
+	int logIndex, remoteTerm, localTerm;
+	public PrevLogTermMismatch(String s, int logIndex, int remoteTerm, int localTerm) {
+		super(s);
+		this.logIndex = logIndex;
+		this.remoteTerm = remoteTerm;
+		this.localTerm = localTerm;
+	}
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/RemoteRaftServer.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/RemoteRaftServer.java
@@ -22,9 +22,12 @@ public interface RemoteRaftServer {
      * @param entries      log entries to store (empty for heartbeat; may send more than one for efficiency)
      * @param leaderCommit leader’s commitIndex
      * @return currentTerm, for leader to update itself
+     * @throws InvalidTermException
+     * @throws PrevLogTermMismatch
+     * @throws InvalidLogIndex
      */
     int appendEntries(int term, UUID leader, int prevLogIndex, int prevLogTerm, List<LogEntry> entries, int leaderCommit)
-            throws Server.InvalidTermException, Server.PrevLogTermMismatch, Server.InvalidLogIndex;
+            throws InvalidTermException, PrevLogTermMismatch, InvalidLogIndex;
 
     /**
      * Invoked by candidates to gather votes.
@@ -33,12 +36,12 @@ public interface RemoteRaftServer {
      * @param lastLogIndex index of candidate’s last log entry
      * @param lastLogTerm term of candidate’s last log entry
      * @return currentTerm, for candidate to update itself
-     * @throws Server.InvalidTermException
-     * @throws Server.AlreadyVotedException
-     * @throws Server.CandidateBehindException
+     * @throws InvalidTermException
+     * @throws AlreadyVotedException
+     * @throws CandidateBehindException
      */
     int requestVote(int term, UUID candidate, int lastLogIndex, int lastLogTerm)
-            throws Server.InvalidTermException, Server.AlreadyVotedException, Server.CandidateBehindException;
+            throws InvalidTermException, AlreadyVotedException, CandidateBehindException;
 
     /**
      * applyToStateMachine applies an operation to the local state machine if the local node is

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/VotingException.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/VotingException.java
@@ -1,0 +1,17 @@
+package sapphire.policy.util.consensus.raft;
+
+/**
+ * Created by quinton on 5/25/18.
+ */
+
+/**
+ * Base class for all voting exceptions.
+ * When candidates request a vote but are denied, they need to know the current term of the voter to update themselves.
+ */
+public class VotingException extends Exception {
+	public int currentTerm;
+	public VotingException(String s, int currentTerm) {
+		super(s);
+		this.currentTerm = currentTerm;
+	}
+}

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/util/consensus/raft/ServerTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/util/consensus/raft/ServerTest.java
@@ -153,10 +153,9 @@ public class ServerTest {
         successfulLeaderElection();
         String[] methods = { "fooMethod", "barMethod" };
         ArrayList<Object> args = new ArrayList<Object>();
-        for (Server server: raftServer) {
-            for (String method : methods) {
-                server.applyToStateMachine(new ConsensusRSMPolicy.RPC(method, args));
-            }
+        for (String method : methods) {
+            // Apply to statemachine is invoked only on leader
+            raftServer[0].applyToStateMachine(new ConsensusRSMPolicy.RPC(method, args));
         }
     }
 }


### PR DESCRIPTION
Following issues are fixed with this PR.
1. appendEntries rpc takes list. And leader passes ArrayList$SubList(view of arraylist) to it. ArrayList$SubList is not serializable and throws Marshalling exception.
2. `AlreadyVotedException, CandidateBehindException, InvalidLogIndex, InvalidTermException, VotingException` exception classes are moved from server to separate files. Because policy stub generated with server$AlreadyVotedException so on for these and fails to compile.
2. Client to do rpc calls to only leader instead of doing to a random server.