### PR TITLE
AppStub generation issue when appclass has multi constructors

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/compiler/AppStub.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/compiler/AppStub.java
@@ -66,14 +66,14 @@ public final class AppStub extends Stub {
     @Override
     public String getStubConstructors() {
         StringBuilder buffer = new StringBuilder();
-        StringBuilder paramNames = new StringBuilder();
+        StringBuilder paramNames;
 
         Constructor<?>[] constructors = stubClass.getConstructors();
 
         for (Constructor<?> constructor : constructors) {
             buffer.append(indenter.indent() + "public " + stubName + " (");
             Class<?>[] params = constructor.getParameterTypes();
-
+            paramNames = new StringBuilder();
             for (int i = 0; i < params.length; i++) {
                 buffer.append(
                         ((i > 0) ? ", " : "")


### PR DESCRIPTION
When APP class has multiple constructors, appstub generation has below issue.

![appstub-issue-with-multi-arg-constructors](https://user-images.githubusercontent.com/35334869/44664860-127bf380-aa32-11e8-8720-c95338e01a52.png)
