### PR TITLE
[Issue 294] Always creates new AppObject instance during sapphire_replicate.

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/app/DMSpec.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/app/DMSpec.java
@@ -2,6 +2,7 @@ package sapphire.app;
 
 import static sapphire.policy.SapphirePolicyUpcalls.SapphirePolicyConfig;
 
+import java.io.Serializable;
 import java.util.*;
 import org.yaml.snakeyaml.Yaml;
 
@@ -11,7 +12,7 @@ import org.yaml.snakeyaml.Yaml;
  * <p>Each DM specification contains a sapphire policy name and an optional list of sapphire policy
  * configurations.
  */
-public final class DMSpec {
+public final class DMSpec implements Serializable {
     private String name;
     private List<SapphirePolicyConfig> configs = new ArrayList<>();
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/app/SapphireObjectSpec.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/app/SapphireObjectSpec.java
@@ -1,5 +1,6 @@
 package sapphire.app;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -38,7 +39,7 @@ import org.yaml.snakeyaml.Yaml;
  * sourceFileLocation: src/main/js/college.js
  * </code>
  */
-public class SapphireObjectSpec {
+public class SapphireObjectSpec implements Serializable {
     /** Programming Language in which the Sapphire object is written */
     private Language lang;
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
@@ -127,6 +127,10 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
             this.spec = spec;
         }
 
+        public SapphireObjectSpec getSapphireObjectSpec() {
+            return this.spec;
+        }
+
         @Override
         public void onCreate(
                 SapphirePolicy.SapphireGroupPolicy group,
@@ -169,7 +173,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
                 Sapphire.createPolicy(
                         this.getGroup().sapphireObjId,
                         spec,
-                        actualAppObject,
                         configMap,
                         processedPolicies,
                         processedPoliciesReplica,
@@ -193,7 +196,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
                         Sapphire.createPolicy(
                                 this.getGroup().sapphireObjId,
                                 spec,
-                                null,
                                 configMap,
                                 this.nextPolicies,
                                 processedPoliciesReplica,

--- a/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
@@ -85,7 +85,6 @@ public class Sapphire {
                     createPolicy(
                             sapphireObjId,
                             spec,
-                            null,
                             configMap,
                             policyNameChain,
                             processedPolicies,
@@ -142,7 +141,6 @@ public class Sapphire {
                     createPolicy(
                             sapphireObjId,
                             spec,
-                            null,
                             configMap,
                             policyNameChain,
                             processedPolicies,
@@ -211,7 +209,6 @@ public class Sapphire {
     public static List<SapphirePolicyContainer> createPolicy(
             SapphireObjectID sapphireObjId,
             SapphireObjectSpec spec,
-            AppObject appObject,
             Map<String, SapphirePolicyConfig> configMap,
             List<SapphirePolicyContainer> policyNameChain,
             List<SapphirePolicyContainer> processedPolicies,
@@ -277,7 +274,7 @@ public class Sapphire {
                     previousServerPolicyStub,
                     client);
         } else {
-            initAppStub(spec, serverPolicy, serverPolicyStub, client, appArgs, appObject);
+            initAppStub(spec, serverPolicy, serverPolicyStub, client, appArgs);
         }
 
         // Note that subList is non serializable; hence, the new list creation.
@@ -312,7 +309,6 @@ public class Sapphire {
             createPolicy(
                     sapphireObjId,
                     spec,
-                    null,
                     configMap,
                     nextPoliciesToCreate,
                     processedPolicies,
@@ -749,6 +745,8 @@ public class Sapphire {
             throws KernelObjectNotFoundException {
         serverPolicyStub.$__initialize(prevServerPolicy.sapphire_getAppObject());
         serverPolicy.$__initialize(prevServerPolicy.sapphire_getAppObject());
+        serverPolicyStub.setSapphireObjectSpec(prevServerPolicy.getSapphireObjectSpec());
+        serverPolicy.setSapphireObjectSpec(prevServerPolicy.getSapphireObjectSpec());
 
         KernelObject previousServerPolicyKernelObject =
                 GlobalKernelReferences.nodeServer.getKernelObject(
@@ -778,20 +776,16 @@ public class Sapphire {
             SapphireServerPolicy serverPolicy,
             SapphireServerPolicy serverPolicyStub,
             SapphireClientPolicy clientPolicy,
-            Object[] appArgs,
-            AppObject appObject)
+            Object[] appArgs)
             throws ClassNotFoundException, IllegalAccessException, CloneNotSupportedException {
-        AppObjectStub appStub;
 
-        if (appObject != null) {
-            serverPolicyStub.$__initialize(appObject);
-            serverPolicy.$__initialize(appObject);
-        } else {
-            appStub = getAppStub(spec, serverPolicy, appArgs);
-            appStub.$__initialize(clientPolicy);
-            serverPolicy.$__initialize(appStub);
-            serverPolicyStub.$__initialize(appStub);
-        }
+        AppObjectStub appStub;
+        appStub = getAppStub(spec, serverPolicy, appArgs);
+        appStub.$__initialize(clientPolicy);
+        serverPolicy.$__initialize(appStub);
+        serverPolicyStub.$__initialize(appStub);
+        serverPolicy.setSapphireObjectSpec(spec);
+        serverPolicyStub.setSapphireObjectSpec(spec);
     }
 
     public static Class<?>[] getParamsClasses(Object[] params) throws ClassNotFoundException {

--- a/sapphire/sapphire-core/src/test/java/sapphire/app/DMSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/app/DMSpecTest.java
@@ -2,13 +2,27 @@ package sapphire.app;
 
 import org.junit.Assert;
 import org.junit.Test;
+import sapphire.common.Utils;
 import sapphire.policy.scalability.LoadBalancedFrontendPolicy;
 import sapphire.policy.scalability.ScaleUpFrontendPolicy;
 
 public class DMSpecTest {
 
     @Test
-    public void test() {
+    public void testYaml() {
+        DMSpec spec = createDMSpec();
+        DMSpec clone = DMSpec.fromYaml(spec.toString());
+        Assert.assertEquals(spec, clone);
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        DMSpec spec = createDMSpec();
+        DMSpec clone = (DMSpec)Utils.toObject(Utils.toBytes(spec));
+        Assert.assertEquals(spec, clone);
+    }
+
+    private DMSpec createDMSpec() {
         ScaleUpFrontendPolicy.Config scaleUpConfig = new ScaleUpFrontendPolicy.Config();
         scaleUpConfig.setReplicationRateInMs(100);
 
@@ -16,15 +30,11 @@ public class DMSpecTest {
         lbConfig.setMaxConcurrentReq(200);
         lbConfig.setReplicaCount(30);
 
-        DMSpec spec =
-                DMSpec.newBuilder()
+        return DMSpec.newBuilder()
                         .setName(ScaleUpFrontendPolicy.class.getName())
                         .addConfig(scaleUpConfig)
                         .addConfig(lbConfig)
                         .create();
 
-        DMSpec clone = DMSpec.fromYaml(spec.toString());
-
-        Assert.assertEquals(spec, clone);
     }
 }

--- a/sapphire/sapphire-core/src/test/java/sapphire/app/SapphireObjectSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/app/SapphireObjectSpecTest.java
@@ -2,13 +2,33 @@ package sapphire.app;
 
 import org.junit.Assert;
 import org.junit.Test;
+import sapphire.common.Utils;
 import sapphire.policy.scalability.LoadBalancedFrontendPolicy;
 import sapphire.policy.scalability.ScaleUpFrontendPolicy;
 
 public class SapphireObjectSpecTest {
-
     @Test
     public void testToYamlFromYaml() {
+        SapphireObjectSpec soSpec = createSpec();
+        SapphireObjectSpec soSpecClone = SapphireObjectSpec.fromYaml(soSpec.toString());
+        Assert.assertEquals(soSpec, soSpecClone);
+    }
+
+    @Test
+    public void testSerializeEmptySpec() {
+        SapphireObjectSpec spec = SapphireObjectSpec.newBuilder().create();
+        SapphireObjectSpec clone = SapphireObjectSpec.fromYaml(spec.toString());
+        Assert.assertEquals(spec, clone);
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        SapphireObjectSpec spec = createSpec();
+        SapphireObjectSpec clone = (SapphireObjectSpec) Utils.toObject(Utils.toBytes(spec));
+        Assert.assertEquals(spec, clone);
+    }
+
+    private SapphireObjectSpec createSpec() {
         ScaleUpFrontendPolicy.Config scaleUpConfig = new ScaleUpFrontendPolicy.Config();
         scaleUpConfig.setReplicationRateInMs(100);
 
@@ -23,34 +43,12 @@ public class SapphireObjectSpecTest {
                         .addConfig(lbConfig)
                         .create();
 
-        SapphireObjectSpec soSpec =
-                SapphireObjectSpec.newBuilder()
+        return SapphireObjectSpec.newBuilder()
                         .setLang(Language.js)
                         .setName("com.org.College")
                         .setSourceFileLocation("src/main/js/college.js")
                         .setConstructorName("college")
                         .addDMSpec(dmSpec)
                         .create();
-
-        System.out.println(soSpec.toString());
-
-        SapphireObjectSpec soSpecClone = SapphireObjectSpec.fromYaml(soSpec.toString());
-        Assert.assertEquals(soSpec, soSpecClone);
-
-        for (DMSpec ds : soSpecClone.getDmList()) {
-            ScaleUpFrontendPolicy.Config scaleUpConfigClone =
-                    (ScaleUpFrontendPolicy.Config) ds.getConfigs().get(0);
-            Assert.assertEquals(scaleUpConfig, scaleUpConfigClone);
-            LoadBalancedFrontendPolicy.Config lbConfigClone =
-                    (LoadBalancedFrontendPolicy.Config) ds.getConfigs().get(1);
-            Assert.assertEquals(lbConfig, lbConfigClone);
-        }
-    }
-
-    @Test
-    public void testSerializeEmptySpec() {
-        SapphireObjectSpec spec = SapphireObjectSpec.newBuilder().create();
-        SapphireObjectSpec clone = SapphireObjectSpec.fromYaml(spec.toString());
-        Assert.assertEquals(spec, clone);
     }
 }

--- a/sapphire/sapphire-core/src/test/java/sapphire/runtime/SapphireMultiPolicyChainTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/runtime/SapphireMultiPolicyChainTest.java
@@ -212,7 +212,6 @@ public class SapphireMultiPolicyChainTest extends MultiPolicyChainBaseTest {
                 Sapphire.createPolicy(
                         sapphireObjId,
                         spec,
-                        null,
                         configMap,
                         policyNameChain,
                         processedPolicies,
@@ -241,7 +240,6 @@ public class SapphireMultiPolicyChainTest extends MultiPolicyChainBaseTest {
                 Sapphire.createPolicy(
                         sapphireObjId,
                         spec,
-                        null,
                         configMap,
                         policyNameChain,
                         processedPolicies,


### PR DESCRIPTION
This PR fixes one bug reported in [issue 294](https://github.com/Huawei-PaaS/DCAP-Sapphire/issues/294): When we run MasterSlave DM with one kernel server, we may have both master server policy and slave server policy refer to one AppObject instance. 

This is not a MasterSlave DM bug. It is a bug in `sapphire_replicate`. This PR makes sure that a new AppObject instance will be created during `sapphire_replicate`.

<img width="833" alt="screen shot 2018-10-16 at 12 04 51 pm" src="https://user-images.githubusercontent.com/1460413/47041057-af0e6800-d13c-11e8-8a0f-66ebadabfa2b.png">
<img width="1075" alt="screen shot 2018-10-16 at 12 06 31 pm" src="https://user-images.githubusercontent.com/1460413/47041066-b46bb280-d13c-11e8-84ee-1095e10fa8aa.png">
<img width="1075" alt="screen shot 2018-10-16 at 12 07 32 pm" src="https://user-images.githubusercontent.com/1460413/47041072-b766a300-d13c-11e8-82ed-21f5e5dc5a5b.png">
<img width="1077" alt="screen shot 2018-10-16 at 12 08 35 pm" src="https://user-images.githubusercontent.com/1460413/47041080-b9c8fd00-d13c-11e8-860b-25c6f3e91921.png">
