### PR TITLE
[multi-lang-dev-branch] BugFix: Creating appObjStub clone in OMS.acquireSapphireObject.

### DIFF
--- a/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorld.java
+++ b/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorld.java
@@ -5,7 +5,7 @@ import sapphire.common.AppObjectStub;
 import sapphire.policy.atleastoncerpc.AtLeastOnceRPCPolicy;
 import sapphire.runtime.Sapphire;
 
-public class HelloWorld implements SapphireObject<AtLeastOnceRPCPolicy> {
+public class HelloWorld implements SapphireObject {
     private String world = "DCAP World";
 
     public HelloWorld(){}

--- a/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorldMain.java
+++ b/sapphire/examples/helloworld/src/main/java/sapphire/appexamples/helloworld/HelloWorldMain.java
@@ -4,10 +4,14 @@ import java.net.InetSocketAddress;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 
+import sapphire.app.DMSpec;
+import sapphire.app.Language;
+import sapphire.app.SapphireObjectSpec;
 import sapphire.common.SapphireObjectID;
 import sapphire.kernel.server.KernelServer;
 import sapphire.kernel.server.KernelServerImpl;
 import sapphire.oms.OMSServer;
+import sapphire.policy.atleastoncerpc.AtLeastOnceRPCPolicy;
 
 public class HelloWorldMain {
     public static void main(String[] args) {
@@ -29,8 +33,16 @@ public class HelloWorldMain {
 
             KernelServer nodeServer = new KernelServerImpl(new InetSocketAddress(args[2], Integer.parseInt(args[3])), new InetSocketAddress(args[0], Integer.parseInt(args[1])));
 
+            SapphireObjectSpec spec = SapphireObjectSpec.newBuilder()
+                    .setLang(Language.java)
+                    .setJavaClassName("sapphire.appexamples.helloworld.HelloWorld")
+                    .addDMSpec(DMSpec.newBuilder()
+                            .setName(AtLeastOnceRPCPolicy.class.getName())
+                            .create())
+                    .create();
+
             SapphireObjectID sapphireObjId =
-                    server.createSapphireObject("sapphire.appexamples.helloworld.HelloWorld", world);
+                    server.createSapphireObject(spec.toString(), world);
             HelloWorld helloWorld = (HelloWorld) server.acquireSapphireObjectStub(sapphireObjId);
             System.out.println(helloWorld.sayHello());
 

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -78,16 +78,18 @@ task compileStubs(type: JavaCompile) {
     options.incremental = true
 }
 
-genStubs.mustRunAfter delStubs
-genStubs.mustRunAfter compileJava
-compileStubs.dependsOn genStubs
-tasks.googleJavaFormat.mustRunAfter genStubs
-check.dependsOn tasks.googleJavaFormat
-compileJava.dependsOn delStubs
-jar.dependsOn compileStubs
-
 task integTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     outputs.upToDateWhen { false }
 }
+
+genStubs.mustRunAfter delStubs
+genStubs.mustRunAfter compileJava
+compileStubs.dependsOn genStubs
+tasks.googleJavaFormat.mustRunAfter genStubs
+check.dependsOn tasks.googleJavaFormat
+check.dependsOn integTest
+integTest.mustRunAfter test
+compileJava.dependsOn delStubs
+jar.dependsOn compileStubs

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -42,6 +42,7 @@ import sapphire.runtime.Sapphire;
  * @author iyzhang
  */
 public class OMSServerImpl implements OMSServer {
+
     private static Logger logger = Logger.getLogger("sapphire.oms.OMSServerImpl");
 
     private GlobalKernelObjectManager kernelObjectManager;
@@ -253,7 +254,15 @@ public class OMSServerImpl implements OMSServer {
             SapphirePolicy.SapphireServerPolicy serverPolicy =
                     (SapphirePolicy.SapphireServerPolicy) policyHandler.getObjects().get(0);
             appObjStub = (AppObjectStub) serverPolicy.sapphire_getRemoteAppObject().getObject();
-            appObjStub.$__initialize(false);
+            // Calling extractAppStub to create a clone of appObjStub and set directInvocation
+            // to false on the clone instance. If we run oms and kernel server on the same
+            // process, serverPolicy.sapphire_getRemoteAppObject().getObject() returns the
+            // real appObjectStub instance within the server policy whose directInvocation is
+            // true. In this case, if we set directInvocation to false on appObjStub directly,
+            // it will modify the the value of appObjStub instance within the server policy
+            // which will cause infinite loop. This infinite loop issue will surface when we
+            // run oms and kernel server in one process.
+            appObjStub = Sapphire.extractAppStub(appObjStub);
             SapphirePolicy.SapphireClientPolicy client = clientPolicy.getClass().newInstance();
             client.onCreate(
                     clientPolicy.getGroup(), clientPolicy.getGroup().getAppConfigAnnotation());


### PR DESCRIPTION
This PR is similar to PR https://github.com/Huawei-PaaS/DCAP-Sapphire/pull/248 on master.

Major changes are:
1. Create appObjStub clone in OMS.acquireSapphireObject
2. Added an integration test
2. Made check depends on integTest

Changes have been tested on
* `gradlew build` passed
* `gradlew integTest` passed
* Minnie-Twitter App passed
* HanksToDo app passed
* HelloWorld app passed

<img width="881" alt="screen shot 2018-10-02 at 11 57 04 am" src="https://user-images.githubusercontent.com/1460413/46370605-db08f400-c63a-11e8-85a9-5a2b8471aaa7.png">
<img width="772" alt="screen shot 2018-10-02 at 11 57 23 am" src="https://user-images.githubusercontent.com/1460413/46370612-e0663e80-c63a-11e8-9be9-734574122cd9.png">
<img width="1436" alt="screen shot 2018-10-02 at 11 58 22 am" src="https://user-images.githubusercontent.com/1460413/46370618-e3612f00-c63a-11e8-83dd-cc7f42a2ef70.png">
<img width="1431" alt="screen shot 2018-10-02 at 11 59 20 am" src="https://user-images.githubusercontent.com/1460413/46370624-e6f4b600-c63a-11e8-9e7d-a1f01fdf92e5.png">
<img width="1440" alt="screen shot 2018-10-02 at 12 00 00 pm" src="https://user-images.githubusercontent.com/1460413/46370627-e9efa680-c63a-11e8-881a-b53d89bb3d01.png">
