### PR TITLE
Add an optional region parameter in createPolicy

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicy.java
@@ -91,7 +91,9 @@ public class DefaultSapphirePolicy extends SapphirePolicy {
 
         @Override
         public void onCreate(
-                SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap)
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
                 throws RemoteException {}
 
         @Override

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/DefaultSapphirePolicyUpcallImpl.java
@@ -58,7 +58,13 @@ public abstract class DefaultSapphirePolicyUpcallImpl extends SapphirePolicyLibr
 
         public SapphireServerPolicy sapphire_replicate(
                 List<SapphirePolicyContainer> processedPolicies) throws RemoteException {
-            return super.sapphire_replicate(processedPolicies);
+            return super.sapphire_replicate(processedPolicies, "");
+        }
+
+        public SapphireServerPolicy sapphire_replicate(
+                List<SapphirePolicyContainer> processedPolicies, String region)
+                throws RemoteException {
+            return super.sapphire_replicate(processedPolicies, region);
         }
 
         public void sapphire_pin(SapphireServerPolicy sapphireServerPolicy, String region)

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
@@ -150,7 +150,8 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
 
         /** Creates a replica of this server and registers it with the group. */
         public SapphireServerPolicy sapphire_replicate(
-                List<SapphirePolicyContainer> processedPolicies) throws RemoteException {
+                List<SapphirePolicyContainer> processedPolicies, String region)
+                throws RemoteException {
             KernelObjectStub serverPolicyStub = null;
             SapphireServerPolicy serverPolicy = null;
 
@@ -178,6 +179,7 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
                         processedPoliciesReplica,
                         null,
                         null,
+                        region,
                         null);
 
                 // Last policy in the returned chain is replica of this policy.
@@ -201,6 +203,7 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
                                 processedPoliciesReplica,
                                 serverPolicy,
                                 serverPolicyStub,
+                                region,
                                 null);
 
                 String ko = "";

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyUpcalls.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyUpcalls.java
@@ -8,6 +8,7 @@ import sapphire.policy.SapphirePolicy.SapphireGroupPolicy;
 import sapphire.policy.SapphirePolicy.SapphireServerPolicy;
 
 public interface SapphirePolicyUpcalls {
+
     /**
      * Interface for sapphire policy configuration.
      *
@@ -67,12 +68,16 @@ public interface SapphirePolicyUpcalls {
         /**
          * Initialize g porouplicy.
          *
+         * @param region
          * @param server the server policy that is managed by the group policy
          * @param configMap the map that contains sapphire policy configurations. The key is the
          *     class name of the configuration, and the value is a {@link SapphirePolicyConfig}
          *     instance.
          */
-        void onCreate(SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap)
+        void onCreate(
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
                 throws RemoteException;
 
         void addServer(SapphireServerPolicy server) throws RemoteException;

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
@@ -6,8 +6,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
-import sapphire.common.SapphireObjectNotFoundException;
-import sapphire.common.SapphireObjectReplicaNotFoundException;
 import sapphire.policy.DefaultSapphirePolicy;
 
 public class DHTPolicy extends DefaultSapphirePolicy {
@@ -65,10 +63,12 @@ public class DHTPolicy extends DefaultSapphirePolicy {
 
         @Override
         public void onCreate(
-                SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap)
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
                 throws RemoteException {
             dhtChord = new DHTChord();
-            super.onCreate(server, configMap);
+            super.onCreate(region, server, configMap);
 
             if (configMap != null) {
                 SapphirePolicyConfig config = configMap.get(DHTPolicy.Config.class.getName());
@@ -80,26 +80,34 @@ public class DHTPolicy extends DefaultSapphirePolicy {
             try {
                 ArrayList<String> regions = sapphire_getRegions();
                 DHTServerPolicy dhtServer = (DHTServerPolicy) server;
+                // TODO: hack for demo.
+                // Sungwook will raise another PR to address it shortly
+                // dhtServer.sapphire_pin(server, regions.get(0));
 
                 // Create replicas based on annotation
                 InetSocketAddress newServerAddress = null;
                 for (int i = 1; i < numOfShards; i++) {
-                    newServerAddress = oms().getServerInRegion(regions.get(i % regions.size()));
+                    region = regions.get(i % regions.size());
+                    if (region == null) {
+                        throw new IllegalStateException("no region available for DHT DM");
+                    }
+                    logger.info(String.format("Creating shard %s in region %s", i, region));
 
                     // TODO (Sungwook, 2018-10-2) Passing processedPolicies may not be necessary as
                     // they are already available.
                     SapphireServerPolicy replica =
-                            dhtServer.sapphire_replicate(server.getProcessedPolicies());
-                    dhtServer.sapphire_pin_to_server(replica, newServerAddress);
+                            dhtServer.sapphire_replicate(server.getProcessedPolicies(), region);
+
+                    // TODO: hack for demo. When we demo DHT + master slave, DHT
+                    // is not the last DM, and therefore should not call sapphire_pin
+                    // to relocate server policy.
+                    // newServerAddress = oms().getServerInRegion(region);
+                    // dhtServer.sapphire_pin_to_server(replica,
+                    // newServerAddress);
                 }
-                dhtServer.sapphire_pin(server, regions.get(0));
             } catch (RemoteException e) {
                 throw new Error(
                         "Could not create new group policy because the oms is not available.");
-            } catch (SapphireObjectNotFoundException e) {
-                throw new Error("Failed to find sapphire object.", e);
-            } catch (SapphireObjectReplicaNotFoundException e) {
-                throw new Error("Failed to find sapphire object replica.", e);
             }
         }
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy2.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy2.java
@@ -141,7 +141,10 @@ public class DHTPolicy2 extends DefaultSapphirePolicy {
 
         @Override
         public void onCreate(
-                SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap) {
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
+                throws java.rmi.RemoteException {
             nodes = new HashMap<Integer, DHTNode>();
 
             try {

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/replication/ConsensusRSMPolicy.java
@@ -221,12 +221,14 @@ public class ConsensusRSMPolicy extends DefaultSapphirePolicy {
 
         @Override
         public void onCreate(
-                SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap)
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
                 throws RemoteException {
             // TODO(merged):
             // super.onCreate(server, annotations);
 
-            super.onCreate(server, configMap);
+            super.onCreate(region, server, configMap);
             addServer(server);
 
             try {

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedFrontendPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedFrontendPolicy.java
@@ -161,9 +161,11 @@ public class LoadBalancedFrontendPolicy extends DefaultSapphirePolicy {
 
         @Override
         public void onCreate(
-                SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap)
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
                 throws RemoteException {
-            super.onCreate(server, configMap);
+            super.onCreate(region, server, configMap);
 
             if (configMap != null) {
                 SapphirePolicyConfig config =
@@ -184,7 +186,7 @@ public class LoadBalancedFrontendPolicy extends DefaultSapphirePolicy {
                 /* Find the current region and the kernel server on which this first instance of
                 sapphire object is being created. And try to replicate the
                 sapphire objects in the same region(excluding this kernel server) */
-                String region = server.sapphire_getRegion();
+                region = server.sapphire_getRegion();
                 InetSocketAddress addr =
                         server.sapphire_locate_kernel_object(server.$__getKernelOID());
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
@@ -19,6 +19,7 @@ import sapphire.common.SapphireObjectNotFoundException;
 import sapphire.common.SapphireObjectReplicaNotFoundException;
 import sapphire.common.Utils;
 import sapphire.kernel.common.GlobalKernelReferences;
+import sapphire.kernel.common.KernelObjectStub;
 import sapphire.policy.DefaultSapphirePolicy;
 import sapphire.policy.scalability.masterslave.Lock;
 import sapphire.policy.scalability.masterslave.MethodInvocationRequest;
@@ -73,6 +74,11 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultSapphirePolicy 
                                 params,
                                 type);
 
+                logger.log(
+                        Level.INFO,
+                        String.format(
+                                "Sending request to master server %s",
+                                ((KernelObjectStub) server).$__getHostname()));
                 MethodInvocationResponse response = server.onRPC(request);
                 switch (response.getReturnCode()) {
                     case SUCCESS:
@@ -159,17 +165,26 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultSapphirePolicy 
         private Logger logger;
         private Random random = new Random(System.currentTimeMillis());
         private Lock masterLock;
+        private Map<String, String> nodeLabels;
 
         @Override
         public void onCreate(
-                SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap)
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
                 throws RemoteException {
             logger = Logger.getLogger(this.getClass().getName());
-            super.onCreate(server, configMap);
-            try {
+            super.onCreate(region, server, configMap);
+            logger.info(String.format("Creating master and slave instance in region %s", region));
 
-                ArrayList<InetSocketAddress> servers =
-                        GlobalKernelReferences.nodeServer.oms.getServers();
+            try {
+                List<InetSocketAddress> servers;
+                if (region != null && !region.isEmpty()) {
+                    servers = GlobalKernelReferences.nodeServer.oms.getServersInRegion(region);
+                } else {
+                    servers = GlobalKernelReferences.nodeServer.oms.getServers();
+                }
+
                 if (servers.size() < NUM_OF_REPLICAS) {
                     logger.warning(
                             String.format(
@@ -179,6 +194,10 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultSapphirePolicy 
                                             + "availability.",
                                     servers.size(), NUM_OF_REPLICAS));
                 }
+
+                logger.info(
+                        String.format(
+                                "Creating master and slave instances in servers: %s", servers));
 
                 List<InetSocketAddress> unavailable = new ArrayList<InetSocketAddress>();
                 InetSocketAddress dest = getAvailable(0, servers, unavailable);
@@ -215,7 +234,7 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultSapphirePolicy 
          * If no available server can be found, then return the {@code index % servers.size()}th
          * server in the {@code servers} list.
          *
-         * @param index index of the
+         * @param index index of the server
          * @param servers a list of servers
          * @param unavailable a list of unavailable servers
          * @return an available server; or the {@code index % servers.size()}th server in the given

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/ScaleUpFrontendPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/ScaleUpFrontendPolicy.java
@@ -163,9 +163,11 @@ public class ScaleUpFrontendPolicy extends LoadBalancedFrontendPolicy {
 
         @Override
         public void onCreate(
-                SapphireServerPolicy server, Map<String, SapphirePolicyConfig> configMap)
+                String region,
+                SapphireServerPolicy server,
+                Map<String, SapphirePolicyConfig> configMap)
                 throws RemoteException {
-            super.onCreate(server, configMap);
+            super.onCreate(region, server, configMap);
 
             if (configMap != null) {
                 SapphirePolicyConfig config =

--- a/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
@@ -1,18 +1,12 @@
 package sapphire.runtime;
 
-import static sapphire.policy.SapphirePolicyUpcalls.SapphirePolicyConfig;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.rmi.RemoteException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.harmony.rmi.common.RMIUtil;
@@ -22,13 +16,7 @@ import sapphire.app.SapphireObject;
 import sapphire.app.SapphireObjectSpec;
 import sapphire.common.*;
 import sapphire.compiler.GlobalStubConstants;
-import sapphire.kernel.common.GlobalKernelReferences;
-import sapphire.kernel.common.KernelOID;
-import sapphire.kernel.common.KernelObjectFactory;
-import sapphire.kernel.common.KernelObjectNotCreatedException;
-import sapphire.kernel.common.KernelObjectNotFoundException;
-import sapphire.kernel.common.KernelObjectStub;
-import sapphire.kernel.common.KernelObjectStubNotCreatedException;
+import sapphire.kernel.common.*;
 import sapphire.kernel.server.KernelObject;
 import sapphire.policy.DefaultSapphirePolicy;
 import sapphire.policy.DefaultSapphirePolicy.DefaultClientPolicy;
@@ -38,6 +26,7 @@ import sapphire.policy.SapphirePolicy.SapphireClientPolicy;
 import sapphire.policy.SapphirePolicy.SapphireGroupPolicy;
 import sapphire.policy.SapphirePolicy.SapphireServerPolicy;
 import sapphire.policy.SapphirePolicyContainer;
+import sapphire.policy.SapphirePolicyUpcalls;
 
 /**
  * Used by the developer to create a Sapphire Object given the Application Object class and the
@@ -66,7 +55,7 @@ public class Sapphire {
 
             List<SapphirePolicyContainer> processedPolicies = new ArrayList<>();
             List<SapphirePolicyContainer> policyNameChain = getPolicyNameChain(spec);
-            Map<String, SapphirePolicyConfig> configMap =
+            Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap =
                     Utils.fromDMSpecListToFlatConfigMap(spec.getDmList());
 
             if (policyNameChain.size() == 0) {
@@ -90,6 +79,7 @@ public class Sapphire {
                             processedPolicies,
                             previousServerPolicy,
                             previousServerPolicyStub,
+                            "",
                             args);
 
             appStub = policyList.get(0).getServerPolicy().sapphire_getAppObjectStub();
@@ -114,7 +104,8 @@ public class Sapphire {
     public static Object new_(Class<?> appObjectClass, Object... args) {
         try {
             Annotation[] annotations = appObjectClass.getAnnotations();
-            Map<String, SapphirePolicyConfig> configMap = Utils.toSapphirePolicyConfig(annotations);
+            Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap =
+                    Utils.toSapphirePolicyConfig(annotations);
             List<SapphirePolicyContainer> processedPolicies =
                     new ArrayList<SapphirePolicyContainer>();
             List<SapphirePolicyContainer> policyNameChain = getPolicyNameChain(annotations);
@@ -146,6 +137,7 @@ public class Sapphire {
                             processedPolicies,
                             previousServerPolicy,
                             previousServerPolicyStub,
+                            "",
                             args);
 
             AppObjectStub appStub = policyList.get(0).getServerPolicy().sapphire_getAppObjectStub();
@@ -209,17 +201,17 @@ public class Sapphire {
     public static List<SapphirePolicyContainer> createPolicy(
             SapphireObjectID sapphireObjId,
             SapphireObjectSpec spec,
-            Map<String, SapphirePolicyConfig> configMap,
+            Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap,
             List<SapphirePolicyContainer> policyNameChain,
             List<SapphirePolicyContainer> processedPolicies,
             SapphireServerPolicy previousServerPolicy,
             KernelObjectStub previousServerPolicyStub,
+            String region,
             Object[] appArgs)
             throws RemoteException, ClassNotFoundException, KernelObjectNotFoundException,
                     KernelObjectNotCreatedException, SapphireObjectNotFoundException,
                     SapphireObjectReplicaNotFoundException, InstantiationException,
                     InvocationTargetException, IllegalAccessException, CloneNotSupportedException {
-
         if (policyNameChain == null || policyNameChain.size() == 0) return null;
         String policyName = policyNameChain.get(0).getPolicyName();
         SapphireGroupPolicy existingGroupPolicy = policyNameChain.get(0).getGroupPolicyStub();
@@ -299,13 +291,21 @@ public class Sapphire {
         serverPolicyStub.setProcessedPolicies(processedPoliciesSoFar);
 
         if (existingGroupPolicy == null) {
-            groupPolicy.onCreate(serverPolicyStub, configMap);
+            groupPolicy.onCreate(region, serverPolicyStub, configMap);
         }
 
         previousServerPolicy = serverPolicy;
         previousServerPolicyStub = (KernelObjectStub) serverPolicyStub;
 
         if (nextPoliciesToCreate.size() != 0) {
+            // TODO: hacks for demo
+            if (policyName != null && policyName.contains("DHT")) {
+                if (region == null || region.isEmpty()) {
+                    List<String> regions = GlobalKernelReferences.nodeServer.oms.getRegions();
+                    logger.info("Regions available for DHT: " + regions);
+                    region = regions.get(0);
+                }
+            }
             createPolicy(
                     sapphireObjId,
                     spec,
@@ -314,6 +314,7 @@ public class Sapphire {
                     processedPolicies,
                     previousServerPolicy,
                     previousServerPolicyStub,
+                    region,
                     appArgs);
         }
 
@@ -351,7 +352,7 @@ public class Sapphire {
             Object[] args,
             PolicyComponents pc,
             Annotation[] annotations,
-            Map<String, SapphirePolicyConfig> configMap)
+            Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap)
             throws Exception {
         /* Register for a sapphire object Id from OMS */
         SapphireObjectID sapphireObjId =
@@ -399,7 +400,7 @@ public class Sapphire {
         client.onCreate(groupPolicyStub, configMap);
         appStub.$__initialize(client);
         serverPolicy.onCreate(groupPolicyStub, configMap);
-        groupPolicyStub.onCreate(serverPolicyStub, configMap);
+        groupPolicyStub.onCreate("", serverPolicyStub, configMap);
 
         logger.info("Sapphire Object created: " + spec);
         return appStub;
@@ -472,7 +473,7 @@ public class Sapphire {
     public static SapphireGroupPolicy createGroupPolicy(
             Class<?> policyClass,
             SapphireObjectID sapphireObjId,
-            Map<String, SapphirePolicyConfig> configMap)
+            Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap)
             throws RemoteException, ClassNotFoundException, KernelObjectNotCreatedException,
                     SapphireObjectNotFoundException {
         SapphireGroupPolicy groupPolicyStub = (SapphireGroupPolicy) getPolicyStub(policyClass);

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/dht/DHTPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/dht/DHTPolicyTest.java
@@ -2,6 +2,7 @@ package sapphire.policy.dht;
 
 import static org.mockito.Mockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
+import static sapphire.policy.SapphirePolicyUpcalls.SapphirePolicyConfig;
 
 import java.net.InetSocketAddress;
 import java.util.*;
@@ -15,7 +16,6 @@ import sapphire.oms.OMSServer;
 import sapphire.oms.OMSServerImpl;
 import sapphire.policy.SapphirePolicy;
 import sapphire.policy.SapphirePolicyContainer;
-import sapphire.policy.SapphirePolicyUpcalls;
 
 public class DHTPolicyTest {
     private OMSServer oms;
@@ -48,7 +48,11 @@ public class DHTPolicyTest {
     @Test
     public void test() throws Exception {
         DHTPolicy.DHTGroupPolicy group = new DHTPolicy.DHTGroupPolicy();
-        group.onCreate(servers[0], null);
+        Map<String, SapphirePolicyConfig> configMap = new HashMap<>();
+        servers[0].onCreate(group, configMap);
+        servers[1].onCreate(group, configMap);
+        servers[2].onCreate(group, configMap);
+        group.onCreate("region-1", servers[0], configMap);
         group.addServer(servers[1]);
         group.addServer(servers[2]);
 
@@ -82,8 +86,8 @@ public class DHTPolicyTest {
         // {
         public void onCreate(
                 SapphirePolicy.SapphireGroupPolicy group,
-                Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap) {
-            this.group = group;
+                Map<String, SapphirePolicyConfig> configMap) {
+            super.onCreate(group, configMap);
         }
 
         @Override
@@ -94,7 +98,7 @@ public class DHTPolicyTest {
 
         @Override
         public SapphirePolicy.SapphireServerPolicy sapphire_replicate(
-                List<SapphirePolicyContainer> processedPolicies) {
+                List<SapphirePolicyContainer> processedPolicies, String region) {
             return new ServerPolicy();
         }
 

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/replication/ConsensusRSMPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/replication/ConsensusRSMPolicyTest.java
@@ -198,7 +198,7 @@ public class ConsensusRSMPolicyTest extends BaseTest {
     public void omsNotAvailable() throws Exception {
         when(this.group.sapphire_getRegions()).thenThrow(new RemoteException());
         thrown.expect(Error.class);
-        this.group.onCreate(this.server1, new HashMap<>());
+        this.group.onCreate("", this.server1, new HashMap<>());
     }
 
     /**

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedFrontendPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedFrontendPolicyTest.java
@@ -206,7 +206,7 @@ public class LoadBalancedFrontendPolicyTest extends BaseTest {
         // Expecting error message- Configured replicas count: 5, created replica count : 2
         thrown.expectMessage("Configured replicas count: 5, created replica count : 2");
         setFieldValueOnInstance(group1, "replicaCount", 5);
-        group1.onCreate(this.server1, new HashMap<>());
+        group1.onCreate("", this.server1, new HashMap<>());
     }
 
     @After

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
@@ -2,6 +2,7 @@ package sapphire.policy.scalability;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.junit.Assert;
@@ -9,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import sapphire.common.AppObject;
 import sapphire.kernel.common.KernelOID;
+import sapphire.policy.SapphirePolicy;
 import sapphire.policy.scalability.masterslave.MethodInvocationRequest;
 import sapphire.policy.scalability.masterslave.MethodInvocationResponse;
 import sapphire.runtime.annotations.Immutable;
@@ -149,7 +151,20 @@ public class LoadBalancedMasterSlaveSyncPolicyIntegTest {
 
     private static class ClientMock extends LoadBalancedMasterSlaveSyncPolicy.ClientPolicy {}
 
-    private static class ServerMock extends LoadBalancedMasterSlaveSyncPolicy.ServerPolicy {}
+    private static class ServerMock extends LoadBalancedMasterSlaveSyncPolicy.ServerPolicy
+            implements sapphire.kernel.common.KernelObjectStub {
+
+        @Override
+        public InetSocketAddress $__getHostname() {
+            return null;
+        }
+
+        @Override
+        public void $__updateHostname(InetSocketAddress hostname) {}
+
+        @Override
+        public void $__setNextClientPolicy(SapphirePolicy.SapphireClientPolicy clientPolicy) {}
+    }
 
     private static class GroupMock extends LoadBalancedMasterSlaveSyncPolicy.GroupPolicy {}
 

--- a/sapphire/sapphire-core/src/test/java/sapphire/runtime/SapphireMultiPolicyChainTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/runtime/SapphireMultiPolicyChainTest.java
@@ -3,6 +3,7 @@ package sapphire.runtime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static sapphire.common.SapphireUtils.deleteSapphireObject;
+import static sapphire.policy.SapphirePolicyUpcalls.SapphirePolicyConfig;
 
 import java.net.InetSocketAddress;
 import java.rmi.registry.LocateRegistry;
@@ -24,10 +25,7 @@ import sapphire.kernel.common.KernelOID;
 import sapphire.kernel.common.KernelObjectFactory;
 import sapphire.kernel.common.KernelObjectStub;
 import sapphire.kernel.server.KernelServerImpl;
-import sapphire.policy.DefaultSapphirePolicy;
-import sapphire.policy.SapphirePolicy;
-import sapphire.policy.SapphirePolicyContainer;
-import sapphire.policy.SapphirePolicyUpcalls;
+import sapphire.policy.*;
 import sapphire.policy.dht.DHTPolicy2;
 
 @RunWith(PowerMockRunner.class)
@@ -45,8 +43,8 @@ public class SapphireMultiPolicyChainTest extends MultiPolicyChainBaseTest {
     public static class DefaultSO extends SO {}
 
     private SapphireObjectSpec spec;
-    private Map<String, Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig>> configMaps;
-    private Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap;
+    private Map<String, Map<String, SapphirePolicyConfig>> configMaps;
+    private Map<String, SapphirePolicyConfig> configMap;
 
     public static class DefaultGroup_Stub extends DefaultSapphirePolicy.DefaultGroupPolicy
             implements KernelObjectStub {
@@ -217,6 +215,7 @@ public class SapphireMultiPolicyChainTest extends MultiPolicyChainBaseTest {
                         processedPolicies,
                         previousServerPolicy,
                         previousServerPolicyStub,
+                        "",
                         null);
 
         assertEquals(1, policyList.size());
@@ -245,6 +244,7 @@ public class SapphireMultiPolicyChainTest extends MultiPolicyChainBaseTest {
                         processedPolicies,
                         previousServerPolicy,
                         previousServerPolicyStub,
+                        "",
                         null);
 
         assertEquals(2, policyList.size());


### PR DESCRIPTION
This PR adds an optional region parameter in `createPolicy` and `group.onCreate`.

This change is made to support DHT + MasterSlave demo. In order to demo DHT(2 shards) + MasterSlave (2 replicas), we have to force 4 replicas on different kernel servers. By passing `region` parameter to MasterSlave, we inform the group policy of MasterSlave DM to *only* select hosts in the given region. 

This PR is considered as a temporary quick fix to support our demos. We will come up with a long term solution to solve multi-DM scheduling issues in the future. At present, only MasterSlave handles this region parameter.  This change is backward compatible. All existing DMs should continue to work as they used to be. 

<img width="1326" alt="screen shot 2018-10-22 at 2 12 30 pm" src="https://user-images.githubusercontent.com/1460413/47320039-20e72580-d605-11e8-962d-266195b78ae5.png">
<img width="1323" alt="screen shot 2018-10-22 at 2 13 40 pm" src="https://user-images.githubusercontent.com/1460413/47320056-2ba1ba80-d605-11e8-848a-62d4cd80ebf4.png">
<img width="1323" alt="screen shot 2018-10-22 at 2 14 37 pm" src="https://user-images.githubusercontent.com/1460413/47320061-32303200-d605-11e8-92da-ef0b7a00459e.png">
<img width="676" alt="screen shot 2018-10-22 at 2 17 02 pm" src="https://user-images.githubusercontent.com/1460413/47320066-35c3b900-d605-11e8-82cc-66a1a162030e.png">
