### PR TITLE
[Issue 299] Replace instance event handler with group policy 

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
@@ -83,7 +83,8 @@ public class ObjectHandler implements Serializable {
     public Object invoke(String method, ArrayList<Object> params) throws Exception {
         // Note in graal sapphire object stub we use varargs (Object ...) as function parameters, so
         // we need to wrap parameters with another object array.
-        // Please refer to unit test sapphire-core/src/test/java/sapphire/common/VarargsFunctionReflectionTest
+        // Please refer to unit test
+        // sapphire-core/src/test/java/sapphire/common/VarargsFunctionReflectionTest
         Object[] p = params.toArray();
         return methods.get(method).invoke(object, isGraalObject ? new Object[] {p} : p);
     }

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
@@ -62,17 +62,7 @@ public interface OMSServer extends Remote {
     SapphireReplicaID registerSapphireReplica(SapphireObjectID sapphireObjId)
             throws RemoteException, SapphireObjectNotFoundException;
 
-    void setSapphireObjectDispatcher(SapphireObjectID sapphireObjId, EventHandler dispatcher)
-            throws RemoteException, SapphireObjectNotFoundException;
-
     void setSapphireReplicaDispatcher(SapphireReplicaID replicaId, EventHandler dispatcher)
-            throws RemoteException, SapphireObjectNotFoundException,
-                    SapphireObjectReplicaNotFoundException;
-
-    EventHandler getSapphireObjectDispatcher(SapphireObjectID sapphireObjId)
-            throws RemoteException, SapphireObjectNotFoundException;
-
-    EventHandler getSapphireReplicaDispatcher(SapphireReplicaID replicaId)
             throws RemoteException, SapphireObjectNotFoundException,
                     SapphireObjectReplicaNotFoundException;
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/SapphireInstanceManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/SapphireInstanceManager.java
@@ -1,19 +1,25 @@
 package sapphire.oms;
 
+import static sapphire.policy.SapphirePolicy.SapphireGroupPolicy;
+
+import java.rmi.RemoteException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 import sapphire.common.AppObjectStub;
 import sapphire.common.SapphireObjectID;
 import sapphire.common.SapphireObjectNotFoundException;
 import sapphire.common.SapphireObjectReplicaNotFoundException;
 import sapphire.common.SapphireReplicaID;
+import sapphire.policy.SapphirePolicy;
 import sapphire.runtime.EventHandler;
 
 public class SapphireInstanceManager {
+    private static final Logger logger = Logger.getLogger(SapphireInstanceManager.class.getName());
 
     private SapphireObjectID oid;
     private String name;
@@ -22,6 +28,19 @@ public class SapphireInstanceManager {
     private AppObjectStub objectStub;
     private HashMap<SapphireReplicaID, EventHandler> replicaDispatchers;
     private Random oidGenerator;
+    /**
+     * Root group policy is the <strong>outmost</strong> group policy of this sapphire object.
+     *
+     * <p>For example, given a sapphire object with DM list [DHT, MasterSlave], its outmost DM is
+     * DHT. In this case, {@code rootGroupPolicy} is the DHT group policy.
+     *
+     * <p>TODO(multi-dm): We actually need to maintain group policies of inner DMs too.
+     * We need to organize group policies, their relationships, and their healthiness into
+     * a table as described in the multi-DM design doc.
+     *
+     *  @see <a href="https://docs.google.com/document/d/1g5SnzsnyGXzdZVDF_uj9MQJomQpHS-PMpfwnYn4RNDU/edit#heading=h.j9vsjm8kyruk">Multi-DM Design Doc</a>
+     */
+    private SapphireGroupPolicy rootGroupPolicy;
 
     /**
      * Randomly generate a new replica id
@@ -38,6 +57,15 @@ public class SapphireInstanceManager {
         replicaDispatchers = new HashMap<SapphireReplicaID, EventHandler>();
         oidGenerator = new Random(new Date().getTime());
         referenceCount = new AtomicInteger(1);
+    }
+
+    /**
+     * Sets the root group policy of this sapphire object.
+     *
+     * @param rootGroupPolicy root group policy
+     */
+    public void setRootGroupPolicy(SapphirePolicy.SapphireGroupPolicy rootGroupPolicy) {
+        this.rootGroupPolicy = rootGroupPolicy;
     }
 
     /**
@@ -140,7 +168,10 @@ public class SapphireInstanceManager {
         return values.toArray(new EventHandler[values.size()]);
     }
 
-    public void clear() {
+    public void clear() throws RemoteException {
+        if (rootGroupPolicy != null) {
+            rootGroupPolicy.onDestroy();
+        }
         replicaDispatchers.clear();
     }
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
@@ -462,6 +462,7 @@ public class Sapphire {
      *
      * @param policyClass
      * @param sapphireObjId
+     * @param configMap
      * @return Returns group policy object stub
      * @throws RemoteException
      * @throws ClassNotFoundException
@@ -479,28 +480,11 @@ public class Sapphire {
             SapphireGroupPolicy groupPolicy = initializeGroupPolicy(groupPolicyStub);
             groupPolicyStub.setSapphireObjId(sapphireObjId);
             groupPolicy.setSapphireObjId(sapphireObjId);
-
-            EventHandler sapphireHandler =
-                    new EventHandler(
-                            GlobalKernelReferences.nodeServer.getLocalHost(),
-                            new ArrayList() {
-                                {
-                                    add(groupPolicyStub);
-                                }
-                            });
-
-            /* Register the handler for the sapphire object */
-            GlobalKernelReferences.nodeServer.oms.setSapphireObjectDispatcher(
-                    sapphireObjId, sapphireHandler);
         } catch (KernelObjectNotFoundException e) {
             logger.severe(
                     "Failed to find the group kernel object created just before it. Exception info: "
                             + e);
             throw new KernelObjectNotCreatedException("Failed to find the kernel object", e);
-        } catch (SapphireObjectNotFoundException e) {
-            logger.warning("Failed to find sapphire object. Exception info: " + e);
-            KernelObjectFactory.delete(groupPolicyStub.$__getKernelOID());
-            throw e;
         }
 
         return groupPolicyStub;

--- a/sapphire/sapphire-core/src/test/java/sapphire/app/DMSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/app/DMSpecTest.java
@@ -18,7 +18,7 @@ public class DMSpecTest {
     @Test
     public void testSerialization() throws Exception {
         DMSpec spec = createDMSpec();
-        DMSpec clone = (DMSpec)Utils.toObject(Utils.toBytes(spec));
+        DMSpec clone = (DMSpec) Utils.toObject(Utils.toBytes(spec));
         Assert.assertEquals(spec, clone);
     }
 
@@ -31,10 +31,9 @@ public class DMSpecTest {
         lbConfig.setReplicaCount(30);
 
         return DMSpec.newBuilder()
-                        .setName(ScaleUpFrontendPolicy.class.getName())
-                        .addConfig(scaleUpConfig)
-                        .addConfig(lbConfig)
-                        .create();
-
+                .setName(ScaleUpFrontendPolicy.class.getName())
+                .addConfig(scaleUpConfig)
+                .addConfig(lbConfig)
+                .create();
     }
 }

--- a/sapphire/sapphire-core/src/test/java/sapphire/app/SapphireObjectSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/app/SapphireObjectSpecTest.java
@@ -44,11 +44,11 @@ public class SapphireObjectSpecTest {
                         .create();
 
         return SapphireObjectSpec.newBuilder()
-                        .setLang(Language.js)
-                        .setName("com.org.College")
-                        .setSourceFileLocation("src/main/js/college.js")
-                        .setConstructorName("college")
-                        .addDMSpec(dmSpec)
-                        .create();
+                .setLang(Language.js)
+                .setName("com.org.College")
+                .setSourceFileLocation("src/main/js/college.js")
+                .setConstructorName("college")
+                .addDMSpec(dmSpec)
+                .create();
     }
 }

--- a/sapphire/sapphire-core/src/test/java/sapphire/common/SapphireUtils.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/common/SapphireUtils.java
@@ -2,7 +2,6 @@ package sapphire.common;
 
 import static org.mockito.Mockito.spy;
 import static sapphire.common.UtilsTest.extractFieldValueOnInstance;
-import static sapphire.compiler.GlobalStubConstants.POLICY_ONDESTROY_MTD_NAME_FORMAT;
 
 import java.net.InetSocketAddress;
 import java.rmi.AccessException;
@@ -22,7 +21,6 @@ import sapphire.oms.OMSServer;
 import sapphire.oms.OMSServerImpl;
 import sapphire.oms.SapphireInstanceManager;
 import sapphire.oms.SapphireObjectManager;
-import sapphire.runtime.EventHandler;
 
 /** Created by Vishwajeet on 4/4/18. */
 public class SapphireUtils {
@@ -127,24 +125,9 @@ public class SapphireUtils {
         return sapphireObjects.get(sapphireObjId);
     }
 
+    @Deprecated
     public static void deleteSapphireObject(OMSServer oms, SapphireObjectID sapphireObjId)
             throws Exception {
-        EventHandler handler = oms.getSapphireObjectDispatcher(sapphireObjId);
-        /* Handlers are made from mocked objects(server & group). Mocked objects will have all the
-         * final methods. Need to remove the final keyword from onDestroy() */
-        // "public final void
-        // sapphire.policy.scalability.ScaleUpFrontendPolicyTest$Group_Stub$$EnhancerByMockitoWithCGLIB$$6faa2a3e.onDestroy() throws java.rmi.RemoteException"
-        StringBuffer destroyName =
-                new StringBuffer(
-                        String.format(
-                                POLICY_ONDESTROY_MTD_NAME_FORMAT,
-                                handler.getObjects().get(0).getClass().getName()));
-        String newDestroyName = destroyName.toString();
-        destroyName.insert("public ".length(), "final ");
-        Hashtable<String, Object> handlers =
-                (Hashtable<String, Object>) extractFieldValueOnInstance(handler, "handlers");
-        Object policyHandler = handlers.get(destroyName.toString());
-        handlers.put(newDestroyName, policyHandler);
         oms.deleteSapphireObject(sapphireObjId);
     }
 }

--- a/sapphire/sapphire-core/src/test/java/sapphire/oms/OMSTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/oms/OMSTest.java
@@ -22,6 +22,7 @@ import sapphire.common.AppObject;
 import sapphire.common.BaseTest;
 import sapphire.common.SapphireObjectID;
 import sapphire.common.SapphireUtils;
+import sapphire.kernel.common.GlobalKernelReferences;
 import sapphire.kernel.common.KernelOID;
 import sapphire.kernel.common.KernelObjectFactory;
 import sapphire.kernel.common.KernelObjectStub;
@@ -130,7 +131,8 @@ public class OMSTest extends BaseTest {
 
     @Test
     public void acquireSapphireObjectStubSuccessTest() throws Exception {
-        SO_Stub appObjstub = (SO_Stub) spiedOms.acquireSapphireObjectStub(group.getSapphireObjId());
+        SapphireObjectID sid = group.getSapphireObjId();
+        SO_Stub appObjstub = (SO_Stub) spiedOms.acquireSapphireObjectStub(sid);
         assertEquals(
                 1, getOmsSapphireInstance(spiedOms, group.getSapphireObjId()).getReferenceCount());
 
@@ -179,6 +181,7 @@ public class OMSTest extends BaseTest {
 
     @After
     public void tearDown() throws Exception {
+        GlobalKernelReferences.nodeServer.oms = spiedOms;
         deleteSapphireObject(spiedOms, group.getSapphireObjId());
     }
 }


### PR DESCRIPTION
@VenuReddyHuawei @SrinivasChilveri  Please review this PR closely. thanks

I plan to raise a series of PRs to simplify and clean up sapphire core. This PR is the first one.

I noticed in [Issue 299](https://github.com/Huawei-PaaS/DCAP-Sapphire/issues/299) that *instance event handler* in `SapphireInstanceManager` is just a sapphire group policy.  This PR makes three major changes:
1. It replaced instance event handler with group policy so that we can get rid of those complex reflection code.
2. It calls out clearly that the group policy (or instance event handler) is the group policy of the out-most DM.
3. Deleted three APIs from `OMSServer` interface.

<img width="609" alt="screen shot 2018-10-18 at 5 12 12 pm" src="https://user-images.githubusercontent.com/1460413/47191241-05c1a080-d2fb-11e8-87a7-59bfb72df4df.png">
<img width="1302" alt="screen shot 2018-10-18 at 5 13 27 pm" src="https://user-images.githubusercontent.com/1460413/47191243-0fe39f00-d2fb-11e8-9dce-e5023cda7d70.png">
<img width="1308" alt="screen shot 2018-10-18 at 5 14 26 pm" src="https://user-images.githubusercontent.com/1460413/47191246-16721680-d2fb-11e8-8caf-f761df3169a7.png">
<img width="1307" alt="screen shot 2018-10-18 at 5 15 39 pm" src="https://user-images.githubusercontent.com/1460413/47191248-1a059d80-d2fb-11e8-9be7-cedb3d1dcf81.png">

