### PR TITLE
Improve incremental builds

### DIFF
--- a/sapphire/examples/example-minnietwitter/build.gradle
+++ b/sapphire/examples/example-minnietwitter/build.gradle
@@ -4,33 +4,28 @@ dependencies {
     compile project(':sapphire-core')
 }
 
-// Task for Stub compilation
-task compileStubs(type: JavaCompile) {
-    source = sourceSets.main.java.srcDirs
-    classpath = sourceSets.main.compileClasspath
-    destinationDir = sourceSets.main.output.classesDir
-    options.incremental = true
-}
-
 // Task for app stub generation
 task genAppStubs(type: JavaExec) {
     main = "sapphire.compiler.StubGenerator"
     classpath = sourceSets.main.runtimeClasspath
     def pkgName = 'sapphire.appexamples.minnietwitter'
     def src = "$buildDir/classes/java/main/sapphire/appexamples/minnietwitter/"
-    def dst = "src/main/java/sapphire/appexamples/minnietwitter/stubs/"
+    def dst = "$projectDir/src/main/java/sapphire/appexamples/minnietwitter/stubs/"
     args src, pkgName, dst
+    outputs.dir dst // Declare outputs, so gradle will run if they have been changed
+    inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
-clean.doFirst {
-    delete fileTree("$projectDir/src/main/java/sapphire/appexamples/minnietwitter/stubs") {
-        include '**/*_Stub.java'
-    }
-    println "Deleted $projectDir/src/main/java/sapphire/appexamples/minnietwitter/stubs"
+// Task for Stub compilation
+task compileStubs(type: JavaCompile) {
+    inputs.dir genAppStubs.outputs // Tell gradle to only recompile stubs when they've been regenerated.
+    outputs.dir "$buildDir/classes/java/main/sapphire/appexamples/minnietwitter/stubs/" // ... or when someone messed with the compiled stubs
+    source = sourceSets.main.java.srcDirs
+    classpath = sourceSets.main.compileClasspath
+    destinationDir = sourceSets.main.output.classesDir
+    options.incremental = true
 }
 
-genAppStubs.mustRunAfter compileJava
-compileStubs.dependsOn genAppStubs
 jar.dependsOn compileStubs
 
 task runoms(type: JavaExec) {

--- a/sapphire/examples/hanksTodo/build.gradle
+++ b/sapphire/examples/hanksTodo/build.gradle
@@ -4,33 +4,28 @@ dependencies {
     compile project(':sapphire-core')
 }
 
-// Task for Stub compilation
-task compileStubs(type: JavaCompile) {
-    source = sourceSets.main.java.srcDirs
-    classpath = sourceSets.main.compileClasspath
-    destinationDir = sourceSets.main.output.classesDir
-    options.incremental = true
-}
-
 // Task for app stub generation
 task genStubs(type: JavaExec) {
     main = "sapphire.compiler.StubGenerator"
     classpath = sourceSets.main.runtimeClasspath
     def pkgName = 'sapphire.appexamples.hankstodo'
     def src = "$buildDir/classes/java/main/sapphire/appexamples/hankstodo"
-    def dst = "src/main/java/sapphire/appexamples/hankstodo/stubs/"
+    def dst = "$projectDir/src/main/java/sapphire/appexamples/hankstodo/stubs/"
     args src, pkgName, dst
+    outputs.dir dst // Declare outputs, so gradle will run if they have been changed
+    inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
-clean.doFirst {
-    delete fileTree("$projectDir/src/main/java/sapphire/appexamples/hankstodo/stubs") {
-        include '**/*_Stub.java'
-    }
-    println "Deleted $projectDir/src/main/java/sapphire/appexamples/hankstodo/stubs"
+// Task for Stub compilation
+task compileStubs(type: JavaCompile) {
+    inputs.dir genStubs.outputs // Tell gradle to only recompile stubs when they've been regenerated.
+    outputs.dir "$buildDir/classes/java/main/sapphire/appexamples/hankstodo/stubs/" // ... or when someone messed with the compiled stubs
+    source = sourceSets.main.java.srcDirs
+    classpath = sourceSets.main.compileClasspath
+    destinationDir = sourceSets.main.output.classesDir
+    options.incremental = true
 }
 
-genStubs.mustRunAfter compileJava
-compileStubs.dependsOn genStubs
 jar.dependsOn compileStubs
 
 // Start OMS with "gradlew runoms"

--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -4,14 +4,6 @@ dependencies {
     compile project(':sapphire-core')
 }
 
-// Task for Stub compilation
-task compileStubs(type: JavaCompile) {
-    source = sourceSets.main.java.srcDirs
-    classpath = sourceSets.main.compileClasspath
-    destinationDir = sourceSets.main.output.classesDir
-    options.incremental = true
-}
-
 // Task for app stub generation
 task genStubs(type: JavaExec) {
     main = "sapphire.compiler.StubGenerator"
@@ -19,18 +11,21 @@ task genStubs(type: JavaExec) {
     def pkgName = 'sapphire.appexamples.helloworld'
     def src = "$buildDir/classes/java/main/sapphire/appexamples/helloworld/"
     def dst = "src/main/java/sapphire/appexamples/helloworld/stubs/"
-    args src, pkgName, dst 
+    args src, pkgName, dst
+    outputs.dir dst // Declare outputs, so gradle will run if they have been changed
+    inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
-clean.doFirst {
-    delete fileTree("$projectDir/src/main/java/sapphire/appexamples/helloworld/stubs") {
-        include '**/*_Stub.java'
-    }
-    println "Deleted $projectDir/src/main/java/sapphire/appexamples/helloworld/stubs"
+// Task for Stub compilation
+task compileStubs(type: JavaCompile) {
+    inputs.dir genStubs.outputs // Tell gradle to only recompile stubs when they've been regenerated.
+    outputs.dir "$buildDir/classes/java/main/sapphire/appexamples/minnietwitter/stubs/" // ... or when someone messed with the compiled stubs
+    source = sourceSets.main.java.srcDirs
+    classpath = sourceSets.main.compileClasspath
+    destinationDir = sourceSets.main.output.classesDir
+    options.incremental = true
 }
 
-genStubs.mustRunAfter compileJava
-compileStubs.dependsOn genStubs
 jar.dependsOn compileStubs
 
 // Start kernel server with "gradlew runoms"

--- a/sapphire/examples/pinkis/build.gradle
+++ b/sapphire/examples/pinkis/build.gradle
@@ -10,26 +10,21 @@ task genStubs(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     def pkgName = 'sapphire.demo'
     def src = "$buildDir/classes/java/main/sapphire/demo/"
-    def dst = "src/main/java/sapphire/demo/stubs/"
+    def dst = "$projectDir/src/main/java/sapphire/demo/stubs/"
     args src, pkgName, dst
+    outputs.dir dst // Declare outputs, so gradle will run if they have been changed
+    inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
 task compileStubs(type: JavaCompile) {
+    inputs.dir genStubs.outputs // Try to convince gradle to only recompile stubs when they've been regenerated.
+    outputs.dir "$buildDir/classes/java/main/sapphire/appexamples/demo/stubs/" // ... or when someone messed with the compiled stubs
     source = sourceSets.main.java.srcDirs
     classpath = sourceSets.main.compileClasspath
     destinationDir = sourceSets.main.output.classesDir
     options.incremental = true
 }
 
-clean.doFirst {
-    delete fileTree("$projectDir/src/main/java/sapphire/demo/stubs") {
-        include '**/*_Stub.java'
-    }
-    println "Deleted the generated stubs"
-}
-
-genStubs.mustRunAfter compileJava
-compileStubs.dependsOn genStubs
 jar.dependsOn compileStubs
 
 // task to start OMS

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     // TODO(multi-lang): Unable to fetch jar from maven central due to Proxy issue.
     // Load jar file from disk temporarily.
     compile files('libs/snakeyaml-1.23.jar')
-
     testCompile 'org.mockito:mockito-core:1.+'
     testCompile 'org.powermock:powermock:1.6.5'
     testCompile 'org.powermock:powermock-module-junit4:1.6.5'
@@ -59,18 +58,14 @@ task genStubs(type: JavaExec) {
     def src = "$buildDir/classes/java/main/sapphire/policy/"
     def dst = "$projectDir/src/main/java/sapphire/policy/stubs/"
     args src, pkgName, dst
-}
-
-// Task for deleting Java stubs
-task delStubs {
-    delete fileTree("$projectDir/src/main/java/sapphire/policy/stubs") {
-        include '**/*_Stub.java'
-    }
-    println "Deleted $projectDir/src/main/java/sapphire/policy/stubs"
+    outputs.dir dst // Declare outputs, so gradle will run if they have been changed
+    inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
 // Task for stub compilation
 task compileStubs(type: JavaCompile) {
+    inputs.dir genStubs.outputs // Try to convince gradle to only recompile stubs when they've been regenerated.
+    outputs.dir "$buildDir/classes/java/main/sapphire/policy/stubs" // ... or when someone messed with the compiled stubs
     source = sourceSets.main.java.srcDirs
     classpath = sourceSets.main.compileClasspath
     destinationDir = sourceSets.main.output.classesDir
@@ -81,15 +76,10 @@ task integTest(type: Test) {
     systemProperty "DCAP_JAVA_HOME", project.property('org.gradle.java.home')
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
 }
 
-genStubs.mustRunAfter delStubs
-genStubs.mustRunAfter compileJava
-compileStubs.dependsOn genStubs
 tasks.googleJavaFormat.mustRunAfter genStubs
 check.dependsOn tasks.googleJavaFormat
 check.dependsOn integTest
 integTest.mustRunAfter test
-compileJava.dependsOn delStubs
-jar.dependsOn compileStubs
+jar.inputs.dir compileStubs.outputs // jar needs to be rebuilt if stubs got recompiled

--- a/sapphire/sapphire-core/src/main/java/sapphire/compiler/StubGenerator.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/compiler/StubGenerator.java
@@ -125,6 +125,5 @@ public class StubGenerator {
         String dst = args[2];
         generateStubs(src, pkg, dst);
         LOGGER.info(String.format("Generated stubs. src: %s, package: %s, dst: %s", src, pkg, dst));
-        System.exit(0);
     }
 }


### PR DESCRIPTION
1. declare outputs for various gradle tasks, so that gradle can figure out when to run each task (i.e. when it's inputs or outputs have changed).
2. remove various clean tasks (because when tasks declare their outputs, then gradle knows how to clean them properly - by deleting all outputs).
3. remove various dependsOn, mustRunAfter and mustRunBefore statements as gradle doesn't need them any more, and does a better job of figuring things out automatically based on task inputs and outputs.

I tested this with various permutations 'gradle clean', 'gradle build', 'gradle test', 'gradle check', 'gradle runapp' etc and it all seems to work as expected.  

I should probably do some additional testing by editing some source files to make sure that they trigger the required stub generation, compilation, testing etc.

One thing I'm not yet totally sure about is how well this handles changes to imported packages.  For example genStubs has 'classes/java/main/sapphire/policy/' as input, but what if something those depend upon change?  Not sure - will test.