### PR TITLE
Replace Stub Generation Gradle Plugin with Direct Invocation on CodeGenerator

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -50,21 +50,20 @@ group = project.property('mavenGroupId')
 version =  project.property('mavenVersion')
 
 // Task for Policy Stub Generation:
-// 1. Run `gradlew genPolicyStubs` to generate policy stub files
-// 2. Run `gradlew cleanGenPolicyStubs` to delete stub files
-task genPolicyStubs(type: PolicyStubGenerationTask) {
-    group 'Stub'
-    description 'Generates sub classes for Sapphire policies'
+// Run `gradlew genStubs` to generate policy stub files
+task genStubs(type: JavaExec) {
+    main = "sapphire.compiler.StubGenerator"
+    classpath = sourceSets.main.runtimeClasspath
+    def pkgName = 'sapphire.policy'
+    def src = "$buildDir/classes/java/main/sapphire/policy/"
+    def dst = "$projectDir/src/main/java/sapphire/policy/stubs/"
+    args src, pkgName, dst
+}
 
-    pkgName 'sapphire.policy'
-
-    def src = new File("$buildDir/classes/java/main/sapphire/policy/")
-    srcDir src
-    inputs.dir src
-
-    def dst = new File("$projectDir/src/main/java/sapphire/policy/stubs/")
-    dstDir dst 
-    outputs.dir dst
+task delStubs(type: Delete) {
+    delete fileTree("$projectDir/src/main/java/sapphire/policy/stubs") {
+        include '**/*_Stub.java'
+    }
 }
 
 // Task for stub compilation
@@ -75,9 +74,10 @@ task compileStubs(type: JavaCompile) {
     options.incremental = true
 }
 
-genPolicyStubs.mustRunAfter compileJava
-compileStubs.dependsOn genPolicyStubs
-tasks.googleJavaFormat.mustRunAfter genPolicyStubs
+genStubs.mustRunAfter delStubs
+genStubs.mustRunAfter compileJava
+compileStubs.dependsOn genStubs
+tasks.googleJavaFormat.mustRunAfter genStubs
 check.dependsOn tasks.googleJavaFormat
 jar.dependsOn compileStubs
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -252,7 +252,7 @@ public class KernelServerImpl implements KernelServer {
 
     /** Send heartbeats to OMS. */
     static void startheartbeat(ServerInfo srvinfo) {
-        logger.info("heartbeat KernelServer" + srvinfo);
+        logger.fine("heartbeat KernelServer" + srvinfo);
         try {
             oms.heartbeatKernelServer(srvinfo);
         } catch (Exception e) {

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
@@ -103,7 +103,7 @@ public class KernelServerManager {
 
     public void heartbeatKernelServer(ServerInfo srvinfo)
             throws RemoteException, NotBoundException, KernelServerNotFoundException {
-        logger.info(
+        logger.fine(
                 "heartbeat from KernelServer: "
                         + srvinfo.getHost().toString()
                         + " in region "


### PR DESCRIPTION
At present stub generation gradle plugin uses sapphire-core.jar from bintray. However, when we run demo apps (e.g. hankstodo), we use sapphire-core project. I realize that this mismatch caused a couple of subtle bugs. For example the signatures of generated stub classes may be incorrect. To fix this issue, I disable the stub generation gradle plugin.

But the "genStubs" task and "delStubs" task still exists. You can still use these tasks to generate stubs and delete stubs.  Running `gradlew build` also triggers stub generations. Nothing changes from user's perspective. But instead of using gradle plugin to generate stubs, we use StubGenerator class directly to generate stubs. 

<img width="974" alt="screen shot 2018-09-12 at 10 47 24 pm" src="https://user-images.githubusercontent.com/1460413/45469327-e1601c00-b6dd-11e8-9ef9-f1c90491ec4b.png">
