### PR TITLE
addserver call removed in group policy oncreate

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
@@ -227,7 +227,6 @@ public class ConsensusRSMPolicy extends DefaultSapphirePolicy {
             // super.onCreate(server, annotations);
 
             super.onCreate(server, configMap);
-            addServer(server);
 
             try {
                 ArrayList<String> regions = sapphire_getRegions();


### PR DESCRIPTION
addserver call removed in group policy oncreate() function as its already called in createPolicy() function.

![buildntest_2018-10-16 15-57-22](https://user-images.githubusercontent.com/9107906/47010615-28b64e00-d15d-11e8-933d-dea4794f6233.png)
![hankstodoapptest_2018-10-16 15-55-32](https://user-images.githubusercontent.com/9107906/47010619-2b18a800-d15d-11e8-9d43-4affa3533f08.png)
