### PR TITLE
Conversion from annotations to DmSpec for client & Group policies

### DIFF
--- a/sapphire/gradle.properties
+++ b/sapphire/gradle.properties
@@ -10,7 +10,7 @@
 # 5. To set up GraalVM JDK in Android Studio, please checkout https://github.com/Huawei-PaaS/DCAP-Sapphire/blob/master/docs/GettingStarted.md
 # 
 # Points org.gradle.java.home to the home dir of your GraalVM JDK.
-# org.gradle.java.home=/Users/terryzhuo/Workspace/graalvm-ce-1.0.0-rc6/Contents/Home
+org.gradle.java.home=/home/root1/SriniCH/MultiLanguage/GRAALVM/graalvm-ee-1.0.0-rc6
 
 # Bintray properties
 # Subprojects which plan to upload to bintray should
@@ -27,3 +27,4 @@ bintrayVcsUrl=unspecified
 mavenGroupId=com.huawei.paas
 mavenArtifactId=unspecified
 mavenVersion=unspecified
+

--- a/sapphire/sapphire-core/src/main/java/sapphire/common/Utils.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/Utils.java
@@ -220,7 +220,7 @@ public class Utils {
      * @param annotations an annotation array
      * @return DMSpec map
      * @deprecated This method is deprecated. Please use {@link SapphirePolicyConfig} to configure
-     * sapphire policies.
+     *     sapphire policies.
      */
     public static Map<String, DMSpec> toDMSpec(Annotation[] annotations) throws Exception {
         Map<String, DMSpec> dmSpecMap = new TreeMap<>();

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import sapphire.app.Language;
 import sapphire.app.SapphireObjectSpec;
 import sapphire.common.AppObjectStub;
 import sapphire.common.SapphireObjectCreationException;
@@ -266,12 +265,7 @@ public class KernelServerImpl implements KernelServer {
             throws RemoteException, SapphireObjectCreationException, ClassNotFoundException {
 
         SapphireObjectSpec spec = SapphireObjectSpec.fromYaml(soSpecYaml);
-        if (spec.getLang() == Language.java) {
-            Class<?> appObjectClass = Class.forName(spec.getJavaClassName());
-            return (AppObjectStub) Sapphire.new_(appObjectClass, args);
-        } else {
-            return (AppObjectStub) Sapphire.new_(spec, args);
-        }
+        return (AppObjectStub) Sapphire.new_(spec, args);
     }
 
     public class MemoryStatThread extends Thread {

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
@@ -1,11 +1,12 @@
 package sapphire.oms;
 
-import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.rmi.NotBoundException;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Map;
+import sapphire.app.DMSpec;
 import sapphire.common.AppObjectStub;
 import sapphire.common.SapphireObjectCreationException;
 import sapphire.common.SapphireObjectID;
@@ -50,7 +51,7 @@ public interface OMSServer extends Remote {
             throws RemoteException, NotBoundException, KernelServerNotFoundException;
 
     SapphirePolicy.SapphireGroupPolicy createGroupPolicy(
-            Class<?> policyClass, SapphireObjectID sapphireObjId, Annotation[] appConfigAnnotation)
+            Class<?> policyClass, SapphireObjectID sapphireObjId, Map<String, DMSpec> dmSpecMap)
             throws RemoteException, ClassNotFoundException, KernelObjectNotCreatedException,
                     SapphireObjectNotFoundException;
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -3,7 +3,6 @@ package sapphire.oms;
 import static sapphire.compiler.GlobalStubConstants.POLICY_ONDESTROY_MTD_NAME_FORMAT;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.rmi.NotBoundException;
@@ -13,9 +12,11 @@ import java.rmi.registry.Registry;
 import java.rmi.server.UnicastRemoteObject;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Random;
 import java.util.logging.Logger;
 import org.json.JSONException;
+import sapphire.app.DMSpec;
 import sapphire.common.AppObjectStub;
 import sapphire.common.SapphireObjectCreationException;
 import sapphire.common.SapphireObjectID;
@@ -364,10 +365,10 @@ public class OMSServerImpl implements OMSServer {
      */
     @Override
     public SapphirePolicy.SapphireGroupPolicy createGroupPolicy(
-            Class<?> policyClass, SapphireObjectID sapphireObjId, Annotation[] appConfigAnnotation)
+            Class<?> policyClass, SapphireObjectID sapphireObjId, Map<String, DMSpec> dmSpecMap)
             throws RemoteException, ClassNotFoundException, KernelObjectNotCreatedException,
                     SapphireObjectNotFoundException {
-        return Sapphire.createGroupPolicy(policyClass, sapphireObjId, appConfigAnnotation);
+        return Sapphire.createGroupPolicy(policyClass, sapphireObjId, dmSpecMap);
     }
 
     public static void main(String args[]) {

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicy.java
@@ -1,6 +1,5 @@
 package sapphire.policy;
 
-import java.lang.annotation.Annotation;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +49,7 @@ public class DefaultSapphirePolicy extends SapphirePolicy {
         }
 
         @Override
-        public void onCreate(SapphireGroupPolicy group, Annotation[] annotations) {
+        public void onCreate(SapphireGroupPolicy group, Map<String, DMSpec> dmSpecMap) {
             this.group = (DefaultGroupPolicy) group;
         }
     }
@@ -87,7 +86,7 @@ public class DefaultSapphirePolicy extends SapphirePolicy {
         }
 
         @Override
-        public void onCreate(SapphireServerPolicy server, Annotation[] annotations)
+        public void onCreate(SapphireServerPolicy server, Map<String, DMSpec> dmSpecMap)
                 throws RemoteException {
             addServer(server);
         }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
@@ -1,10 +1,11 @@
 package sapphire.policy;
 
-import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.UUID;
+import sapphire.app.DMSpec;
 import sapphire.common.AppObject;
 import sapphire.common.SapphireObjectNotFoundException;
 import sapphire.common.SapphireObjectReplicaNotFoundException;
@@ -95,7 +96,7 @@ public abstract class DefaultSapphirePolicyUpcallImpl extends SapphirePolicyLibr
             this.params = params;
         }
 
-        public Annotation[] getAppConfigAnnotation() {
+        public Map<String, DMSpec> getAppConfigAnnotation() {
             return super.getAppConfigAnnotation();
         }
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
@@ -1,6 +1,5 @@
 package sapphire.policy;
 
-import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
@@ -272,7 +271,7 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
     public abstract static class SapphireGroupPolicyLibrary implements SapphireGroupPolicyUpcalls {
         protected String appObjectClassName;
         protected ArrayList<Object> params;
-        protected Annotation[] appConfigAnnotation;
+        protected Map<String, DMSpec> dmSpecMap;
         protected KernelOID oid;
         protected SapphireObjectID sapphireObjId;
 
@@ -308,12 +307,12 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
             return this.oid;
         }
 
-        public void setAppConfigAnnotation(Annotation[] appConfigAnnotation) {
-            this.appConfigAnnotation = appConfigAnnotation;
+        public void setAppConfigAnnotation(Map<String, DMSpec> dmSpecMap) {
+            this.dmSpecMap = dmSpecMap;
         }
 
-        public Annotation[] getAppConfigAnnotation() {
-            return appConfigAnnotation;
+        public Map<String, DMSpec> getAppConfigAnnotation() {
+            return dmSpecMap;
         }
 
         public void setSapphireObjId(SapphireObjectID sapphireId) {

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyUpcalls.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyUpcalls.java
@@ -1,7 +1,6 @@
 package sapphire.policy;
 
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Map;
@@ -21,6 +20,7 @@ public interface SapphirePolicyUpcalls {
 
         /**
          * Parse the given {@link DMSpec} and returns a new {@link SapphirePolicyConfig} instance.
+         *
          * @param spec {@link DMSpec}
          * @return a new {@link SapphirePolicyConfig} instance
          */
@@ -28,8 +28,14 @@ public interface SapphirePolicyUpcalls {
     }
 
     interface SapphireClientPolicyUpcalls extends Serializable {
-        // TODO(multi-lang): replace annotations with Map<String, DMSpec>
-        void onCreate(SapphireGroupPolicy group, Annotation[] annotations);
+        /**
+         * Initialize client policy.
+         *
+         * @param group the group policy
+         * @param dmSpecMap the map that contains all DM specification. The key is the DM name. The
+         *     value is the DM specification.
+         */
+        void onCreate(SapphireGroupPolicy group, Map<String, DMSpec> dmSpecMap);
 
         void setServer(SapphireServerPolicy server);
 
@@ -60,8 +66,15 @@ public interface SapphirePolicyUpcalls {
     }
 
     interface SapphireGroupPolicyUpcalls extends Serializable {
-        // TODO(multi-lang): replace annotations with Map<String, DMSpec>
-        void onCreate(SapphireServerPolicy server, Annotation[] annotations) throws RemoteException;
+        /**
+         * Initialize g porouplicy.
+         *
+         * @param server the server policy that is managed by the group policy
+         * @param dmSpecMap the map that contains all DM specification. The key is the DM name. The
+         *     value is the DM specification.
+         */
+        void onCreate(SapphireServerPolicy server, Map<String, DMSpec> dmSpecMap)
+                throws RemoteException;
 
         void addServer(SapphireServerPolicy server) throws RemoteException;
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
@@ -1,8 +1,5 @@
 package sapphire.policy.dht;
 
-import static sapphire.common.Utils.getAnnotation;
-
-import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -104,14 +101,16 @@ public class DHTPolicy extends DefaultSapphirePolicy {
         private Random generator = new Random(System.currentTimeMillis());
 
         @Override
-        public void onCreate(SapphireServerPolicy server, Annotation[] annotations)
+        public void onCreate(SapphireServerPolicy server, Map<String, DMSpec> dmSpecMap)
                 throws RemoteException {
             dhtChord = new DHTChord();
-            super.onCreate(server, annotations);
+            super.onCreate(server, dmSpecMap);
 
-            DHTConfigure annotation = getAnnotation(annotations, DHTConfigure.class);
-            if (annotation != null) {
-                this.numOfShards = annotation.numOfShards();
+            if (dmSpecMap != null) {
+                DMSpec spec = dmSpecMap.get(DHTPolicy.class.getSimpleName());
+                if ((spec != null) && (spec.getProperty("numOfShards") != null)) {
+                    this.numOfShards = Integer.parseInt(spec.getProperty("numOfShards"));
+                }
             }
 
             try {

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
@@ -1,7 +1,6 @@
 package sapphire.policy.replication;
 
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
@@ -193,9 +192,9 @@ public class ConsensusRSMPolicy extends DefaultSapphirePolicy {
         private static Logger logger = Logger.getLogger(GroupPolicy.class.getName());
 
         @Override
-        public void onCreate(SapphireServerPolicy server, Annotation[] annotations)
+        public void onCreate(SapphireServerPolicy server, Map<String, DMSpec> dmSpecMap)
                 throws RemoteException {
-            super.onCreate(server, annotations);
+            super.onCreate(server, dmSpecMap);
             try {
                 ArrayList<String> regions = sapphire_getRegions();
                 // Register the first replica, which has already been created.

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
@@ -3,18 +3,19 @@ package sapphire.policy.scalability;
 import static sapphire.policy.scalability.masterslave.MethodInvocationResponse.ReturnCode;
 
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import sapphire.app.DMSpec;
 import sapphire.common.SapphireObjectNotFoundException;
 import sapphire.common.SapphireObjectReplicaNotFoundException;
 import sapphire.common.Utils;
@@ -162,10 +163,10 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultSapphirePolicy 
         private Lock masterLock;
 
         @Override
-        public void onCreate(SapphireServerPolicy server, Annotation[] annotations)
+        public void onCreate(SapphireServerPolicy server, Map<String, DMSpec> dmSpecMap)
                 throws RemoteException {
             logger = Logger.getLogger(this.getClass().getName());
-            super.onCreate(server, annotations);
+            super.onCreate(server, dmSpecMap);
             RuntimeSpec spec = Utils.getRuntimeSpec(server.getClass());
             try {
 

--- a/sapphire/sapphire-core/src/test/java/sapphire/graal/io/WriterTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/graal/io/WriterTest.java
@@ -1,0 +1,94 @@
+package sapphire.graal.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WriterTest {
+    private Context polyglotCtx;
+    private String JS_Code =
+            "class Student {"
+                    + "constructor() {"
+                    + "this.id = 0;"
+                    + "this.name = \"\";"
+                    + "this.buddies = [];"
+                    + "this.birthDate = new Date();"
+                    + "}"
+                    + "setId(id) {"
+                    + "this.id = id;"
+                    + "}"
+                    + "getId() {"
+                    + "return this.id;"
+                    + "}"
+                    + "setName(name) {"
+                    + "this.name = name;"
+                    + "}"
+                    + "getName() {"
+                    + "return this.name;"
+                    + "}"
+                    + "addBuddy(buddy) {"
+                    + "this.buddies.push(buddy);"
+                    + "}"
+                    + "getBuddies() {"
+                    + "return this.buddies;"
+                    + "}"
+                    + "}";
+
+    @Before
+    public void setup() {
+        polyglotCtx = Context.newBuilder(new String[] {"js"}).allowAllAccess(true).build();
+    }
+
+    @Test
+    public void testBasicSerialization() throws Exception {
+        int studentId = 1;
+        String studentName = "Alex";
+        int buddyId = 2;
+        String buddyName = "Bob";
+
+        // Create a student
+        Value Student = polyglotCtx.eval("js", JS_Code);
+        Value student = Student.newInstance();
+
+        student.getMember("setId").execute(studentId);
+        student.getMember("setName").execute(studentName);
+
+        // Create a buddy
+        Value buddy = Student.newInstance();
+        buddy.getMember("setId").execute(buddyId);
+        buddy.getMember("setName").execute(buddyName);
+
+        // Add buddy
+        student.getMember("addBuddy").execute(buddy);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Serializer ser = new Serializer(out, "js");
+        Value clone = null;
+
+        try {
+            ser.serialize(student);
+            ByteArrayInputStream io = new ByteArrayInputStream(out.toByteArray());
+
+            Deserializer de = new Deserializer(io, polyglotCtx);
+            clone = de.deserialize();
+        } catch (Exception e) {
+
+        }
+
+        Assert.assertEquals(studentId, clone.getMember("id").asInt());
+        Assert.assertEquals(studentName, clone.getMember("name").asString());
+
+        List<Object> list = clone.getMember("getBuddies").execute().as(List.class);
+        Assert.assertEquals(1, list.size());
+        Map m = (Map) list.get(0);
+        Assert.assertEquals(buddyId, m.get("id"));
+        Assert.assertEquals(buddyName, m.get("name"));
+    }
+}

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/replication/ConsensusRSMPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/replication/ConsensusRSMPolicyTest.java
@@ -12,10 +12,10 @@ import static sapphire.policy.util.consensus.raft.ServerTest.getCurrentLeader;
 import static sapphire.policy.util.consensus.raft.ServerTest.makeFollower;
 import static sapphire.policy.util.consensus.raft.ServerTest.makeLeader;
 
-import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
+import java.util.*;
 import java.util.ArrayList;
 import org.junit.After;
 import org.junit.Before;
@@ -206,7 +206,7 @@ public class ConsensusRSMPolicyTest extends BaseTest {
     public void omsNotAvailable() throws Exception {
         when(this.group.sapphire_getRegions()).thenThrow(new RemoteException());
         thrown.expect(Error.class);
-        this.group.onCreate(this.server1, new Annotation[] {});
+        this.group.onCreate(this.server1, new HashMap<>());
     }
 
     /**

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedFrontendPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedFrontendPolicyTest.java
@@ -8,16 +8,20 @@ import static sapphire.common.SapphireUtils.deleteSapphireObject;
 import static sapphire.common.UtilsTest.extractFieldValueOnInstance;
 import static sapphire.common.UtilsTest.setFieldValueOnInstance;
 
-import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.rmi.registry.LocateRegistry;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -49,9 +53,6 @@ import sapphire.runtime.Sapphire;
 public class LoadBalancedFrontendPolicyTest extends BaseTest {
     int exceptionExpected = 0;
 
-    @LoadBalancedFrontendPolicy.LoadBalancedFrontendPolicyConfigAnnotation(
-            maxconcurrentReq = 2,
-            replicacount = 2)
     public static class LoadBalanceSO extends SO
             implements SapphireObject<LoadBalancedFrontendPolicy> {}
 
@@ -123,6 +124,10 @@ public class LoadBalancedFrontendPolicyTest extends BaseTest {
     public void setUp() throws Exception {
         super.setUp(Server_Stub.class, Group_Stub.class);
         SapphireObjectSpec spec = new SapphireObjectSpec();
+        LoadBalancedFrontendPolicy.Config config = new LoadBalancedFrontendPolicy.Config();
+        config.setMaxConcurrentReq(2);
+        config.setReplicaCount(2);
+        spec.addDM(config.toDMSpec());
         spec.setLang(Language.java);
         spec.setJavaClassName(
                 "sapphire.policy.scalability.LoadBalancedFrontendPolicyTest$LoadBalanceSO");
@@ -205,7 +210,7 @@ public class LoadBalancedFrontendPolicyTest extends BaseTest {
         // Expecting error message- Configured replicas count: 5, created replica count : 2
         thrown.expectMessage("Configured replicas count: 5, created replica count : 2");
         setFieldValueOnInstance(group1, "replicaCount", 5);
-        group1.onCreate(this.server1, new Annotation[] {});
+        group1.onCreate(this.server1, new HashMap<>());
     }
 
     @Test

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
@@ -1,7 +1,6 @@
 package sapphire.policy.scalability;
 
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,7 +46,7 @@ public class LoadBalancedMasterSlaveSyncPolicyIntegTest {
         group.addServer(server2);
 
         client.setServer(server1);
-        client.onCreate(group, new Annotation[] {});
+        client.onCreate(group, new HashMap<>());
         server1.onCreate(group, new HashMap<>());
         server2.onCreate(group, new HashMap<>());
         server1.start();

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/ScaleUpFrontendPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/ScaleUpFrontendPolicyTest.java
@@ -52,12 +52,6 @@ import sapphire.runtime.Sapphire;
 public class ScaleUpFrontendPolicyTest extends BaseTest {
     @Rule public ExpectedException thrown = ExpectedException.none();
 
-    @ScaleUpFrontendPolicy.ScaleUpFrontendPolicyConfigAnnotation(
-            replicationRateInMs = 20,
-            loadbalanceConfig =
-                    @LoadBalancedFrontendPolicy.LoadBalancedFrontendPolicyConfigAnnotation(
-                            maxconcurrentReq = 2,
-                            replicacount = 2))
     public static class ScaleUpSO extends SO implements SapphireObject<ScaleUpFrontendPolicy> {}
 
     public static class Group_Stub extends ScaleUpFrontendPolicy.GroupPolicy
@@ -126,6 +120,12 @@ public class ScaleUpFrontendPolicyTest extends BaseTest {
     public void setUp() throws Exception {
         super.setUp(Server_Stub.class, Group_Stub.class);
         SapphireObjectSpec spec = new SapphireObjectSpec();
+
+        ScaleUpFrontendPolicy.Config config = new ScaleUpFrontendPolicy.Config();
+        config.setMaxConcurrentReq(2);
+        config.setReplicaCount(2);
+        spec.addDM(config.toDMSpec());
+
         spec.setLang(Language.java);
         spec.setJavaClassName("sapphire.policy.scalability.ScaleUpFrontendPolicyTest$ScaleUpSO");
 


### PR DESCRIPTION
1. Changes from annotations to DMSpec in group & client policy create function
2. Deleted Annotations and changed accordingly
3. added basic UT for the graal Serialisation & Deserialization 
all UT test cases are passing.

![buildntest](https://user-images.githubusercontent.com/9107906/46205622-f58f5480-c33e-11e8-9606-0144bceef2e1.png)
