### PR TITLE
unused code clean-up

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
@@ -4,7 +4,6 @@ import java.net.InetSocketAddress;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import sapphire.common.SapphireObjectNotFoundException;
 import sapphire.common.SapphireObjectReplicaNotFoundException;
@@ -103,10 +102,6 @@ public abstract class DefaultSapphirePolicyUpcallImpl extends SapphirePolicyLibr
         public void $__initialize(String appObjectClassName, ArrayList<Object> params) {
             this.appObjectClassName = appObjectClassName;
             this.params = params;
-        }
-
-        public Map<String, SapphirePolicyConfig> getAppConfigAnnotation() {
-            return super.getAppConfigAnnotation();
         }
 
         public SapphireServerPolicy onRefRequest() throws RemoteException {

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
@@ -507,7 +507,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
     public abstract static class SapphireGroupPolicyLibrary implements SapphireGroupPolicyUpcalls {
         protected String appObjectClassName;
         protected ArrayList<Object> params;
-        protected Map<String, SapphirePolicyConfig> configMap;
         protected KernelOID oid;
         protected SapphireObjectID sapphireObjId;
 
@@ -541,14 +540,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
 
         public KernelOID $__getKernelOID() {
             return this.oid;
-        }
-
-        public void setAppConfigAnnotation(Map<String, SapphirePolicyConfig> configMap) {
-            this.configMap = configMap;
-        }
-
-        public Map<String, SapphirePolicyConfig> getAppConfigAnnotation() {
-            return configMap;
         }
 
         public void setSapphireObjId(SapphireObjectID sapphireId) {

--- a/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
@@ -475,7 +475,6 @@ public class Sapphire {
             SapphireGroupPolicy groupPolicy = initializeGroupPolicy(groupPolicyStub);
             groupPolicyStub.setSapphireObjId(sapphireObjId);
             groupPolicy.setSapphireObjId(sapphireObjId);
-            groupPolicy.setAppConfigAnnotation(configMap);
 
             EventHandler sapphireHandler =
                     new EventHandler(


### PR DESCRIPTION
`protected Map<String, SapphirePolicyConfig> configMap;` in 'SapphirePolicyLibrary.java' was added when we used to create new instance of client policy on oms acquire method. It is not used anymore. Removing this field, getter and setter for it.