### PR TITLE
Automate stub generation in build

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -87,4 +87,13 @@ subprojects {
             }
         }
     }
+
+    // Task for Stub compilation
+    task compileStubs(type: JavaCompile) {
+        source = sourceSets.main.java.srcDirs
+        classpath = sourceSets.main.compileClasspath
+        destinationDir = sourceSets.main.output.classesDir
+        options.incremental = true
+    }
+    jar.dependsOn compileStubs
 }

--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -1,0 +1,26 @@
+import dcap.sapphire.gradle.PolicyStubGenerationTask
+
+dependencies {
+    compile project(':sapphire-core')
+}
+
+// Task for app stub generation
+task genAppStubs(type: JavaExec) {
+    main = "sapphire.compiler.StubGenerator"
+    classpath = sourceSets.main.runtimeClasspath
+    def pkgName = 'sapphire.appexamples.helloworld'
+    def src = "$buildDir/classes/java/main/sapphire/appexamples/helloworld/"
+    def dst = "src/main/java/sapphire/appexamples/helloworld/stubs/"
+    args src, pkgName, dst 
+}
+
+genAppStubs.mustRunAfter compileJava
+compileStubs.dependsOn genAppStubs
+
+// Task for run HelloWorld demo app
+// Usage: gradlew runHelloWorld -PW=DisneyWorld
+task runHelloWorld(type: JavaExec) {
+    main = "sapphire.appexamples.helloworld.HelloWorldMain"
+    classpath = sourceSets.main.runtimeClasspath
+    args project.hasProperty('W') ? project.property('W') : "DCAP World"
+}

--- a/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorld.java
+++ b/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorld.java
@@ -1,0 +1,23 @@
+package sapphire.appexamples.helloworld;
+
+import sapphire.app.*;
+import sapphire.common.AppObjectStub;
+import sapphire.policy.atleastoncerpc.AtLeastOnceRPCPolicy;
+import sapphire.runtime.Sapphire;
+
+public class HelloWorld implements SapphireObject<AtLeastOnceRPCPolicy>, AppEntryPoint {
+    private String world = "DCAP World";
+
+    public HelloWorld(String world) {
+        this.world = world;
+    }
+
+    public String sayHello() {
+        return "Hi " + this.world;
+    }
+
+    @Override
+    public AppObjectStub start() throws AppObjectNotCreatedException {
+        return (AppObjectStub) Sapphire.new_(HelloWorld.class);
+    }
+}

--- a/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorldMain.java
+++ b/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorldMain.java
@@ -1,0 +1,13 @@
+package sapphire.appexamples.helloworld;
+
+public class HelloWorldMain {
+    public static void main(String[] args) {
+        String world = "DCAP World";
+        if (args.length > 0 && args[0] != null && args[0].length()>0) {
+            world = args[0];
+        }
+
+        HelloWorld helloWorld = new HelloWorld(world);
+        System.out.println(helloWorld.sayHello());
+    }
+}

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 googleJavaFormat {
-  options style: 'AOSP'
+    options style: 'AOSP'
 }
 
 dependencies {
@@ -22,7 +22,6 @@ dependencies {
     testCompile 'org.powermock:powermock-api-mockito:1.6.5'
 }
 
-compileJava.dependsOn tasks.googleJavaFormat
 
 // Maven Plugin Properties
 // Reset maven properties to ensure that their values are 
@@ -47,3 +46,8 @@ task genPolicyStubs(type: PolicyStubGenerationTask) {
     dstDir dst 
     outputs.dir dst
 }
+
+genPolicyStubs.mustRunAfter compileJava
+compileStubs.dependsOn genPolicyStubs
+tasks.googleJavaFormat.mustRunAfter genPolicyStubs
+check.dependsOn tasks.googleJavaFormat

--- a/sapphire/settings.gradle
+++ b/sapphire/settings.gradle
@@ -6,3 +6,6 @@ include ':dependencies:java.rmi'
 include ':dependencies:javax.rmi'
 include ':dependencies:javax.activity'
 include ':dependencies:apache.harmony'
+
+// Sapphire demo app
+include ':examples:helloworld'


### PR DESCRIPTION
With this PR, `gradlew build` will automatically generate stub codes, compile stub codes, and add them into jar file.

#### Major changes are:
1. Added gradle tasks to generate application stubs
2. Enabled stub generation in `gradlew build`
3. Added a HelloWorld demo application

#### Generate and compiles policy stubs for sapphire core
<img width="696" alt="screen shot 2018-08-01 at 5 34 06 pm" src="https://user-images.githubusercontent.com/1460413/43555788-24ad6772-95b1-11e8-926d-9a9b72ea0d7c.png">

#### Generate and compile app stubs for helloworld
<img width="701" alt="screen shot 2018-08-01 at 5 40 42 pm" src="https://user-images.githubusercontent.com/1460413/43555968-25a2a9e8-95b2-11e8-9902-756d9123548c.png">
