### PR TITLE
Rename the project name from "hankstodo" to "hanksTodo"

### DIFF
--- a/sapphire/settings.gradle
+++ b/sapphire/settings.gradle
@@ -9,5 +9,5 @@ include ':dependencies:apache.harmony'
 
 // Sapphire demo app
 include ':examples:helloworld'
-include ':examples:hankstodo'
+include ':examples:hanksTodo'
 include ':examples:example-minnietwitter'


### PR DESCRIPTION
This PR is a cosmetic change. You can safely skip it.

The PR renames the project name from "hankstodo" to "hanksTodo" so that the project name matches with the directory name. 

