### PR TITLE
 [multi-lang-dev-branch] added GraalObject class for polyglot applications

### DIFF
--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/kernel/KernelIntegrationTestHelloWorld.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/kernel/KernelIntegrationTestHelloWorld.java
@@ -18,7 +18,6 @@ import sapphire.kernel.server.KernelServerImpl;
 import sapphire.oms.OMSServer;
 import sapphire.oms.OMSServerImpl;
 import sapphire.policy.atleastoncerpc.AtLeastOnceRPCPolicy;
-import sapphire.policy.dht.DHTPolicy;
 
 /** Tests the SO creation process in Kernel Server and OMS. */
 public class KernelIntegrationTestHelloWorld {
@@ -45,16 +44,17 @@ public class KernelIntegrationTestHelloWorld {
                         new InetSocketAddress(hostIp, hostPort),
                         new InetSocketAddress(omsIp, omsPort));
 
-        SapphireObjectSpec spec = SapphireObjectSpec.newBuilder()
-                .setLang(Language.java)
-                .setJavaClassName("sapphire.appexamples.helloworld.HelloWorld")
-                .addDMSpec(DMSpec.newBuilder()
-                        .setName(AtLeastOnceRPCPolicy.class.getName())
-                        .create())
-                .create();
+        SapphireObjectSpec spec =
+                SapphireObjectSpec.newBuilder()
+                        .setLang(Language.java)
+                        .setJavaClassName("sapphire.appexamples.helloworld.HelloWorld")
+                        .addDMSpec(
+                                DMSpec.newBuilder()
+                                        .setName(AtLeastOnceRPCPolicy.class.getName())
+                                        .create())
+                        .create();
 
-        SapphireObjectID sapphireObjId =
-                server.createSapphireObject(spec.toString(), world);
+        SapphireObjectID sapphireObjId = server.createSapphireObject(spec.toString(), world);
         HelloWorld helloWorld = (HelloWorld) server.acquireSapphireObjectStub(sapphireObjId);
         Assert.assertEquals("Hi " + world, helloWorld.sayHello());
         server.deleteSapphireObject(sapphireObjId);

--- a/sapphire/sapphire-core/src/main/java/sapphire/common/GraalObject.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/GraalObject.java
@@ -1,0 +1,116 @@
+package sapphire.common;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import sapphire.app.Language;
+import sapphire.app.SapphireObjectSpec;
+import sapphire.graal.io.Deserializer;
+import sapphire.graal.io.Serializer;
+
+/** Created by AmitRoushan on 9/29/18. Wrapper of graal object for polyglot Sapphire object */
+// TODO: Need to update how to serialize Graal Object
+public class GraalObject implements Serializable {
+    private Language lang;
+    private transient Context context;
+    private transient Value value;
+    private String sourceLocation;
+    private String constructor;
+
+    private GraalObject() {}
+
+    private void setSourceLocation(String sourceLocation) {
+        this.sourceLocation = sourceLocation;
+    }
+
+    private void setConstructor(String constructor) {
+        this.constructor = constructor;
+    }
+
+    private void setContext(Context context) {
+        this.context = context;
+    }
+
+    private void setLang(String lang) {
+        for (Language l : Language.values()) {
+            if (l.toString().equals(lang)) {
+                this.lang = l;
+            }
+        }
+    }
+
+    private void setValue(Value value) {
+        this.value = value;
+    }
+
+    public GraalObject(SapphireObjectSpec spec, Object[] params) throws IOException {
+        lang = spec.getLang();
+        sourceLocation = spec.getSourceFileLocation();
+        constructor = spec.getConstructorName();
+
+        context = Context.newBuilder(lang.toString()).allowAllAccess(true).build();
+        context.eval(
+                org.graalvm.polyglot.Source.newBuilder(
+                                lang.toString(), new java.io.File(sourceLocation))
+                        .build());
+
+        // create class instance with default constructor
+        if (params == null || params.length == 0) {
+            value = context.eval(lang.toString(), constructor).newInstance();
+            return;
+        }
+        value = context.eval(lang.toString(), constructor).newInstance(params);
+    }
+
+    public synchronized Object invoke(String method, ArrayList<Object> params) throws Exception {
+        ArrayList<Object> objs = new ArrayList<>();
+        for (Object p : params) {
+            ByteArrayInputStream in = new ByteArrayInputStream((byte[]) p);
+            sapphire.graal.io.Deserializer deserializer = new Deserializer(in, context);
+            objs.add(deserializer.deserialize());
+        }
+        return value.getMember(method).execute(objs.toArray());
+    }
+
+    public void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeUTF(sourceLocation);
+        out.writeUTF(constructor);
+        out.writeUTF(lang.toString());
+        sapphire.graal.io.Serializer serializer = new Serializer(out, lang);
+        serializer.serialize(value);
+    }
+
+    public static Object readObject(ObjectInputStream in) throws IOException {
+
+        String sourceLocation = in.readUTF();
+        String constructor = in.readUTF();
+        String lang = in.readUTF();
+
+        GraalObject graalObject = new GraalObject();
+        Context context = Context.newBuilder(lang).allowAllAccess(true).build();
+        context.eval(
+                org.graalvm.polyglot.Source.newBuilder(lang, new java.io.File(sourceLocation))
+                        .build());
+
+        graalObject.setSourceLocation(sourceLocation);
+        graalObject.setConstructor(constructor);
+        graalObject.setLang(lang);
+        graalObject.setContext(context);
+
+        sapphire.graal.io.Deserializer deserializer = new Deserializer(in, context);
+        Value value = deserializer.deserialize();
+        graalObject.setValue(value);
+
+        return graalObject;
+    }
+
+    @Override
+    public String toString() {
+        return sourceLocation + constructor + lang.toString();
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.logging.Logger;
 import org.graalvm.polyglot.*;
-import sapphire.app.Language;
 import sapphire.graal.io.*;
 
 /**
@@ -19,7 +18,12 @@ public class ObjectHandler implements Serializable {
     /** Reference to the actual object instance */
     private Object object;
 
-    private Language lang;
+    public enum ObjectType {
+        graal,
+        java,
+    }
+
+    private boolean isGraalObject = false;
 
     private static Logger logger = Logger.getLogger(ObjectHandler.class.getName());
 
@@ -45,7 +49,7 @@ public class ObjectHandler implements Serializable {
     }
 
     private boolean IsGraalObject() {
-        return lang != Language.java;
+        return (object instanceof GraalObject);
     }
 
     /**
@@ -53,19 +57,13 @@ public class ObjectHandler implements Serializable {
      * stub. We also inspect the methods of the object to set up a table we can use to look up the
      * method on RPC.
      *
-     * @param stub
+     * @param obj
      */
     public ObjectHandler(Object obj) {
         // TODO: get all the methods from all superclasses - careful about duplicates
         object = obj;
 
-        // TODO: we should support other languages than js, when object is created we can track it's
-        // language.
-        if (org.graalvm.polyglot.Value.class.isAssignableFrom(obj.getClass())) {
-            lang = Language.js;
-        } else {
-            lang = Language.java;
-        }
+        isGraalObject = IsGraalObject();
 
         if (!IsGraalObject()) {
             fillMethodTable(obj);
@@ -81,16 +79,8 @@ public class ObjectHandler implements Serializable {
      * @return the return value from the method
      */
     public Object invoke(String method, ArrayList<Object> params) throws Exception {
-        if (IsGraalObject()) {
-            Value v = (Value) object;
-            ArrayList<Object> objs = new ArrayList<>();
-            for (Object p : params) {
-                ByteArrayInputStream in = new ByteArrayInputStream((byte[]) p);
-                sapphire.graal.io.Deserializer deserializer =
-                        new Deserializer(in, GraalContext.getContext());
-                objs.add(deserializer.deserialize());
-            }
-            return v.getMember(method).execute(objs.toArray());
+        if (isGraalObject) {
+            return ((GraalObject) object).invoke(method, params);
         } else {
             return methods.get(method).invoke(object, params.toArray());
         }
@@ -100,21 +90,17 @@ public class ObjectHandler implements Serializable {
         return (Serializable) object;
     }
 
-    public Value getGraalObject() {
-        return (Value) object;
-    }
-
     public void setObject(Serializable object) {
         this.object = object;
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {
-        out.writeUTF(lang.toString());
-        if (IsGraalObject()) {
+        if (isGraalObject) {
+            out.writeUTF(ObjectType.graal.toString());
             // TODO: make language configurable.
-            sapphire.graal.io.Serializer serializer = new Serializer(out, lang);
-            serializer.serialize((Value) this.object);
+            ((GraalObject) object).writeObject(out);
         } else {
+            out.writeUTF(ObjectType.java.toString());
             out.writeObject(object);
         }
     }
@@ -131,11 +117,8 @@ public class ObjectHandler implements Serializable {
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        lang = Language.valueOf(in.readUTF());
-        if (IsGraalObject()) {
-            sapphire.graal.io.Deserializer deserializer =
-                    new Deserializer(in, GraalContext.getContext());
-            object = deserializer.deserialize();
+        if (ObjectType.valueOf(in.readUTF()) == ObjectType.graal) {
+            object = GraalObject.readObject(in);
         } else {
             Object obj = in.readObject();
             fillMethodTable(obj);

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
@@ -8,17 +8,16 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.harmony.rmi.common.RMIUtil;
-import org.graalvm.polyglot.Context;
 import sapphire.app.Language;
 import sapphire.app.SapphireObjectSpec;
 import sapphire.common.AppObject;
 import sapphire.common.AppObjectStub;
+import sapphire.common.GraalObject;
 import sapphire.common.SapphireObjectID;
 import sapphire.common.SapphireObjectNotFoundException;
 import sapphire.common.SapphireObjectReplicaNotFoundException;
 import sapphire.common.SapphireReplicaID;
 import sapphire.compiler.GlobalStubConstants;
-import sapphire.graal.io.GraalContext;
 import sapphire.kernel.common.GlobalKernelReferences;
 import sapphire.kernel.common.KernelOID;
 import sapphire.kernel.common.KernelObjectFactory;
@@ -44,7 +43,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
         protected AppObject appObject;
         protected KernelOID oid;
         protected SapphireReplicaID replicaId;
-        protected Context context;
         protected Map<String, SapphirePolicyConfig> configMap;
         protected SapphirePolicy.SapphireGroupPolicy group;
 
@@ -224,11 +222,7 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
                     actualAppObject.$__initialize(true);
                     appObject = new AppObject(actualAppObject);
                 } else {
-                    appObject =
-                            new AppObject(
-                                    GraalContext.getContext()
-                                            .eval(spec.getLang().name(), spec.getConstructorName())
-                                            .newInstance(params));
+                    appObject = new AppObject(new GraalObject(spec, params));
                 }
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "Failed to initialize server policy", e);


### PR DESCRIPTION
Currently we are handling Graal objects (`Value` and `Context`) in `ObjectHandler`. Added a wrapper `GraalObject` which ObjectHandler can use to invoke methods. Also `ObjectHandler` can see GraalObject as normal java object.
Changes Added:
 1. Added new class `GraalObject`

This PR has passed the following tests:

Unit tests passed
Integ test passed
Minnie-Twitter passed
HanksToDo passed

Note: 
This PR is on top of [245](https://github.com/Huawei-PaaS/DCAP-Sapphire/pull/245) PR

![hankstodoapp](https://user-images.githubusercontent.com/9818606/46246582-c13e9580-c41d-11e8-9ea6-c1dd44c920cf.png)
![minnitwitter](https://user-images.githubusercontent.com/9818606/46246584-cac7fd80-c41d-11e8-84ae-4b1c44063033.png)
![ut and integrarion test](https://user-images.githubusercontent.com/9818606/46246586-d0254800-c41d-11e8-9a21-46bca6b29836.png)
