### PR TITLE
pinkis - applied DHT policy

### DIFF
--- a/sapphire/examples/pinkis/build.gradle
+++ b/sapphire/examples/pinkis/build.gradle
@@ -47,6 +47,19 @@ task runks(type: JavaExec) {
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 
+// task to start more kernel server (hosting the SO)
+task runks2(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'sapphire.kernel.server.KernelServerImpl'
+    args project.property('kernelServerIp'), project.property('kernelServerPort2'), project.property('omsIp'), project.property('omsPort')
+}
+
+task runks3(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'sapphire.kernel.server.KernelServerImpl'
+    args project.property('kernelServerIp'), project.property('kernelServerPort3'), project.property('omsIp'), project.property('omsPort')
+}
+
 // task for run client
 task runapp(type: JavaExec) {
     main = "sapphire.demo.pinkisClient"

--- a/sapphire/examples/pinkis/gradle.properties
+++ b/sapphire/examples/pinkis/gradle.properties
@@ -3,3 +3,5 @@ omsPort=22222
 
 kernelServerIp=127.0.0.1
 kernelServerPort=22345
+kernelServerPort2=22346
+kernelServerPort3=22347

--- a/sapphire/examples/pinkis/src/main/java/sapphire/demo/pinkisServer.java
+++ b/sapphire/examples/pinkis/src/main/java/sapphire/demo/pinkisServer.java
@@ -7,21 +7,24 @@ import java.io.Serializable;
 import java.util.Hashtable;
 import java.util.Map;
 
-@SapphireConfiguration(Policies = "sapphire.policy.DefaultSapphirePolicy")
+@SapphireConfiguration(Policies = "sapphire.policy.dht.DHTPolicy")
 public class pinkisServer implements SapphireObject {
     private Map<String, Serializable> kvStore = new Hashtable<>();
 
     public pinkisServer() {}
 
     public void set(String key, Serializable value) {
+        System.out.println("setting: " + key + " = " + value);
         this.kvStore.put(key, value);
     }
 
     public Serializable get(String key) {
+        System.out.println("getting: " + key);
         return this.kvStore.get(key);
     }
 
     public Boolean contains(String key) {
+        System.out.println("querying: " + key);
         return this.kvStore.containsKey(key);
     }
 }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
@@ -68,7 +68,7 @@ public class DHTPolicy extends DefaultSapphirePolicy {
                 // Create replicas based on annotation
                 InetSocketAddress newServerAddress = null;
                 for (int i = 1; i < numOfShards; i++) {
-                    newServerAddress = oms().getServerInRegion(regions.get(i));
+                    newServerAddress = oms().getServerInRegion(regions.get(i % regions.size()));
 
                     // TODO (Sungwook, 2018-10-2) Passing processedPolicies may not be necessary as
                     // they are already available.


### PR DESCRIPTION
### applied DHT policy to pinkis sample
other minor change - 
* added runks2/3 as the ideal setup is of 3 ks nodes
* added print statements for demo visibility at server nodes
* brought back DHT policy logic to allow nodes fewer than the default shard number
### unit test result
![10-04-test](https://user-images.githubusercontent.com/16367914/46488571-e3d30480-c7b7-11e8-8d1b-c1701fd843e0.png)
### pinkis w/ 3 ks
![10-04-pinkis](https://user-images.githubusercontent.com/16367914/46488579-e9304f00-c7b7-11e8-83b2-74bea4daaf19.png)
