### PR TITLE
Add file logging to examples

### DIFF
--- a/sapphire/examples/example-minnietwitter/build.gradle
+++ b/sapphire/examples/example-minnietwitter/build.gradle
@@ -35,18 +35,21 @@ jar.dependsOn compileStubs
 task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.oms.OMSServerImpl'
     args project.property('omsIp'), project.property('omsPort')
 }
 
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
 
 task runapp(type: JavaExec) {
     main = "sapphire.appexamples.minnietwitter.MinnieTwitterMain"
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     classpath = sourceSets.main.runtimeClasspath
     args project.property('omsIp'), project.property('omsPort'), project.property('kernelIpAndroid'), project.property('kernelServerPort')
 }

--- a/sapphire/examples/hanksTodo/build.gradle
+++ b/sapphire/examples/hanksTodo/build.gradle
@@ -36,6 +36,7 @@ jar.dependsOn compileStubs
 task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.oms.OMSServerImpl'
     args project.property('omsIp'), project.property('omsPort')
 }
@@ -43,6 +44,7 @@ task runoms(type: JavaExec) {
 // Start kernel server with "gradlew runks"
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
@@ -52,5 +54,6 @@ task runks(type: JavaExec) {
 task runapp(type: JavaExec) {
     main = "sapphire.appexamples.hankstodo.HanksTodoMain"
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     args project.property('omsIp'), project.property('omsPort'), project.property('kernelIpAndroid'), project.property('kernelServerPort')
 }

--- a/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/HanksTodoMain.java
+++ b/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/HanksTodoMain.java
@@ -34,7 +34,6 @@ public class HanksTodoMain {
 
         Registry registry;
 
-        java.util.logging.Logger.getLogger("my.category").setLevel(Level.FINEST);
         try {
             registry = LocateRegistry.getRegistry(args[0],Integer.parseInt(args[1]));
             OMSServer omsserver = (OMSServer) registry.lookup("SapphireOMS");

--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -22,6 +22,7 @@ jar.dependsOn compileStubs
 task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.oms.OMSServerImpl'
     args project.property('omsIp'), project.property('omsPort')
 }
@@ -29,6 +30,7 @@ task runoms(type: JavaExec) {
 // Start kernel server with "gradlew runks"
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
@@ -62,6 +64,7 @@ task runjsapp(type: Exec) {
 // Task for run Java demo app
 task runapp(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     systemProperty "RUBY_HOME",  "${project.projectDir}/src/main/ruby/sapphire/appexamples/hankstodo/"
     systemProperty "JS_HOME",  "${project.projectDir}/src/main/js/sapphire/appexamples/hankstodo/"
     main = 'sapphire.appexamples.hankstodo.stubs.Client_Stub'

--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -36,6 +36,7 @@ jar.dependsOn compileStubs
 task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.oms.OMSServerImpl'
     args project.property('omsIp'), project.property('omsPort')
 }
@@ -43,6 +44,7 @@ task runoms(type: JavaExec) {
 // Start kernel server with "gradlew runks"
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
@@ -52,5 +54,6 @@ task runks(type: JavaExec) {
 task runapp(type: JavaExec) {
     main = "sapphire.appexamples.helloworld.HelloWorldMain"
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     args project.property('omsIp'), project.property('omsPort'), project.property('kernelIpAndroid'), project.property('kernelServerPort'), project.hasProperty('W') ? project.property('W') : "DCAP World"
 }

--- a/sapphire/examples/kvstore/build.gradle
+++ b/sapphire/examples/kvstore/build.gradle
@@ -35,6 +35,7 @@ jar.dependsOn compileStubs
 task runoms(type: JavaExec) {
     dependsOn jar
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.oms.OMSServerImpl'
     args project.property('omsIp'), project.property('omsPort')
 }
@@ -42,6 +43,7 @@ task runoms(type: JavaExec) {
 // task to start kernel server (hosting the SO)
 task runks(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')
 }
@@ -49,12 +51,14 @@ task runks(type: JavaExec) {
 // task to start more kernel server (hosting the SO)
 task runks2(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort2'), project.property('omsIp'), project.property('omsPort')
 }
 
 task runks3(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     main = 'sapphire.kernel.server.KernelServerImpl'
     args project.property('kernelServerIp'), project.property('kernelServerPort3'), project.property('omsIp'), project.property('omsPort')
 }
@@ -62,6 +66,7 @@ task runks3(type: JavaExec) {
 // task for run client
 task runapp(type: JavaExec) {
     main = "sapphire.demo.KeyValueStoreClient"
+    jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
     classpath = sourceSets.main.runtimeClasspath
     args project.property('omsIp'), project.property('omsPort')
 }

--- a/sapphire/logging.properties
+++ b/sapphire/logging.properties
@@ -1,0 +1,37 @@
+#################################################################################
+# Default logging configuration
+# For a more detailed explanation of the contents of this file see:
+# https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html
+# and http://tutorials.jenkov.com/java-logging/configuration.html
+#################################################################################
+
+# Log to both file and console
+handlers = java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Individual loggers can be customized like this.
+# "sapphire.kernel.server.KernelServerImpl".handlers           =
+# "sapphire.kernel.server.KernelServerImpl".useParentHandlers  =
+# "sapphire.kernel.server.KernelServerImpl".level              =
+# etc
+
+# Override defaults for all uncustomized loggers, by type
+
+# Limit log level in log files to INFO and higher, so they're not too verbose
+# Valid values are OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST
+java.util.logging.FileHandler.level     = INFO
+
+# Simple text logs instead of the default XML logs.
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Rotate log files after this many log entries, rather than the default unlimited growth.
+java.util.logging.FileHandler.limit     = 50000
+
+# Cycle through 10 log files, rather than the default 1 
+java.util.logging.FileHandler.count     = 10
+
+# Place our log files in the system temporary (%t) directory (typically
+# C:\TEMP on Windows, /var/tmp on Linux, $TMPDIR on OS X etc) rather than the default "%h/java%u.log"
+java.util.logging.FileHandler.pattern   = %t/sapphire.%u.%g.log
+                                                                
+
+java.util.logging.ConsoleHandler.level  = INFO

--- a/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/common/ObjectHandler.java
@@ -83,7 +83,8 @@ public class ObjectHandler implements Serializable {
     public Object invoke(String method, ArrayList<Object> params) throws Exception {
         // Note in graal sapphire object stub we use varargs (Object ...) as function parameters, so
         // we need to wrap parameters with another object array.
-        // Please refer to unit test sapphire-core/src/test/java/sapphire/common/VarargsFunctionReflectionTest
+        // Please refer to unit test
+        // sapphire-core/src/test/java/sapphire/common/VarargsFunctionReflectionTest
         Object[] p = params.toArray();
         return methods.get(method).invoke(object, isGraalObject ? new Object[] {p} : p);
     }

--- a/sapphire/sapphire-core/src/test/java/sapphire/app/DMSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/app/DMSpecTest.java
@@ -18,7 +18,7 @@ public class DMSpecTest {
     @Test
     public void testSerialization() throws Exception {
         DMSpec spec = createDMSpec();
-        DMSpec clone = (DMSpec)Utils.toObject(Utils.toBytes(spec));
+        DMSpec clone = (DMSpec) Utils.toObject(Utils.toBytes(spec));
         Assert.assertEquals(spec, clone);
     }
 
@@ -31,10 +31,9 @@ public class DMSpecTest {
         lbConfig.setReplicaCount(30);
 
         return DMSpec.newBuilder()
-                        .setName(ScaleUpFrontendPolicy.class.getName())
-                        .addConfig(scaleUpConfig)
-                        .addConfig(lbConfig)
-                        .create();
-
+                .setName(ScaleUpFrontendPolicy.class.getName())
+                .addConfig(scaleUpConfig)
+                .addConfig(lbConfig)
+                .create();
     }
 }

--- a/sapphire/sapphire-core/src/test/java/sapphire/app/SapphireObjectSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/app/SapphireObjectSpecTest.java
@@ -44,11 +44,11 @@ public class SapphireObjectSpecTest {
                         .create();
 
         return SapphireObjectSpec.newBuilder()
-                        .setLang(Language.js)
-                        .setName("com.org.College")
-                        .setSourceFileLocation("src/main/js/college.js")
-                        .setConstructorName("college")
-                        .addDMSpec(dmSpec)
-                        .create();
+                .setLang(Language.js)
+                .setName("com.org.College")
+                .setSourceFileLocation("src/main/js/college.js")
+                .setConstructorName("college")
+                .addDMSpec(dmSpec)
+                .create();
     }
 }


### PR DESCRIPTION
The changes in the java files are only due to automated reformatting, and can be ignored. 
It seems someone checked in code without autoformatting it first.

Other than that, this PR is a simple logging.properties file to configure logging, and adding jvmArgs to each example gradle file to feed that file to java.

I haven't added logging to the non-java apps yet.  Can do that in a followup PR.

Test results:

$ ./gradlew check
...
BUILD SUCCESSFUL in 13s
27 actionable tasks: 7 executed, 20 up-to-date

$ ./gradlew :examples:hanksTodo:runoms --info
...
INFO: OMS ready

$ ls -als $TMPDIR/sapphire*
4 -rw-r--r-- 1 quinton staff  72 Oct 18 17:42 /var/folders/m9/l7ktdwdj345bwjplvp_dchq80000gn/T//sapphire.0.0.log
4 -rw-r--r-- 1 quinton staff 338 Oct 18 17:41 /var/folders/m9/l7ktdwdj345bwjplvp_dchq80000gn/T//sapphire.0.1.log