### PR TITLE
Makes buildSrc depend on sapphire-core

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -1,3 +1,5 @@
+import dcap.gradle.StubGenerationTask
+
 buildscript {
     repositories {
         google()
@@ -83,3 +85,7 @@ subprojects {
         }
     }
 }
+
+// Task for stub generation
+task stubgen(type: StubGenerationTask)
+

--- a/sapphire/buildSrc/build.gradle
+++ b/sapphire/buildSrc/build.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'maven'
+apply plugin: 'java'
+
+repositories {
+    jcenter()
+    google()
+    // TODO: Getting packages from personal maven repository temporarily.
+    // Replace it with the offical team repository.
+    maven { url  "https://dl.bintray.com/terryzhuo/DCAP" }
+}
+
+dependencies {
+    implementation gradleApi()
+    compile 'com.huawei.paas:sapphire-core:1.0.0'
+}

--- a/sapphire/buildSrc/src/main/java/dcap/gradle/StubGenerationTask.java
+++ b/sapphire/buildSrc/src/main/java/dcap/gradle/StubGenerationTask.java
@@ -1,0 +1,13 @@
+package dcap.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.apache.harmony.rmi.common.RMIUtil;
+import sapphire.policy.SapphirePolicy;
+
+public class StubGenerationTask extends DefaultTask {
+    @TaskAction
+    public void run() {
+        System.out.println("hello from StubGenerator!");
+    }
+}

--- a/sapphire/dependencies/apache.harmony/build.gradle
+++ b/sapphire/dependencies/apache.harmony/build.gradle
@@ -1,0 +1,5 @@
+// Mave Plugin Properties
+// Reset maven properties to ensure that their values are
+// consistent with the values used by Maven Publish Plugin
+group = project.property('mavenGroupId')
+version = project.property('mavenVersion')

--- a/sapphire/dependencies/apache.harmony/gradle.properties
+++ b/sapphire/dependencies/apache.harmony/gradle.properties
@@ -10,5 +10,5 @@ bintrayVcsUrl=https://github.com/Huawei-PaaS/DCAP-Sapphire.git
 
 # maven properties
 mavenGroupId=com.huawei.paas
-mavenArtifactId=apache-harmony
+mavenArtifactId=apache.harmony
 mavenVersion=1.0.0

--- a/sapphire/dependencies/java.rmi/build.gradle
+++ b/sapphire/dependencies/java.rmi/build.gradle
@@ -1,3 +1,9 @@
+// Mave Plugin Properties
+// Reset maven properties to ensure that their values
+// are consistent with the values used by Maven Publish plugin
+group = project.property('mavenGroupId')
+version =  project.property('mavenVersion')
+
 dependencies {
     compile project(':dependencies:apache.harmony')
 }

--- a/sapphire/dependencies/java.rmi/gradle.properties
+++ b/sapphire/dependencies/java.rmi/gradle.properties
@@ -10,5 +10,5 @@ bintrayVcsUrl=https://github.com/Huawei-PaaS/DCAP-Sapphire.git
 
 # maven properties
 mavenGroupId=com.huawei.paas
-mavenArtifactId=java-rmi
+mavenArtifactId=java.rmi
 mavenVersion=1.0.0

--- a/sapphire/gradle.properties
+++ b/sapphire/gradle.properties
@@ -7,7 +7,7 @@ bintrayLicense=MIT
 bintrayVersion=unspecified
 bintrayVcsUrl=unspecified
 
-# Maven properties
+# Maven Publish Plugin Properties
 # Subprojects which plan to publish maven packages should
 # override these properties in its own gradle.properties
 mavenGroupId=com.huawei.paas

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -19,6 +19,12 @@ dependencies {
 
 compileJava.dependsOn tasks.googleJavaFormat
 
+// Maven Plugin Properties
+// Reset maven properties to ensure that their values are 
+// consistent with the values used by Maven Publish Plugin
+group = project.property('mavenGroupId')
+version =  project.property('mavenVersion')
+
 // run `gradle delstubs` to remove stub java files
 task delstubs(type: Delete) {
     delete fileTree('src/main/java/sapphire/policy/stubs') {


### PR DESCRIPTION
Major changes are:
1. Added dependency on buildSrc. Make it depend on sapphire-core. Gradle pulls package from Jcenter. Verified that the dependency works. 
2. Added a task skeleton for stub generation

<img width="632" alt="screen shot 2018-07-30 at 2 13 06 pm" src="https://user-images.githubusercontent.com/1460413/43424221-75bd0780-9403-11e8-86c9-cb14a88609fd.png">

<img width="667" alt="screen shot 2018-07-30 at 2 16 37 pm" src="https://user-images.githubusercontent.com/1460413/43424224-7b1af7b4-9403-11e8-9496-4783903570be.png">
