### PR TITLE
Implements Direct call for DM methods. fixes #346 

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/compiler/AppStub.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/compiler/AppStub.java
@@ -32,6 +32,12 @@ public final class AppStub extends Stub {
         return ms;
     }
 
+    /**
+     * Method defined for overriding Base class abstract method. Is a dummy method in AppStub class,
+     * as no handling is needed in the AppStub, as this method handles DM class methods.
+     *
+     * @return List of DM methods
+     */
     @Override
     public TreeSet<MethodStub> getDMMethods() {
         TreeSet<MethodStub> ms = new TreeSet<MethodStub>();
@@ -149,6 +155,8 @@ public final class AppStub extends Stub {
     /**
      * Returns the stub implementation code section source for the methods
      *
+     * @param m : Method for which stub implementation code is needed.
+     * @param isDMMethod : Is not used as the same is not needed in AppStub class.
      * @return Stub implementation code for the methods.
      */
     @Override

--- a/sapphire/sapphire-core/src/main/java/sapphire/compiler/PolicyStub.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/compiler/PolicyStub.java
@@ -16,7 +16,7 @@ public class PolicyStub extends Stub {
     public TreeSet<MethodStub> getMethods() {
         TreeSet<MethodStub> ms = new TreeSet<MethodStub>();
 
-        Class<?> ancestorClass = stubClass.getSuperclass();
+        Class<?> ancestorClass = stubClass;
         while ((!ancestorClass.getSimpleName().equals("SapphireServerPolicyLibrary"))
                 && (!ancestorClass.getSimpleName().equals("SapphireGroupPolicyLibrary"))) {
 
@@ -33,13 +33,19 @@ public class PolicyStub extends Stub {
         return ms;
     }
 
+    /**
+     * Method checks whether onRPC method has been overriden in the DM class. If overridden, then
+     * the onRPC method has to be Directly invoked on the DM instead of following the chain in the
+     * case of MultiDM scenarios.
+     *
+     * @return List of DM Class Methods
+     */
     @Override
     public TreeSet<MethodStub> getDMMethods() {
         TreeSet<MethodStub> ms = new TreeSet<MethodStub>();
-
         Class<?> dmClass = stubClass;
         for (Method m : dmClass.getDeclaredMethods()) {
-            if (Modifier.isPublic(m.getModifiers())) {
+            if (Modifier.isPublic(m.getModifiers()) && m.getName().equals("onRPC")) {
                 ms.add(new MethodStub((Method) m));
             }
         }

--- a/sapphire/sapphire-core/src/main/java/sapphire/compiler/Stub.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/compiler/Stub.java
@@ -116,7 +116,12 @@ public abstract class Stub implements RmicConstants {
     private String getMethodImplementations() {
         StringBuilder buffer = new StringBuilder();
         for (Iterator<MethodStub> i = methods.iterator(); i.hasNext(); ) {
-            buffer.append(EOLN + i.next().getStubImpl(false));
+            MethodStub m = i.next();
+            if (m.name.equals("onRPC")) {
+                buffer.append(EOLN + m.getStubImpl(false));
+            } else {
+                buffer.append(EOLN + m.getStubImpl(true));
+            }
         }
         return buffer.toString();
     }


### PR DESCRIPTION
This PR updates the DM Stubs generated so that the DM methods are directly invoked without going through the DM chain.
This simplifies the method invocations in the case of Multi-DM chain scenarios.