### PR TITLE
Simpified LoadBalancedFrontendPolicy.

### DIFF
--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -49,9 +49,11 @@ task runks(type: JavaExec) {
 }
 
 // Task for run HelloWorld demo app
-// Usage: gradlew runapp -PW=DisneyWorld
+// Usage: gradlew runapp -PW=DisneyWorld -Ptimes=1
 task runapp(type: JavaExec) {
     main = "sapphire.appexamples.helloworld.HelloWorldMain"
     classpath = sourceSets.main.runtimeClasspath
-    args project.property('omsIp'), project.property('omsPort'), project.property('kernelIpAndroid'), project.property('kernelServerPort'), project.hasProperty('W') ? project.property('W') : "DCAP World"
+    ext.word = project.hasProperty('W') ? project.property('W') : "DCAP World"
+    ext.cnt = project.hasProperty('times') ? project.property('times') : 1
+    args project.property('omsIp'), project.property('omsPort'), project.property('kernelIpAndroid'), project.property('kernelServerPort'), ext.word, ext.cnt
 }

--- a/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorldMain.java
+++ b/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorldMain.java
@@ -11,32 +11,51 @@ import sapphire.oms.OMSServer;
 
 public class HelloWorldMain {
     public static void main(String[] args) {
-        String world = "DCAP World";
+        String world = "Hello DCAP";
+        int cnt = 1;
 
-        if (args.length < 4) {
+        if (args.length < 5) {
             System.out.println("Incorrect arguments to the program");
-            System.out.println("<host-ip> <host-port> <oms ip> <oms-port> [program-arg]");
+            showUsage();
             return;
         }
 
-        if (args.length > 4 && args[4] != null && args[4].length()>0) {
-            world = args[4];
+        world = args[4];
+        if (args.length > 5 && args[5] != null && args[5].length()>0) {
+            try {
+                cnt = Integer.valueOf(args[5]);
+            } catch (NumberFormatException e) {
+                System.out.println(String.format("Invalid RepeatTime '%s'. RepeatTime must be a number.", args[5]));
+                showUsage();
+                return;
+            }
         }
 
         try {
             Registry registry = LocateRegistry.getRegistry(args[0], Integer.parseInt(args[1]));
             OMSServer server = (OMSServer) registry.lookup("SapphireOMS");
 
-            KernelServer nodeServer = new KernelServerImpl(new InetSocketAddress(args[2], Integer.parseInt(args[3])), new InetSocketAddress(args[0], Integer.parseInt(args[1])));
+            new KernelServerImpl(new InetSocketAddress(args[2], Integer.parseInt(args[3])), new InetSocketAddress(args[0], Integer.parseInt(args[1])));
 
             SapphireObjectID sapphireObjId =
                     server.createSapphireObject("sapphire.appexamples.helloworld.HelloWorld", world);
             HelloWorld helloWorld = (HelloWorld) server.acquireSapphireObjectStub(sapphireObjId);
-            System.out.println(helloWorld.sayHello());
 
-            server.deleteSapphireObject(sapphireObjId);
+            for (int i=0; i<cnt; i++) {
+                System.out.println(helloWorld.sayHello());
+                Thread.sleep(1000);
+            }
+
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private static void showUsage() {
+        System.out.println("Usage:");
+        System.out.println("<host-ip> <host-port> <oms ip> <oms-port> <Message> [RepeatTime]");
+        System.out.println("<Message>: the string you plan to send to HelloWorld");
+        System.out.println("[RepeatTime]: an optional integer specifies the number of time to " +
+                "send the message repeatedly. Default value is 1.");
     }
 }

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -329,7 +329,7 @@ public class KernelServerImpl implements KernelServer {
             omsHost = new InetSocketAddress(args[2], Integer.parseInt(args[3]));
         } catch (NumberFormatException e) {
             System.out.println("Incorrect arguments to the kernel server");
-            System.out.println("[host ip] [host port] [oms ip] [oms port]");
+            System.out.println("[host ip] [host port] [oms ip] [oms port] [region]");
             return;
         }
 


### PR DESCRIPTION
LoadBalancedFrontendPolicy used to select kernel servers by regions. However,
it gets region value from the first server policy. The region of the first
server policy is kind of random. This PR removed the region selector. It also
allows running multiple server policies on a single kernel server.

We will fix region issue in a separate PR.

<img width="1110" alt="screen shot 2018-09-21 at 4 42 41 pm" src="https://user-images.githubusercontent.com/1460413/45910393-77bace80-bdbd-11e8-840b-4d5fc29dc160.png">
<img width="867" alt="screen shot 2018-09-23 at 3 18 31 pm" src="https://user-images.githubusercontent.com/1460413/45933541-fd688680-bf43-11e8-824a-546c8009ef49.png">
