### PR TITLE
hanksTodoRuby app gradle issue fix

### DIFF
--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -53,8 +53,8 @@ task runapp(type: Exec) {
 // Start kernel server with "gradlew runapp"
 task runapp(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    systemProperty "RUBY_HOME",  "${project.projectDir}/src/main/ruby/sapphire/appexamples/hankstodo/"
     main = 'sapphire.appexamples.hankstodo.stubs.Client_Stub'
-    System.setProperty("RUBY_HOME", "${project.projectDir}/src/main/ruby/sapphire/appexamples/hankstodo/")
     args project.property('kernelIpAndroid'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 

--- a/sapphire/examples/hanksTodoRuby/gradle.properties
+++ b/sapphire/examples/hanksTodoRuby/gradle.properties
@@ -1,5 +1,5 @@
-omsIp=192.168.56.205
-kernelServerIp=192.168.56.205
+omsIp=127.0.0.1
+kernelServerIp=127.0.0.1
 omsPort=22346
 kernelServerPort=22345
 kernelIpAndroid=10.0.2.15

--- a/sapphire/examples/hanksTodoRuby/src/main/java/sapphire/appexamples/hankstodo/stubs/Client_Stub.java
+++ b/sapphire/examples/hanksTodoRuby/src/main/java/sapphire/appexamples/hankstodo/stubs/Client_Stub.java
@@ -58,7 +58,6 @@ public class Client_Stub {
             return;
         }
 
-        java.lang.System.setProperty("RUBY_HOME", "/Users/haibinxie/Code/DCAP_Sapphire_Fork/DCAP-Sapphire/sapphire/examples/hanksTodoRuby/src/main/ruby/sapphire/appexamples/hankstodo");
         java.lang.String rubyHome = java.lang.System.getProperty("RUBY_HOME");
 
         Test(host, omsHost, sapphire.app.Language.js, rubyHome + "/todo_list_manager.js");

--- a/sapphire/examples/hanksTodoRuby/src/main/ruby/sapphire/appexamples/hankstodo/todo_list_manager.rb
+++ b/sapphire/examples/hanksTodoRuby/src/main/ruby/sapphire/appexamples/hankstodo/todo_list_manager.rb
@@ -1,10 +1,36 @@
 #!/usr/bin/ruby
+# TODO: Support multifile SO .
+# Ruby library/file load steps:
+#   loadPath = File.expand_path('src/main/ruby/sapphire/appexamples/hankstodo',__dir__)
+#   $:.unshift(folder) unless $:.include?(loadPath)
+# Identified Issue: When Ruby SO is used in kernel server "__dir__" returns current working directory
+#                   But when run in Ruby env it returns directory of ruby file itself.
+class TodoList
+    def initialize(name)
+        @to_dos = Array.new
+        @name = name
+    end
 
-folder = File.expand_path('src/main/ruby/sapphire/appexamples/hankstodo',__dir__)
-puts "foldername : #{folder}"
-$:.unshift(folder) unless $:.include?(folder)
+    def add_todo(todo)
+        @to_dos.push(todo)
+        puts "add #{todo} success!!!"
+        return "OK!"
+    end
 
-require 'todo_list'
+    def complete_todo(todo)
+        @to_dos.delete(todo)
+        puts "#{todo} task removed"
+        return "OK!"
+    end
+
+    def get_todos
+        return @to_dos
+    end
+
+    def getName
+        @name
+    end
+end
 
 class Manager
     def initialize

--- a/sapphire/gradle.properties
+++ b/sapphire/gradle.properties
@@ -10,7 +10,7 @@
 # 5. To set up GraalVM JDK in Android Studio, please checkout https://github.com/Huawei-PaaS/DCAP-Sapphire/blob/master/docs/GettingStarted.md
 # 
 # Points org.gradle.java.home to the home dir of your GraalVM JDK.
-org.gradle.java.home=/Users/terryzhuo/Workspace/graalvm-ce-1.0.0-rc6/Contents/Home
+org.gradle.java.home=/home/paas/graalvm-ce-1.0.0-rc6
 
 # Bintray properties
 # Subprojects which plan to upload to bintray should

--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/policy/SimpleDMIntegrationTest.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/policy/SimpleDMIntegrationTest.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.util.List;
-
 import org.junit.*;
 import sapphire.app.SapphireObjectSpec;
 import sapphire.common.SapphireObjectID;
@@ -31,9 +30,9 @@ public class SimpleDMIntegrationTest {
 
     @BeforeClass
     public static void bootstrap() throws Exception {
-        OMSServerImpl.main(new String[]{omsIp, String.valueOf(omsPort)});
+        OMSServerImpl.main(new String[] {omsIp, String.valueOf(omsPort)});
         KernelServerImpl.main(
-                new String[]{kstIp, String.valueOf(ksPort), omsIp, String.valueOf(omsPort), "r1"});
+                new String[] {kstIp, String.valueOf(ksPort), omsIp, String.valueOf(omsPort), "r1"});
     }
 
     @Before

--- a/sapphire/sapphire-core/src/main/java/sapphire/graal/io/Deserializer.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/graal/io/Deserializer.java
@@ -91,7 +91,7 @@ public class Deserializer implements AutoCloseable {
                 Value instVars = v.getMember("instance_variables").execute();
                 List<String> varStr = new ArrayList<String>();
                 for (int i = 0; i < instVars.getArraySize(); i++) {
-                    varStr.add(instVars.getArrayElement(i).toString());
+                    varStr.add(instVars.getArrayElement(i).toString().replaceAll(":", ""));
                 }
                 return varStr;
             case js:

--- a/sapphire/sapphire-core/src/main/java/sapphire/graal/io/Serializer.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/graal/io/Serializer.java
@@ -81,7 +81,7 @@ public class Serializer implements AutoCloseable {
                 serializeHelper(v.getArrayElement(i));
             }
         } else { // isComplex
-            logger.fine("found non-primitive, " + " canExecute " + v.canExecute() + " " + v);
+            logger.fine("found non-primitive, " + " canExecute " + v.canExecute());
             out.writeInt(GraalType.OBJECT.ordinal());
             // String className = v.getMetaObject().getMember("className").asString();
             String className = getClassName(v);
@@ -117,10 +117,7 @@ public class Serializer implements AutoCloseable {
     private String getClassName(Value v) {
         switch (lang) {
             case ruby:
-                System.out.println(v.getMetaObject().getMemberKeys());
-                System.out.println(v.getMetaObject().toString());
                 return v.getMetaObject().toString();
-                // return v.getMetaObject().getMember("name").execute().asString();
             case js:
                 return v.getMetaObject().getMember("className").asString();
         }
@@ -130,7 +127,6 @@ public class Serializer implements AutoCloseable {
     private List<String> getMemberVariables(Value v) {
         switch (lang) {
             case ruby:
-                System.out.println(v.getMemberKeys());
                 Value instVars = v.getMember("instance_variables").execute();
                 List<String> varSte = new ArrayList<String>();
                 for (int i = 0; i < instVars.getArraySize(); i++) {

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -2,7 +2,6 @@ package sapphire.kernel.server;
 
 import java.io.Serializable;
 import java.net.InetSocketAddress;
-import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;


### PR DESCRIPTION
Following changes are added in this PR:
1. modified `examples:hanksTodoRuby:runapp` task to handle RUBY_HOME path.
2. Moved TodoList class from todo_list.rb to todo_list_manager.rb.
3. Modified Deserialisation code to handle Ruby SO.

Note:
  Currently todo_list.rb content moved to todo_list_manager.rb. 
  Issue : When Ruby SO is used in kernel server "__dir__" returns current working directory.                 
              But when run in Ruby env it returns directory of ruby file itself.

UT And Integration test Report:
![utreport](https://user-images.githubusercontent.com/9818606/46862043-a9a9d880-ce31-11e8-8a77-39b6217f7023.png)
Ruby App : 
![rubyappreport](https://user-images.githubusercontent.com/9818606/46862064-b9c1b800-ce31-11e8-9394-9edac1049f0a.png)

