### PR TITLE
Separate unit tests and integration tests

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -21,7 +21,6 @@ sourceSets {
         }
         resources.srcDir file('src/integrationTest/resources')
     }
-    test.java.srcDirs += 'src/integrationTest/java'
 }
 
 configurations {
@@ -72,10 +71,6 @@ task compileStubs(type: JavaCompile) {
     classpath = sourceSets.main.compileClasspath
     destinationDir = sourceSets.main.output.classesDir
     options.incremental = true
-}
-
-test {
-    systemProperty "DCAP_JAVA_HOME", project.property('org.gradle.java.home')
 }
 
 task integTest(type: Test) {


### PR DESCRIPTION
Today, `gradlew test` also runs tests in `src/integrationTest/java` directory. This behavior is caused by a misconfiguration in `sourceSet`. This PR fixed this issue.

<img width="871" alt="screen shot 2018-10-03 at 5 48 32 pm" src="https://user-images.githubusercontent.com/1460413/46447020-91043900-c734-11e8-98e3-7d5ab0dddd02.png">
