### PR TITLE
unit test fix: testSOCreation

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -74,6 +74,10 @@ task compileStubs(type: JavaCompile) {
     options.incremental = true
 }
 
+test {
+    systemProperty "DCAP_JAVA_HOME", project.property('org.gradle.java.home')
+}
+
 task integTest(type: Test) {
     systemProperty "DCAP_JAVA_HOME", project.property('org.gradle.java.home')
     testClassesDirs = sourceSets.integrationTest.output.classesDirs


### PR DESCRIPTION
:sapphire-core:test called the integration test code which requires graavlvm java.
$ ./gradlew :sapphire-core:test
![unit-test](https://user-images.githubusercontent.com/16367914/46441970-049a4c00-c71d-11e8-8f59-549e2d7b1059.png)
 
![10-02-tweet](https://user-images.githubusercontent.com/16367914/46442083-60fd6b80-c71d-11e8-9f96-5dfefc30dbe2.png)

![10-02-hankstodo](https://user-images.githubusercontent.com/16367914/46442181-943ffa80-c71d-11e8-90aa-2d515857e3b3.png)

