### PR TITLE
Enabled logging in demo apps

### DIFF
--- a/sapphire/examples/example-minnietwitter/build.gradle
+++ b/sapphire/examples/example-minnietwitter/build.gradle
@@ -36,12 +36,14 @@ task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.oms.OMSServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('omsIp'), project.property('omsPort')
 }
 
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 

--- a/sapphire/examples/example-minnietwitter/src/main/resources/ks-logging.properties
+++ b/sapphire/examples/example-minnietwitter/src/main/resources/ks-logging.properties
@@ -1,0 +1,45 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-ks-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/example-minnietwitter/src/main/resources/oms-logging.properties
+++ b/sapphire/examples/example-minnietwitter/src/main/resources/oms-logging.properties
@@ -1,0 +1,44 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-oms-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/hanksTodo/build.gradle
+++ b/sapphire/examples/hanksTodo/build.gradle
@@ -37,6 +37,7 @@ task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.oms.OMSServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('omsIp'), project.property('omsPort')
 }
 
@@ -44,6 +45,7 @@ task runoms(type: JavaExec) {
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 

--- a/sapphire/examples/hanksTodo/src/main/resources/ks-logging.properties
+++ b/sapphire/examples/hanksTodo/src/main/resources/ks-logging.properties
@@ -1,0 +1,45 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-ks-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/hanksTodo/src/main/resources/oms-logging.properties
+++ b/sapphire/examples/hanksTodo/src/main/resources/oms-logging.properties
@@ -1,0 +1,44 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-oms-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -23,6 +23,7 @@ task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.oms.OMSServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('omsIp'), project.property('omsPort')
 }
 
@@ -30,6 +31,7 @@ task runoms(type: JavaExec) {
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 

--- a/sapphire/examples/hanksTodoRuby/src/main/resources/ks-logging.properties
+++ b/sapphire/examples/hanksTodoRuby/src/main/resources/ks-logging.properties
@@ -1,0 +1,45 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-ks-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/hanksTodoRuby/src/main/resources/oms-logging.properties
+++ b/sapphire/examples/hanksTodoRuby/src/main/resources/oms-logging.properties
@@ -1,0 +1,44 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-oms-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -37,6 +37,7 @@ task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.oms.OMSServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('omsIp'), project.property('omsPort')
 }
 
@@ -44,6 +45,7 @@ task runoms(type: JavaExec) {
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 

--- a/sapphire/examples/helloworld/src/main/resources/ks-logging.properties
+++ b/sapphire/examples/helloworld/src/main/resources/ks-logging.properties
@@ -1,0 +1,45 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-ks-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/helloworld/src/main/resources/oms-logging.properties
+++ b/sapphire/examples/helloworld/src/main/resources/oms-logging.properties
@@ -1,0 +1,44 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-oms-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/pinkis/build.gradle
+++ b/sapphire/examples/pinkis/build.gradle
@@ -36,6 +36,7 @@ task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.oms.OMSServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('omsIp'), project.property('omsPort')
 }
 
@@ -43,6 +44,7 @@ task runoms(type: JavaExec) {
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 
@@ -50,12 +52,14 @@ task runks(type: JavaExec) {
 task runks2(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('kernelServerIp'), project.property('kernelServerPort2'), project.property('omsIp'), project.property('omsPort')
 }
 
 task runks3(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'sapphire.kernel.server.KernelServerImpl'
+    jvmArgs "-DLOG_DIR=" + project.property('logDir')
     args project.property('kernelServerIp'), project.property('kernelServerPort3'), project.property('omsIp'), project.property('omsPort')
 }
 

--- a/sapphire/examples/pinkis/src/main/resources/ks-logging.properties
+++ b/sapphire/examples/pinkis/src/main/resources/ks-logging.properties
@@ -1,0 +1,45 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-ks-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/examples/pinkis/src/main/resources/oms-logging.properties
+++ b/sapphire/examples/pinkis/src/main/resources/oms-logging.properties
@@ -1,0 +1,44 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= sapphire.utils.EnvFileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+sapphire.utils.EnvFileHandler.pattern = ${LOG_DIR}/sapphire-oms-%g.log
+sapphire.utils.EnvFileHandler.limit = 50000
+sapphire.utils.EnvFileHandler.count = 1
+sapphire.utils.EnvFileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+

--- a/sapphire/gradle.properties
+++ b/sapphire/gradle.properties
@@ -8,9 +8,12 @@
 # 4. uncomment the following line. Point org.gradle.java.home to your GraalVM.
 # Gradle will use this property to figure out JDK location.
 # 5. To set up GraalVM JDK in Android Studio, please checkout https://github.com/Huawei-PaaS/DCAP-Sapphire/blob/master/docs/GettingStarted.md
-# 
-# Points org.gradle.java.home to the home dir of your GraalVM JDK.
-org.gradle.java.home=/home/paas/graalvm-ce-1.0.0-rc6
+
+# Set home dir of your GraalVM JDK.
+# org.gradle.java.home=/Path_To_Your_Graal_VM/graalvm-ce-1.0.0-rc6/Contents/Home
+
+# Set log base directory
+logDir=/var/log
 
 # Bintray properties
 # Subprojects which plan to upload to bintray should

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -40,6 +40,16 @@ import sapphire.runtime.Sapphire;
  * @author iyzhang
  */
 public class KernelServerImpl implements KernelServer {
+
+    static {
+        String path =
+                KernelServerImpl.class
+                        .getClassLoader()
+                        .getResource("ks-logging.properties")
+                        .getFile();
+        System.setProperty("java.util.logging.config.file", path);
+    }
+
     private static Logger logger = Logger.getLogger("sapphire.kernel.server.KernelServerImpl");
     private InetSocketAddress host;
     private String region;

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -42,6 +42,14 @@ import sapphire.runtime.Sapphire;
  * @author iyzhang
  */
 public class OMSServerImpl implements OMSServer {
+    static {
+        String path =
+                OMSServerImpl.class
+                        .getClassLoader()
+                        .getResource("oms-logging.properties")
+                        .getFile();
+        System.setProperty("java.util.logging.config.file", path);
+    }
 
     private static Logger logger = Logger.getLogger("sapphire.oms.OMSServerImpl");
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/utils/EnvFileHandler.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/utils/EnvFileHandler.java
@@ -1,0 +1,25 @@
+package sapphire.utils;
+
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.LogManager;
+
+/**
+ * A file handler which is able to replace <code>${LOG_DIR}</code> in log property file with the
+ * value of <code>LOG_DIR</code> system property.
+ */
+public class EnvFileHandler extends FileHandler {
+    private static String LOG_DIR_ENV_KEY = "LOG_DIR";
+    private static String DEFAULT_LOG_DIR = "/var/log";
+    private static String TARGET_PATTERN = "${" + LOG_DIR_ENV_KEY + "}";
+
+    private static String pattern() throws IOException {
+        String prefix = EnvFileHandler.class.getName();
+        String v = LogManager.getLogManager().getProperty(prefix + ".pattern");
+        return v.replace(TARGET_PATTERN, System.getProperty(LOG_DIR_ENV_KEY, DEFAULT_LOG_DIR));
+    }
+
+    public EnvFileHandler() throws IOException {
+        super(pattern());
+    }
+}


### PR DESCRIPTION
This PR enables logging in OMS and Kernel Server.

It turns out that `Java.util.logging.FileHandler` does not support using system properties in logging.properties. I have to create a `EnvFileHandler` to do it.

By default, log files are written to `/var/tmp` directory. If you want to put log file in a different location, you need to set the `logDir` in `DCAP_Sapphire/sapphire/gradle.properties` file.

<img width="871" alt="screen shot 2018-10-12 at 7 05 32 pm" src="https://user-images.githubusercontent.com/1460413/46900116-d241ca80-ce51-11e8-88be-4abeecfa5acf.png">

<img width="1303" alt="screen shot 2018-10-12 at 6 53 08 pm" src="https://user-images.githubusercontent.com/1460413/46900090-5d6e9080-ce51-11e8-85dd-21d878cddaa7.png">
<img width="1299" alt="screen shot 2018-10-12 at 6 54 32 pm" src="https://user-images.githubusercontent.com/1460413/46900106-a45c8600-ce51-11e8-8bd5-3e9ab6de7220.png">
<img width="1306" alt="screen shot 2018-10-12 at 6 55 27 pm" src="https://user-images.githubusercontent.com/1460413/46900107-a6bee000-ce51-11e8-90fc-46d1e8125ad9.png">
<img width="1302" alt="screen shot 2018-10-12 at 6 56 42 pm" src="https://user-images.githubusercontent.com/1460413/46900108-acb4c100-ce51-11e8-92c5-d7433ea1d631.png">
