### PR TITLE
build failure issue fixes

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/serializability/OptConcurrentTransactPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/serializability/OptConcurrentTransactPolicy.java
@@ -32,7 +32,8 @@ public class OptConcurrentTransactPolicy extends DefaultSapphirePolicy {
             oos = new ObjectOutputStream(dos);
             oos.writeObject(appObject);
             digest = dos.getMessageDigest().digest();
-        } catch (NoSuchAlgorithmException | IOException e) {
+        } catch (NoSuchAlgorithmException e) {
+        } catch (IOException e) {
         } finally {
             if (null != oos) {
                 try {

--- a/sapphire/sapphire-core/src/test/java/sapphire/common/UtilsTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/common/UtilsTest.java
@@ -108,6 +108,8 @@ public class UtilsTest {
         field = getField(instance.getClass(), name);
         if (null != field) {
             field.set(instance, value);
+        }
+    }
 
     @Test
     public void testLogEntrySerialization() throws Exception {

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.Serializable;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 
@@ -50,8 +51,8 @@ public class LoadBalancedMasterSlaveSyncPolicyIntegTest {
 
         client.setServer(server1);
         client.onCreate(group);
-        server1.onCreate(group);
-        server2.onCreate(group);
+        server1.onCreate(group, new Annotation[]{});
+        server2.onCreate(group, new Annotation[]{});
         server1.start();
         server2.start();
     }

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyTest.java
@@ -3,6 +3,7 @@ package sapphire.policy.scalability;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Date;
@@ -74,7 +75,7 @@ public class LoadBalancedMasterSlaveSyncPolicyTest {
             AppObject appObj = new AppObject(new Date());
             server.$__setKernelOID(new KernelOID(i));
             server.$__initialize(appObj);
-            server.onCreate(group);
+            server.onCreate(group, new Annotation[]{});
             group.addServer(server);
             servers.add(server);
         }


### PR DESCRIPTION
Following changes are made:
1. UT cases were failing because of annotation support PR merge. server.onCreate and group.onCreate methods have annotation array as input. Modified test scripts to pass annotations.
2. java 1.6 do not support catching of multiple exceptions in single catch clause. OptConcurrentTransaction PR had used to catch multiple exceptions in single catch in an instance. But gradle build file use sourceCompatibility and targetCompatibilty of 1.6. Modified to support be 1.6 compatible.
3. UtilsTest file had merge resolution issue with LoadBalanceFrontend UT PR.