### PR TITLE
Enable the build of hankstodo and twittermanager

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -31,7 +31,6 @@ subprojects {
         jcenter()
         google()
     }
-    apply plugin: 'java-library'
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
@@ -87,13 +86,4 @@ subprojects {
             }
         }
     }
-
-    // Task for Stub compilation
-    task compileStubs(type: JavaCompile) {
-        source = sourceSets.main.java.srcDirs
-        classpath = sourceSets.main.compileClasspath
-        destinationDir = sourceSets.main.output.classesDir
-        options.incremental = true
-    }
-    jar.dependsOn compileStubs
 }

--- a/sapphire/dependencies/apache.harmony/build.gradle
+++ b/sapphire/dependencies/apache.harmony/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'java-library'
 // Mave Plugin Properties
 // Reset maven properties to ensure that their values are
 // consistent with the values used by Maven Publish Plugin

--- a/sapphire/dependencies/java.rmi/build.gradle
+++ b/sapphire/dependencies/java.rmi/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'java-library'
 // Mave Plugin Properties
 // Reset maven properties to ensure that their values
 // are consistent with the values used by Maven Publish plugin

--- a/sapphire/dependencies/javax.activity/build.gradle
+++ b/sapphire/dependencies/javax.activity/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'java-library'

--- a/sapphire/dependencies/javax.rmi/build.gradle
+++ b/sapphire/dependencies/javax.rmi/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'java-library'
 dependencies {
     compile project(':dependencies:apache.harmony')
 }

--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -1,7 +1,16 @@
 import dcap.sapphire.gradle.PolicyStubGenerationTask
+apply plugin: 'java-library'
 
 dependencies {
     compile project(':sapphire-core')
+}
+
+// Task for Stub compilation
+task compileStubs(type: JavaCompile) {
+    source = sourceSets.main.java.srcDirs
+    classpath = sourceSets.main.compileClasspath
+    destinationDir = sourceSets.main.output.classesDir
+    options.incremental = true
 }
 
 // Task for app stub generation
@@ -16,6 +25,7 @@ task genAppStubs(type: JavaExec) {
 
 genAppStubs.mustRunAfter compileJava
 compileStubs.dependsOn genAppStubs
+jar.dependsOn compileStubs
 
 // Task for run HelloWorld demo app
 // Usage: gradlew runHelloWorld -PW=DisneyWorld

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -7,6 +7,7 @@ plugins {
     // 3. More usage information can be found at 
     // https://github.com/sherter/google-java-format-gradle-plugin
     id 'com.github.sherter.google-java-format' version '0.7.1'
+    id 'java-library'
 }
 
 googleJavaFormat {
@@ -47,7 +48,16 @@ task genPolicyStubs(type: PolicyStubGenerationTask) {
     outputs.dir dst
 }
 
+// Task for stub compilation
+task compileStubs(type: JavaCompile) {
+    source = sourceSets.main.java.srcDirs
+    classpath = sourceSets.main.compileClasspath
+    destinationDir = sourceSets.main.output.classesDir
+    options.incremental = true
+}
+
 genPolicyStubs.mustRunAfter compileJava
 compileStubs.dependsOn genPolicyStubs
 tasks.googleJavaFormat.mustRunAfter genPolicyStubs
 check.dependsOn tasks.googleJavaFormat
+jar.dependsOn compileStubs

--- a/sapphire/settings.gradle
+++ b/sapphire/settings.gradle
@@ -9,3 +9,5 @@ include ':dependencies:apache.harmony'
 
 // Sapphire demo app
 include ':examples:helloworld'
+include ':examples:hankstodo'
+include ':examples:example-minnietwitter'


### PR DESCRIPTION
Since we are actively developing DM code and sapphire core, I feel that it is not a good timing to move demo apps to a separate repository at present. This PR will enable build on hankstodo and twittermanger again. 

<img width="915" alt="screen shot 2018-08-02 at 2 58 45 pm" src="https://user-images.githubusercontent.com/1460413/43613552-a085c0a2-9664-11e8-8ed2-2bbf6eac3043.png">
