### PR TITLE
[Master] Simplify acquireSapphireObject in OMSServerImpl

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -245,11 +245,6 @@ public class OMSServerImpl implements OMSServer {
 
         AppObjectStub appObjStub = null;
         try {
-            AppObjectStub localObjStub = objectManager.getInstanceObjectStub(sapphireObjId);
-            SapphirePolicy.SapphireClientPolicy clientPolicy = extractClientPolicy(localObjStub);
-            SapphirePolicy.SapphireServerPolicy serverPolicy =
-                    (SapphirePolicy.SapphireServerPolicy) policyHandler.getObjects().get(0);
-            appObjStub = (AppObjectStub) serverPolicy.sapphire_getRemoteAppObject().getObject();
             // Calling extractAppStub to create a clone of appObjStub and set directInvocation
             // to false on the clone instance. If we run oms and kernel server on the same
             // process, serverPolicy.sapphire_getRemoteAppObject().getObject() returns the
@@ -258,12 +253,8 @@ public class OMSServerImpl implements OMSServer {
             // it will modify the the value of appObjStub instance within the server policy
             // which will cause infinite loop. This infinite loop issue will surface when we
             // run oms and kernel server in one process.
-            appObjStub = Sapphire.extractAppStub(appObjStub);
-            SapphirePolicy.SapphireClientPolicy client = clientPolicy.getClass().newInstance();
-            client.onCreate(
-                    clientPolicy.getGroup(), clientPolicy.getGroup().getAppConfigAnnotation());
-            client.setServer(serverPolicy);
-            appObjStub.$__initialize(client);
+            AppObjectStub localObjStub = objectManager.getInstanceObjectStub(sapphireObjId);
+            appObjStub = Sapphire.extractAppStub(localObjStub);
         } catch (Exception e) {
             logger.warning("Exception occurred : " + e);
             throw new SapphireObjectNotFoundException(


### PR DESCRIPTION
@VenuReddyHuawei Please take a close look at this PR and approve it if it looks good to you. I will not merge it until get your approval.

It looks to me that our current `acquireSapphireObjectStub` in OMSServerImpl.java is over complicated. I simplified it and all tests passed.

<img width="1014" alt="screen shot 2018-10-03 at 3 46 32 pm" src="https://user-images.githubusercontent.com/1460413/46443893-598d9080-c724-11e8-985b-08a420329d68.png">
<img width="1008" alt="screen shot 2018-10-03 at 3 47 35 pm" src="https://user-images.githubusercontent.com/1460413/46443896-5d211780-c724-11e8-855e-e89c1c53a53f.png">
<img width="1008" alt="screen shot 2018-10-03 at 3 48 34 pm" src="https://user-images.githubusercontent.com/1460413/46443901-61e5cb80-c724-11e8-9dae-d27570296e33.png">
