### PR TITLE
Add graal-sdk.jar as a local dependency

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     // TODO(multi-lang): Unable to fetch jar from maven central due to Proxy issue.
     // Load jar file from disk temporarily.
     compile files('libs/snakeyaml-1.23.jar')
+    compile 'org.graalvm:graal-sdk:1.0.0-rc7'
     testCompile 'org.mockito:mockito-core:1.+'
     testCompile 'org.powermock:powermock:1.6.5'
     testCompile 'org.powermock:powermock-module-junit4:1.6.5'


### PR DESCRIPTION
Added dependency on `graal-sdk.jar`. It will make things easier for Android applications to consume `graal-sdk.jar`.  

With this PR, you no longer need to manually add `graal-sdk.jar` into the classpath of your graal-vm SDK in intelliJ and android studio.

**This PR should be merged after PR 305.**

<img width="764" alt="screen shot 2018-10-15 at 7 27 45 pm" src="https://user-images.githubusercontent.com/1460413/46989406-da984080-d0b1-11e8-9d6c-0ed9d05e486f.png">
<img width="1217" alt="screen shot 2018-10-15 at 7 29 19 pm" src="https://user-images.githubusercontent.com/1460413/46989412-dff58b00-d0b1-11e8-8c04-d32a5105b90b.png">
<img width="1207" alt="screen shot 2018-10-15 at 7 30 33 pm" src="https://user-images.githubusercontent.com/1460413/46989416-e3891200-d0b1-11e8-9b09-b8bceb8e85bb.png">
<img width="1197" alt="screen shot 2018-10-15 at 7 32 15 pm" src="https://user-images.githubusercontent.com/1460413/46989420-e6840280-d0b1-11e8-9c10-168bd3df4d6a.png">
