### PR TITLE
WIP: Separate ObjectHandler for non-Graal from GraalObjectHandler

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/common/GraalObjectHandler.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/GraalObjectHandler.java
@@ -1,0 +1,105 @@
+package sapphire.common;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.logging.Logger;
+
+import sapphire.app.Language;
+import sapphire.graal.io.Deserializer;
+import sapphire.graal.io.GraalContext;
+import sapphire.graal.io.Serializer;
+import org.graalvm.polyglot.*;
+
+/**
+ * An object handler for Graal objects.
+ *
+ * @author quinton
+ */
+public class GraalObjectHandler extends ObjectHandler implements Serializable {
+    private Language lang; // What language is the object written in?
+    private static Logger logger = Logger.getLogger(GraalObjectHandler.class.getName());
+
+    /**
+     * See superclass constructor for description.
+     *
+     * @param stub  TODO: quinton: Is this the stub or the actual object.  Reconcile javadoc with code
+     */
+    public GraalObjectHandler(Object obj) {
+        super(obj, false); // Don't fill the method table
+        // TODO: we should support other languages than js, when object is created we can track it's
+        // language.
+        // TODO: quinton: The logic here looks questionable.  Pretty sure that java is also assignable.
+        if (org.graalvm.polyglot.Value.class.isAssignableFrom(obj.getClass())) {
+            lang = Language.js;
+        } else {
+            lang = Language.java;
+        }
+        /*
+            TODO: Why do we handle java objects differently?  I think this is a bug?
+            Presumably we should do this for all Graal objects, even if they're java?
+         */
+        if (lang != Language.java) {
+            fillMethodTable(obj);
+        }
+    }
+
+    /**
+     * Invoke method on the object using the params
+     *
+     * @param method
+     * @param params
+     * @return the return value from the method
+     */
+    public Object invoke(String method, ArrayList<Object> params) throws Exception {
+        /*
+            TODO: Why do we handle java objects differently?  I think this is a bug?
+            Presumably we should do this for all Graal objects, even if they're java?
+         */
+        if (lang != Language.java) {
+            Value v = (Value) object;
+            ArrayList<Object> objs = new ArrayList<>();
+            for (Object p : params) {
+                ByteArrayInputStream in = new ByteArrayInputStream((byte[]) p);
+                Deserializer deserializer =
+                        new Deserializer(in, GraalContext.getContext());
+                objs.add(deserializer.deserialize());
+            }
+            return v.getMember(method).execute(objs.toArray());
+        } else { // TODO: See above - presumably we should never do this here for Graal
+            return methods.get(method).invoke(object, params.toArray());
+        }
+    }
+
+    /**
+     * TODO: quinton: Should be able to just do this cast in the caller instead, and delete this method.
+     * @return
+     */
+    public Value getGraalObject() {
+        return (Value) object;
+    }
+
+    @Override
+    /**
+     * Use the graal serializer to write out the object.
+     * TODO: quinton - we really can't afford to create a new serializer for every invocation like this.
+     */
+    protected void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeUTF(lang.toString());
+        // TODO: make language configurable.
+        Serializer serializer = new Serializer(out, lang);
+        serializer.serialize((Value) this.object);
+    }
+
+    @Override
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        lang = Language.valueOf(in.readUTF());
+        Deserializer deserializer = new Deserializer(in, GraalContext.getContext());
+        object = deserializer.deserialize();
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
@@ -5,7 +5,8 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.logging.Logger;
-import org.graalvm.polyglot.*;
+//import org.graalvm.polyglot.*;
+import sapphire.app.Language;
 import sapphire.graal.io.*;
 
 /**
@@ -16,14 +17,9 @@ import sapphire.graal.io.*;
  */
 public class ObjectHandler implements Serializable {
     /** Reference to the actual object instance */
-    private Object object;
+    protected Object object;
 
-    public enum ObjectType {
-        graal,
-        java,
-    }
-
-    private boolean isGraalObject = false;
+    private Language lang;
 
     private static Logger logger = Logger.getLogger(ObjectHandler.class.getName());
 
@@ -49,26 +45,32 @@ public class ObjectHandler implements Serializable {
     }
 
     private boolean IsGraalObject() {
-        return (object instanceof GraalObject);
+        return lang != Language.java;
     }
 
     /**
      * At creation time, we create the actual object, which happens to be the superclass of the
-     * stub. We also inspect the methods of the object to set up a table we can use to look up the
+     * stub. We also optionally inspect the methods of the object to set up a table we can use to look up the
      * method on RPC.
      *
+     * @param stub
+     * @param fillMethodTable false to suppress filling the method table
+     */
+    public ObjectHandler(Object obj, boolean fillMethodTable) {
+        // TODO: get all the methods from all superclasses - careful about duplicates
+        object = obj;
+        if (fillMethodTable) {
+            this.fillMethodTable(obj);
+        }
+        logger.fine("Created object " + obj.toString());
+    }
+
+    /**
+     * Constructor, with method table filling enabled
      * @param obj
      */
     public ObjectHandler(Object obj) {
-        // TODO: get all the methods from all superclasses - careful about duplicates
-        object = obj;
-
-        isGraalObject = IsGraalObject();
-
-        if (!IsGraalObject()) {
-            fillMethodTable(obj);
-        }
-        logger.fine("Created object " + obj.toString());
+        this(obj, true);
     }
 
     /**
@@ -79,11 +81,7 @@ public class ObjectHandler implements Serializable {
      * @return the return value from the method
      */
     public Object invoke(String method, ArrayList<Object> params) throws Exception {
-        if (isGraalObject) {
-            return ((GraalObject) object).invoke(method, params);
-        } else {
-            return methods.get(method).invoke(object, params.toArray());
-        }
+        return methods.get(method).invoke(object, params.toArray());
     }
 
     public Serializable getObject() {
@@ -94,39 +92,27 @@ public class ObjectHandler implements Serializable {
         this.object = object;
     }
 
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        if (isGraalObject) {
-            out.writeUTF(ObjectType.graal.toString());
-            // TODO: make language configurable.
-            ((GraalObject) object).writeObject(out);
-        } else {
-            out.writeUTF(ObjectType.java.toString());
-            out.writeObject(object);
-        }
+    protected void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeObject(object);
     }
 
     /**
      * Write the object to a stream.
-     *
-     * @param out
-     * @throws IOException Note - it's not possible to simply make writeObject public, as java
+     * Note - it's not possible to simply make writeObject public, as java
      *     serialization requires it to be private.
+     * @param out
+     * @throws IOException
      */
     public void write(ObjectOutputStream out) throws IOException {
         this.writeObject(out);
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        /*
         lang = Language.valueOf(in.readUTF());
         if (IsGraalObject()) {
             sapphire.graal.io.Deserializer deserializer =
                     new Deserializer(in, GraalContext.getContext());
             object = deserializer.deserialize();
-            System.out.println("Successfully de-serialized object " + object.toString());
-            */
-        if (ObjectType.valueOf(in.readUTF()) == ObjectType.graal) {
-            object = GraalObject.readObject(in);
         } else {
             Object obj = in.readObject();
             fillMethodTable(obj);

--- a/sapphire/sapphire-core/src/test/java/sapphire/common/GraalObjectHandlerTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/common/GraalObjectHandlerTest.java
@@ -1,0 +1,33 @@
+package sapphire.common;
+
+import org.graalvm.polyglot.*;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class GraalObjectHandlerTest {
+
+    @Test
+    public void testValue() throws Exception {
+        Context c = Context.create();
+        Value v = c.eval("js", "[1,42,3]");
+        ObjectHandler objHandler = new GraalObjectHandler(v);
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(byteArrayOutputStream);
+        oos.writeObject(objHandler);
+        oos.flush();
+
+        byte[] bytes = byteArrayOutputStream.toByteArray();
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+        ObjectInputStream objectInputSteam = new ObjectInputStream(byteArrayInputStream);
+        ObjectHandler clone = (ObjectHandler) objectInputSteam.readObject();
+
+        System.out.println("Original value is " + objHandler.getGraalObject());
+        System.out.println("After SerDe, value is " + objHandler.getGraalObject());
+
+        assert objHandler.getObject().toString().equals(clone.getObject().toString());
+    }
+}

--- a/sapphire/sapphire-core/src/test/java/sapphire/common/ObjectHandlerTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/common/ObjectHandlerTest.java
@@ -3,98 +3,20 @@ package sapphire.common;
 import static org.junit.Assert.*;
 
 import java.io.*;
-import org.graalvm.polyglot.*;
 import org.junit.Test;
-import sapphire.app.DMSpec;
-import sapphire.app.Language;
-import sapphire.app.SapphireObjectSpec;
-import sapphire.policy.dht.DHTPolicy;
 
 public class ObjectHandlerTest {
-
     @Test
-    public void testGraalObject() throws Exception {
-        String JS_Code =
-                "class Student {"
-                        + "constructor() {"
-                        + "this.id = 0;"
-                        + "this.name = \"\";"
-                        + "this.buddies = [];"
-                        + "}"
-                        + "setId(id) {"
-                        + "this.id = id;"
-                        + "}"
-                        + "getId() {"
-                        + "return this.id;"
-                        + "}"
-                        + "setName(name) {"
-                        + "this.name = name;"
-                        + "}"
-                        + "getName() {"
-                        + "return this.name;"
-                        + "}"
-                        + "addBuddy(buddy) {"
-                        + "this.buddies.push(buddy);"
-                        + "}"
-                        + "getBuddies() {"
-                        + "return this.buddies;"
-                        + "}"
-                        + "}";
-        String filename = "student.js";
-
-        PrintWriter out = new PrintWriter("student.js");
-        out.println(JS_Code);
-        out.flush();
-
-        DHTPolicy.Config config = new DHTPolicy.Config();
-        config.setNumOfShards(3);
-
-        SapphireObjectSpec spec =
-                SapphireObjectSpec.newBuilder()
-                        .setLang(Language.js)
-                        .setConstructorName("Student")
-                        .setSourceFileLocation(filename)
-                        .addDMSpec(
-                                DMSpec.newBuilder()
-                                        .setName(DHTPolicy.class.getName())
-                                        .addConfig(config)
-                                        .create())
-                        .create();
-
-        GraalObject graalObject = new GraalObject(spec, null);
-
-        ObjectHandler objHandler = new ObjectHandler(graalObject);
-        // objHandler.SetGraalContext(c);
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(byteArrayOutputStream);
-        oos.writeObject(objHandler);
-        //        objHandler.write(oos);
-        oos.flush();
-
-        byte[] bytes = byteArrayOutputStream.toByteArray();
-        //        ObjectHandler inObj = new ObjectHandler(c.eval("js", "0"));
-        //        inObj.SetGraalContext(c);
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-        ObjectInputStream objectInputSteam = new ObjectInputStream(byteArrayInputStream);
-        ObjectHandler clone = (ObjectHandler) objectInputSteam.readObject();
-        //        inObj.read(objectInputSteam);
-
-        System.out.println("Original value is " + objHandler.getObject().toString());
-        System.out.println("After SerDe, value is " + clone.getObject().toString());
-
-        (new File(filename)).delete();
-
-        assert objHandler.getObject().toString().equals(clone.getObject().toString());
-    }
-
-    @Test
-    public void testJavaObject() throws Exception {
+    /**
+     * Test a String
+     * TODO: quinton: This was called testJavaObject, but it only really tersted a java String.
+     *      We need to test an arbitrary java object, with inheritance, enbedded objects etc.
+     */
+    public void testJavaString() throws Exception {
         String s = "helloworld";
         ObjectHandler obj = new ObjectHandler(s);
         byte[] bytes = Utils.toBytes(obj);
-
         ObjectHandler obj2 = (ObjectHandler) Utils.toObject(bytes);
-
         assert s.equals(obj2.getObject());
     }
 }


### PR DESCRIPTION
This is work in progress, to separate graal-dependent code from non-graal code, so that we can build for non-graal (for example to run on Android, on which Graal is not yet supported).

Code is not yet tested, probably doesn't work, and contains several todos requiring clarification.

This PR replaces https://github.com/quinton-hoole-2/DCAP-Sapphire/pull/1