### PR TITLE
Simplify task names and delete stub file in "clean" task

### DIFF
--- a/sapphire/examples/hanksTodo/build.gradle
+++ b/sapphire/examples/hanksTodo/build.gradle
@@ -14,7 +14,7 @@ task compileStubs(type: JavaCompile) {
 }
 
 // Task for app stub generation
-task genhanksTodoAppStubs(type: JavaExec) {
+task genStubs(type: JavaExec) {
     main = "sapphire.compiler.StubGenerator"
     classpath = sourceSets.main.runtimeClasspath
     def pkgName = 'sapphire.appexamples.hankstodo'
@@ -23,26 +23,35 @@ task genhanksTodoAppStubs(type: JavaExec) {
     args src, pkgName, dst
 }
 
-genhanksTodoAppStubs.mustRunAfter compileJava
-compileStubs.dependsOn genhanksTodoAppStubs
+clean.doFirst {
+    delete fileTree("$projectDir/src/main/java/sapphire/appexamples/hankstodo/stubs") {
+        include '**/*_Stub.java'
+    }
+    println "Deleted $projectDir/src/main/java/sapphire/appexamples/hankstodo/stubs"
+}
+
+genStubs.mustRunAfter compileJava
+compileStubs.dependsOn genStubs
 jar.dependsOn compileStubs
 
-task runHanksTodoOms(type: JavaExec) {
+// Start OMS with "gradlew runoms"
+task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.oms.OMSServerImpl'
     args project.property('omsIp'), project.property('omsPort')
 }
 
-task runHanksTodoKernelServer(type: JavaExec) {
+// Start kernel server with "gradlew runks"
+task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 
 // Task for run hanksTodoApp demo app
-// Usage: gradlew runHanksTodoApp -PW=DisneyWorld
-task runHanksTodoApp(type: JavaExec) {
+// Usage: gradlew runapp -PW=DisneyWorld
+task runapp(type: JavaExec) {
     main = "sapphire.appexamples.hankstodo.hanskTododMain"
     classpath = sourceSets.main.runtimeClasspath
     args project.property('omsIp'), project.property('omsPort'), project.property('kernelIpAndroid'), project.property('kernelServerPort')

--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -1,4 +1,3 @@
-import dcap.sapphire.gradle.PolicyStubGenerationTask
 apply plugin: 'java-library'
 
 dependencies {
@@ -14,7 +13,7 @@ task compileStubs(type: JavaCompile) {
 }
 
 // Task for app stub generation
-task genAppStubs(type: JavaExec) {
+task genStubs(type: JavaExec) {
     main = "sapphire.compiler.StubGenerator"
     classpath = sourceSets.main.runtimeClasspath
     def pkgName = 'sapphire.appexamples.helloworld'
@@ -23,26 +22,35 @@ task genAppStubs(type: JavaExec) {
     args src, pkgName, dst 
 }
 
-genAppStubs.mustRunAfter compileJava
-compileStubs.dependsOn genAppStubs
+clean.doFirst {
+    delete fileTree("$projectDir/src/main/java/sapphire/appexamples/helloworld/stubs") {
+        include '**/*_Stub.java'
+    }
+    println "Deleted $projectDir/src/main/java/sapphire/appexamples/helloworld/stubs"
+}
+
+genStubs.mustRunAfter compileJava
+compileStubs.dependsOn genStubs
 jar.dependsOn compileStubs
 
-task runHelloWorldOms(type: JavaExec) {
+// Start kernel server with "gradlew runoms"
+task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.oms.OMSServerImpl'
     args project.property('omsIp'), project.property('omsPort')
 }
 
-task runHelloWorldKernelServer(type: JavaExec) {
+// Start kernel server with "gradlew runks"
+task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 
 // Task for run HelloWorld demo app
-// Usage: gradlew runHelloWorld -PW=DisneyWorld
-task runHelloWorld(type: JavaExec) {
+// Usage: gradlew runapp -PW=DisneyWorld
+task runapp(type: JavaExec) {
     main = "sapphire.appexamples.helloworld.HelloWorldMain"
     classpath = sourceSets.main.runtimeClasspath
     args project.property('omsIp'), project.property('omsPort'), project.property('kernelIpAndroid'), project.property('kernelServerPort'), project.hasProperty('W') ? project.property('W') : "DCAP World"


### PR DESCRIPTION
Major changes are:
* Delete stub.java files in gradle clean task
* Simplified gradle task names. For example, *runHanksTodoOms* is simplified to *runoms*. With this PR, we will have a set of standard gradles tasks: genStubs, compileStubs, runoms, runks, runapp.

<img width="837" alt="screen shot 2018-09-20 at 6 07 04 pm" src="https://user-images.githubusercontent.com/1460413/45854452-0406bc00-bd00-11e8-944a-0f0a75550430.png">
