### PR TITLE
Use $projectDir in genPolicyStubs.dst

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -43,7 +43,7 @@ task genPolicyStubs(type: PolicyStubGenerationTask) {
     srcDir src
     inputs.dir src
 
-    def dst = new File("src/main/java/sapphire/policy/stubs/")
+    def dst = new File("$projectDir/src/main/java/sapphire/policy/stubs/")
     dstDir dst 
     outputs.dir dst
 }


### PR DESCRIPTION
Currently, the genPolicyStubs.dst is defined as "src/main/java/sapphire/policy/stubs/"
which is a path relative to the current directory, i.e. the directory where the gradle
command is invoked. If a user runs `gradlew genPolicyStubs` outside of sapphire-core
project, the stub files will be put outside of sapphire-core.

This PR changes dst to "$projectDir/src/main/java/sapphire/policy/stubs/" so that
generated stub files always live in the src directory of sapphire-core project.

<img width="938" alt="screen shot 2018-08-20 at 4 54 10 pm" src="https://user-images.githubusercontent.com/1460413/44372628-b2b5a380-a499-11e8-8413-36fc53f25f72.png">
