### PR TITLE
dm test issues and added support for ondestroy

### DIFF
--- a/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/TodoList.java
+++ b/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/TodoList.java
@@ -1,6 +1,5 @@
 package sapphire.appexamples.hankstodo;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 
 import sapphire.app.*;

--- a/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/TodoListManager.java
+++ b/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/TodoListManager.java
@@ -21,4 +21,11 @@ public class TodoListManager implements SapphireObject<DHTPolicy> {
 		System.out.println("This managers lists" + todoLists.toString());
 		return t;
 	}
+
+	public void deleteTodoList(String name) {
+		TodoList t = todoLists.remove(new DHTKey(name));
+		if (t != null) {
+			delete_(t);
+		}
+	}
 }

--- a/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/hanskTododMain.java
+++ b/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/hanskTododMain.java
@@ -48,6 +48,10 @@ public class hanskTododMain {
             System.out.println(tl3.addToDo("Second todo"));
             System.out.println(tl3.addToDo("Third todo"));
 
+            tlm.deleteTodoList("Hanks");
+            tlm.deleteTodoList("AAA");
+            tlm.deleteTodoList("HHH");
+            omsserver.deleteSapphireObject(sapphireObjId);
         } catch (Exception e) {
             // TODO Auto-generated catch block
             System.out.println("Exception Received : " + e);

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
@@ -200,6 +200,10 @@ public class KernelServerManager {
      * @return list of kernel server host addresses in the given region otherwise null
      */
     public ArrayList<InetSocketAddress> getServersInRegion(String region) {
-        return regions.get(region);
+        ArrayList<InetSocketAddress> servers = regions.get(region);
+        if (servers == null) {
+            return null;
+        }
+        return new ArrayList<>(servers);
     }
 }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicy.java
@@ -79,11 +79,6 @@ public class DefaultSapphirePolicy extends SapphirePolicy {
         public void onFailure(SapphireServerPolicy server) throws RemoteException {}
 
         @Override
-        public SapphireServerPolicy onRefRequest() throws RemoteException {
-            return null;
-        }
-
-        @Override
         public ArrayList<SapphireServerPolicy> getServers() throws RemoteException {
             if (servers == null) {
                 return new ArrayList<SapphireServerPolicy>();

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
@@ -77,6 +77,10 @@ public abstract class DefaultSapphirePolicyUpcallImpl extends SapphirePolicyLibr
             return super.sapphire_getAppObject();
         }
 
+        public String sapphire_getRegion() {
+            return super.sapphire_getRegion();
+        }
+
         public void onDestroy() {}
     }
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/cache/WriteThroughCachePolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/cache/WriteThroughCachePolicy.java
@@ -18,25 +18,19 @@ import sapphire.policy.DefaultSapphirePolicy;
 public class WriteThroughCachePolicy extends DefaultSapphirePolicy {
 
     public static class ClientPolicy extends DefaultClientPolicy {
-        private ServerPolicy server;
         // TODO: Add a timeout for cachedObject
         private AppObject cachedObject = null;
-
-        @Override
-        public void setServer(SapphireServerPolicy server) {
-            this.server = (ServerPolicy) server;
-        }
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
             Object ret = null;
 
             if (isMethodMutable(method, params)) {
-                ret = server.onRPC(method, params);
-                cachedObject = server.getObject();
+                ret = getServer().onRPC(method, params);
+                cachedObject = ((ServerPolicy) getServer()).getObject();
             } else {
                 if (cachedObject == null) {
-                    cachedObject = server.getObject();
+                    cachedObject = ((ServerPolicy) getServer()).getObject();
                 }
 
                 ret = cachedObject.invoke(method, params);

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
@@ -135,6 +135,16 @@ public class LoadBalancedMasterSlaveSyncPolicy extends LoadBalancedMasterSlaveBa
         }
 
         @Override
+        public void onDestroy() {
+            super.onDestroy();
+            try {
+                finalize();
+            } catch (Throwable throwable) {
+                throwable.printStackTrace();
+            }
+        }
+
+        @Override
         protected void finalize() throws Throwable {
             if (commitExecutor != null) {
                 commitExecutor.close();

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/serializability/LockingTransactionPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/serializability/LockingTransactionPolicy.java
@@ -44,7 +44,7 @@ public class LockingTransactionPolicy extends CacheLeasePolicy {
                         throw new Exception("Transaction timed out.  Transaction rolled back.");
                     }
                 } else { // Outside of transactions, we invoke against the server
-                    return server.onRPC(method, params);
+                    return getServer().onRPC(method, params);
                 }
             }
         }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/servercache/DurableOnDemandCachedList.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/servercache/DurableOnDemandCachedList.java
@@ -1,9 +1,7 @@
 package sapphire.policy.servercache;
 
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
-import sapphire.policy.SapphirePolicy;
-import sapphire.policy.cache.CacheLeasePolicy.CacheLeaseServerPolicy;
+import sapphire.policy.DefaultSapphirePolicy;
 
 /*
  * This class must be applied to an object that extends the List class.
@@ -11,32 +9,9 @@ import sapphire.policy.cache.CacheLeasePolicy.CacheLeaseServerPolicy;
  * It interposes on each method call, stores everything to disk and caches sublists. (see Facebook's TAO paper)
  */
 
-public class DurableOnDemandCachedList extends SapphirePolicy {
+public class DurableOnDemandCachedList extends DefaultSapphirePolicy {
 
-    public static class DurableOnDemandCachedListClientPolicy extends SapphireClientPolicy {
-        private DurableOnDemandCachedListServerPolicy server;
-        private DurableOnDemandCachedListGroupPolicy group;
-
-        @Override
-        public void onCreate(SapphireGroupPolicy group, Annotation[] annotations) {
-            this.group = (DurableOnDemandCachedListGroupPolicy) group;
-        }
-
-        @Override
-        public SapphireGroupPolicy getGroup() {
-            return group;
-        }
-
-        @Override
-        public SapphireServerPolicy getServer() {
-            return server;
-        }
-
-        @Override
-        public void setServer(SapphireServerPolicy server) {
-            this.server = (DurableOnDemandCachedListServerPolicy) server;
-        }
-
+    public static class DurableOnDemandCachedListClientPolicy extends DefaultClientPolicy {
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
             /* Switch on the method we need to execute */
@@ -45,24 +20,9 @@ public class DurableOnDemandCachedList extends SapphirePolicy {
     }
 
     // TODO: think about concurrency
-    public static class DurableOnDemandCachedListServerPolicy extends SapphireServerPolicy {
-        private DurableOnDemandCachedListGroupPolicy group;
+    public static class DurableOnDemandCachedListServerPolicy extends DefaultServerPolicy {
         int listSize; // cache the size of the list
         int numMisses; // to automatically grow the cache if possible
-
-        @Override
-        public void onCreate(SapphireGroupPolicy group, Annotation[] annotations) {
-            // TODO Auto-generated method stub
-            this.group = (DurableOnDemandCachedListGroupPolicy) group;
-        }
-
-        @Override
-        public SapphireGroupPolicy getGroup() {
-            return group;
-        }
-
-        @Override
-        public void onMembershipChange() {}
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
@@ -70,33 +30,5 @@ public class DurableOnDemandCachedList extends SapphirePolicy {
         }
     }
 
-    public static class DurableOnDemandCachedListGroupPolicy extends SapphireGroupPolicy {
-        CacheLeaseServerPolicy server;
-
-        @Override
-        public void addServer(SapphireServerPolicy server) {
-            this.server = (CacheLeaseServerPolicy) server;
-        }
-
-        @Override
-        public void removeServer(SapphireServerPolicy server) {}
-
-        @Override
-        public void onFailure(SapphireServerPolicy server) {}
-
-        @Override
-        public SapphireServerPolicy onRefRequest() {
-            return server;
-        }
-
-        @Override
-        public ArrayList<SapphireServerPolicy> getServers() {
-            return null;
-        }
-
-        @Override
-        public void onCreate(SapphireServerPolicy server, Annotation[] annotations) {
-            addServer(server);
-        }
-    }
+    public static class DurableOnDemandCachedListGroupPolicy extends DefaultGroupPolicy {}
 }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/Server.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/Server.java
@@ -81,6 +81,10 @@ public class Server
         this.become(State.FOLLOWER, vState.getState());
     }
 
+    public void stop() {
+        this.become(State.NONE, vState.getState());
+    }
+
     /**
      * Transition to a new state if current state is preconditionState, i.e. optimistic concurrency.
      *

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/util/consensus/raft/ServerTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/util/consensus/raft/ServerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.spy;
 import static sapphire.common.UtilsTest.extractFieldValueOnInstance;
 import static sapphire.policy.util.consensus.raft.Server.State.FOLLOWER;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -22,6 +23,7 @@ import sapphire.policy.replication.ConsensusRSMPolicy;
 /** Created by quinton on 3/16/18. */
 public class ServerTest {
     final int SERVER_COUNT = 3;
+    SapphirePolicy.SapphireGroupPolicy groupPolicy = mock(ConsensusRSMPolicy.GroupPolicy.class);
     SapphirePolicy.SapphireServerPolicy[] serverPolicy =
             new SapphirePolicy.SapphireServerPolicy[SERVER_COUNT];
     Server raftServer[] = new Server[SERVER_COUNT];
@@ -32,9 +34,11 @@ public class ServerTest {
         appObject = mock(AppObject.class);
 
         for (int i = 0; i < SERVER_COUNT; i++) {
+
             serverPolicy[i] = spy(ConsensusRSMPolicy.ServerPolicy.class);
             serverPolicy[i].$__initialize(appObject);
-            ((ConsensusRSMPolicy.ServerPolicy) serverPolicy[i]).initializeRaftServer();
+            ((ConsensusRSMPolicy.ServerPolicy) serverPolicy[i])
+                    .onCreate(groupPolicy, new Annotation[] {});
             try {
                 raftServer[i] =
                         (Server) (extractFieldValueOnInstance(this.serverPolicy[i], "raftServer"));


### PR DESCRIPTION
Following changes incorporated with this PR.
1. All the DMs made to extend Default Sapphire Policy.
2. Cache lease Policy's release lease issue fix.
3. Scaleup Policy server's get region issue fix and update host name after pinning issue fix.
4. Consensus DM modifed to support stop raft server, overriden onDestory to stop the raft server. Modified onCreate to create raft server instance.
4. Get servers in region(in `KernelServerManager.java`) on OMS to return a wrapped arraylist of servers.

All modified DMs are tested.