### PR TITLE
Added uberJar task in sapphire-core build.gradle

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -45,5 +45,11 @@ task createJar(type: Copy) {
     include('classes.jar')
     rename('classes.jar', 'sapphire-core.jar')
 }
-
 createJar.dependsOn(deleteJar, build)
+
+task uberJar(type: Jar) {
+    dependsOn ':dependencies:build'
+    baseName = 'sapphire-core-all'
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+}


### PR DESCRIPTION
Added a task in build.gradle to generate uber jar for sapphire core. The name of uber jar is `sapphire-core-all.jar`. It lives in `build/libs` directory. This jar file contains sapphire core and its dependencies, e.g. java.rmi, json, etc.

You can run `gradlew uberJar` under `sapphire-core` project to generate uber jar.

<img width="680" alt="screen shot 2018-07-24 at 6 47 19 pm" src="https://user-images.githubusercontent.com/1460413/43175053-1062bed8-8f72-11e8-9ecb-72b50d2cf7e6.png">
