### PR TITLE
Fixes #328 Fix missing appArgs issue and allow dynamic replication.

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
@@ -53,7 +53,8 @@ public interface OMSServer extends Remote {
     SapphirePolicy.SapphireGroupPolicy createGroupPolicy(
             Class<?> policyClass,
             SapphireObjectID sapphireObjId,
-            Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap)
+            Map<String, SapphirePolicyUpcalls.SapphirePolicyConfig> configMap,
+            Object[] appArgs)
             throws RemoteException, ClassNotFoundException, KernelObjectNotCreatedException,
                     SapphireObjectNotFoundException;
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -329,20 +329,20 @@ public class OMSServerImpl implements OMSServer {
      *
      * @param policyClass
      * @param sapphireObjId
+     * @param configMap
+     * @param appArgs
      * @return Returns group policy object stub
-     * @throws RemoteException
      * @throws ClassNotFoundException
      * @throws KernelObjectNotCreatedException
-     * @throws SapphireObjectNotFoundException
      */
     @Override
     public SapphirePolicy.SapphireGroupPolicy createGroupPolicy(
             Class<?> policyClass,
             SapphireObjectID sapphireObjId,
-            Map<String, SapphirePolicyConfig> configMap)
-            throws RemoteException, ClassNotFoundException, KernelObjectNotCreatedException,
-                    SapphireObjectNotFoundException {
-        return Sapphire.createGroupPolicy(policyClass, sapphireObjId, configMap);
+            Map<String, SapphirePolicyConfig> configMap,
+            Object[] appArgs)
+            throws ClassNotFoundException, KernelObjectNotCreatedException {
+        return Sapphire.createGroupPolicy(policyClass, sapphireObjId, configMap, appArgs);
     }
 
     public static void main(String args[]) {


### PR DESCRIPTION
1. Pass appArg to prevent no construction being thrown to creation of appObject.
2. Store appArgs in group policy so that it can be pulled dynamically during runtime for replica appObject creation.
3. Added TODOs.

<img width="1557" alt="screen shot 2018-10-24 at 3 06 02 pm" src="https://user-images.githubusercontent.com/12723038/47465302-414be700-d7a1-11e8-9a8b-f15e8340d527.png">
<img width="1680" alt="screen shot 2018-10-24 at 3 09 46 pm" src="https://user-images.githubusercontent.com/12723038/47465304-4446d780-d7a1-11e8-807f-8faa0ddf4276.png">
<img width="1680" alt="screen shot 2018-10-24 at 3 14 34 pm" src="https://user-images.githubusercontent.com/12723038/47465310-46109b00-d7a1-11e8-8efc-a660919beef7.png">
