### PR TITLE
MasterSlave DM generates ClientID at the first call - third item in issue #294

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
@@ -37,16 +37,21 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultSapphirePolicy 
     public abstract static class ClientBase extends DefaultClientPolicy {
         private static Logger logger = Logger.getLogger(ClientBase.class.getName());
         private final AtomicLong SeqGenerator = new AtomicLong();
-        private final UUID CLIENT_ID;
+        private transient UUID CLIENT_ID;
 
-        public ClientBase() {
-            CLIENT_ID = UUID.randomUUID();
-        }
+        public ClientBase() {}
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
             final int MAX_RETRY = 5;
             int retryCnt = 1, waitInMilliseconds = 50;
+
+            if (CLIENT_ID == null) {
+                // This ensures client ID is generated only after the first RPC call; thus,
+                // preventing different clients using the same ID (e.g., Group policy making a call)
+                CLIENT_ID = UUID.randomUUID();
+            }
+
             GroupBase group = (GroupBase) getGroup();
             MethodInvocationRequest.MethodType type = MethodInvocationRequest.MethodType.MUTABLE;
 


### PR DESCRIPTION
What it does: 
ClientID for MasterSlave DM is generated when onRPC is called the first time instead of during DM chain creation time.

Note that title of this PR did not mention 'fix' since this PR only addresses 3) of the issue and mentioning 'fix' will close the issue.

This PR resolves 3rd item in the following issue #294:
https://github.com/Huawei-PaaS/DCAP-Sapphire/issues/294

Detail:
The issue was triggered because the chain contains the same clientId; hence, whether it was group policy or application client, they were using the same clientID if they used the same serverStub node from previous policy (e.g, DHT in DHT+MasterSlave). This is because serverStub referenes the same nextClient which is MasterSlave client in this example. By making a calling to onRpc to generate the ID, ID will stay with the client that invoked onRpc. When it gets the serverStub again next time, it will generates the new client ID. This is because Client ID in the client policy of the group stub is not updated.

<img width="1557" alt="screen shot 2018-10-24 at 5 47 42 pm" src="https://user-images.githubusercontent.com/12723038/47470477-c8f21f80-d7ba-11e8-9447-8ae0b38888ff.png">
<img width="1680" alt="screen shot 2018-10-24 at 6 03 33 pm" src="https://user-images.githubusercontent.com/12723038/47470480-cbed1000-d7ba-11e8-8871-0694662e0d67.png">
<img width="1680" alt="screen shot 2018-10-24 at 6 10 07 pm" src="https://user-images.githubusercontent.com/12723038/47470485-ce4f6a00-d7ba-11e8-9523-9487c9cfe949.png">
<img width="1680" alt="screen shot 2018-10-24 at 6 12 38 pm" src="https://user-images.githubusercontent.com/12723038/47470488-d14a5a80-d7ba-11e8-878c-d1b6e52a9953.png">
