### PR TITLE
bug fix: integTest to use graalVM java

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -75,6 +75,7 @@ task compileStubs(type: JavaCompile) {
 }
 
 task integTest(type: Test) {
+    systemProperty "DCAP_JAVA_HOME", project.property('org.gradle.java.home')
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     outputs.upToDateWhen { false }
@@ -89,10 +90,3 @@ check.dependsOn integTest
 integTest.mustRunAfter test
 compileJava.dependsOn delStubs
 jar.dependsOn compileStubs
-
-task integTest(type: Test) {
-    systemProperty "dcap_java_home", project.property('org.gradle.java.home')
-    testClassesDirs = sourceSets.integrationTest.output.classesDirs
-    classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
-}

--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/kernel/KernelIntegrationTestHelloWorld.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/kernel/KernelIntegrationTestHelloWorld.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import sapphire.appexamples.helloworld.HelloWorld;
 import sapphire.common.SapphireObjectID;
@@ -17,8 +16,8 @@ import sapphire.oms.OMSServer;
 import sapphire.oms.OMSServerImpl;
 
 /** Tests the SO creation process in Kernel Server and OMS. */
-// note: running in IDE may fail due to java path issue. Please ensure graalVM is the default java in that case.
 public class KernelIntegrationTestHelloWorld {
+
     @Test
     public void testCreateSapphireObject() throws Exception {
         String world = "Disney";
@@ -48,13 +47,12 @@ public class KernelIntegrationTestHelloWorld {
         server.deleteSapphireObject(sapphireObjId);
     }
 
-    // TODO: This test is broken!
-    @Ignore
+    // note: running in IDE may fail due to java path issue. Please ensure graalVM is the default
+    // java in that case.
     @Test
-    public void testSOCreation() {
     public void testSOCreation() throws Exception {
         String ip = "127.0.0.1";
-        String[] appHost = new String[] {ip, "22346", "10.0.2.15", "22344"};
+        String[] appHost = new String[] {ip, "22446", "10.0.2.15", "22444"};
         Runtime runtime = Runtime.getRuntime();
         Process omsProcess = null;
         Process kernelServerProcess = null;
@@ -62,7 +60,7 @@ public class KernelIntegrationTestHelloWorld {
         /* Start OMS and kernel server as separate process and invoke rpc from app client */
         try {
             String cwd = System.getProperty("user.dir");
-            String javaHome = System.getProperty("dcap_java_home");
+            String javaHome = System.getProperty("DCAP_JAVA_HOME");
             String javaExe = "java";
             if (javaHome != null) {
                 javaExe = Paths.get(javaHome, "bin", "java").toString();
@@ -79,22 +77,27 @@ public class KernelIntegrationTestHelloWorld {
                             + "/../examples/helloworld/build/libs/helloworld.jar ";
 
             String omsCmd =
-                    javaExe + " -cp " + sapphireCore + " sapphire.oms.OMSServerImpl " + ip + " 22346 ";
+                    javaExe
+                            + " -cp "
+                            + sapphireCore
+                            + " sapphire.oms.OMSServerImpl "
+                            + ip
+                            + " 22446 ";
             omsProcess = runtime.exec(omsCmd);
             sleep(500);
             String ksCmd =
                     javaExe
-                            +" -cp "
+                            + " -cp "
                             + sapphireCore
                             + " sapphire.kernel.server.KernelServerImpl "
                             + ip
-                            + " 22345 "
+                            + " 22445 "
                             + ip
-                            + " 22346 ";
+                            + " 22446 ";
             kernelServerProcess = runtime.exec(ksCmd);
             sleep(1000);
 
-            Registry registry = LocateRegistry.getRegistry(ip, Integer.parseInt("22346"));
+            Registry registry = LocateRegistry.getRegistry(ip, Integer.parseInt("22446"));
             OMSServer server = (OMSServer) registry.lookup("SapphireOMS");
 
             KernelServer appKernel =


### PR DESCRIPTION
fixed test issue: integTest failed after java switched to graalVM
$ ./gradlew :sapphire-core:integTest --info
![integtest](https://user-images.githubusercontent.com/16367914/46371133-5fa84200-c63c-11e8-9842-c4b4a36250f9.png)
