### PR TITLE
Make genStubs task depends on clean task

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -1,5 +1,3 @@
-import dcap.sapphire.gradle.PolicyStubGenerationTask
-
 plugins {
     // Google Java Format Plugin:
     // 1. Run `gradlew goJF` to format source codes
@@ -75,10 +73,12 @@ task compileStubs(type: JavaCompile) {
     options.incremental = true
 }
 
+genStubs.mustRunAfter clean
 genStubs.mustRunAfter compileJava
 compileStubs.dependsOn genStubs
 tasks.googleJavaFormat.mustRunAfter genStubs
 check.dependsOn tasks.googleJavaFormat
+compileJava.dependsOn clean
 jar.dependsOn compileStubs
 
 task integTest(type: Test) {


### PR DESCRIPTION
Today genStubs task does not depend on clean task. If we have some out-of-date broken stub files, these broken stub files will cause compilation failure.  By making genStubs task depend on clean task, out-of-date stub files will always be deleted first.

<img width="1028" alt="screen shot 2018-09-23 at 12 15 13 pm" src="https://user-images.githubusercontent.com/1460413/45931963-95f20d00-bf2a-11e8-95ba-549da541fa40.png">

<img width="1077" alt="screen shot 2018-09-23 at 12 16 38 pm" src="https://user-images.githubusercontent.com/1460413/45931964-9a1e2a80-bf2a-11e8-9d24-2a15f32b2e15.png">

