### PR TITLE
Added warning for enabling graalvm JDK

### DIFF
--- a/sapphire/gradle.properties
+++ b/sapphire/gradle.properties
@@ -1,3 +1,17 @@
+# WARNING:
+# PR https://github.com/Huawei-PaaS/DCAP-Sapphire/pull/220 added some Graal
+# classes into sapphire-core. Now our sapphire-core can only be compiled by
+# GraalVM JDK. Please following this instruction to set up GraalVM JDK properly. 
+# 1. Download GraalVM at https://www.graalvm.org/downloads/ 
+# 2. Do NOT add GraalVM into PATH. 
+# 3. unset JAVA_HOME env variable. If your JAVA_HOME points to a different JDK (other than Graal JDK), it may confuse gradle.
+# 4. uncomment the following line. Point org.gradle.java.home to your GraalVM.
+# Gradle will use this property to figure out JDK location.
+# 5. To set up GraalVM JDK in Android Studio, please checkout https://github.com/Huawei-PaaS/DCAP-Sapphire/blob/master/docs/GettingStarted.md
+# 
+# Points org.gradle.java.home to the home dir of your GraalVM JDK.
+# org.gradle.java.home=/Users/terryzhuo/Workspace/graalvm-ce-1.0.0-rc6/Contents/Home
+
 # Bintray properties
 # Subprojects which plan to upload to bintray should
 # override these properties in its own gradle.properties
@@ -13,5 +27,3 @@ bintrayVcsUrl=unspecified
 mavenGroupId=com.huawei.paas
 mavenArtifactId=unspecified
 mavenVersion=unspecified
-# point to your local graalvm installation path
-org.gradle.java.home=/Users/terryzhuo/Workspace/graalvm-ce-1.0.0-rc6/Contents/Home


### PR DESCRIPTION
**WARNING:**

PR https://github.com/Huawei-PaaS/DCAP-Sapphire/pull/220 added some Graal classes into sapphire-core. Now our sapphire-core can only be compiled by GraalVM JDK. Please following this instruction to set up GraalVM JDK properly.

1. Download GraalVM at https://www.graalvm.org/downloads/
2. Do NOT add GraalVM into PATH.
3. unset JAVA_HOME env variable. If your JAVA_HOME points to a different JDK (other than Graal JDK), it may confuse gradle.
4. Add org.gradle.java.home in DCAP_Sapphire/sapphire/gradle.properties. Pointing it to your GraalVM home directory. Gradle will use this property to figure out JDK location.
```
org.gradle.java.home=<location of your graalVM home>
```
5. To set up GraalVM JDK in Android Studio, please checkout https://github.com/Huawei-PaaS/DCAP-Sapphire/blob/master/docs/GettingStarted.md

