### PR TITLE
Delete sapphire object issue fixed. And load balance master slave DM based sapphire object destroy issue fixed

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -342,7 +342,19 @@ public class OMSServerImpl implements OMSServer {
             Map<String, SapphirePolicyConfig> configMap)
             throws RemoteException, ClassNotFoundException, KernelObjectNotCreatedException,
                     SapphireObjectNotFoundException {
-        return Sapphire.createGroupPolicy(policyClass, sapphireObjId, configMap);
+        SapphirePolicy.SapphireGroupPolicy group =
+                Sapphire.createGroupPolicy(policyClass, sapphireObjId, configMap);
+
+        /* TODO: This rootGroupPolicy is used in sapphire object deletion. Need to handle for multiDM case. In case of
+        multiDM, multiple group policy objects are created in DM chain establishment. Currently, just ensuring not to
+        overwrite the outermost DM's group policy reference(i.e., first created group policy in chain).So that deletion
+        works for single DM case.
+         */
+        if (objectManager.getRootGroupPolicy(sapphireObjId) == null) {
+            objectManager.setRootGroupPolicy(sapphireObjId, group);
+        }
+
+        return group;
     }
 
     public static void main(String args[]) {

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/SapphireInstanceManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/SapphireInstanceManager.java
@@ -71,6 +71,14 @@ public class SapphireInstanceManager {
     }
 
     /**
+     * Gets the root group policy object of this sapphire instance
+     * @return Sapphire Group Policy Object
+     */
+    public SapphireGroupPolicy getRootGroupPolicy() {
+        return rootGroupPolicy;
+    }
+
+    /**
      * Gets the event handler of this sapphire instance
      *
      * @return Returns event handler

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/SapphireObjectManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/SapphireObjectManager.java
@@ -60,6 +60,21 @@ public class SapphireObjectManager {
         instance.setInstanceDispatcher(dispatcher);
     }
 
+    /**
+     * Gets the root group policy object with sapphire object id
+     * @param oid
+     * @return Sapphire Group Policy Object
+     * @throws SapphireObjectNotFoundException
+     */
+    public SapphirePolicy.SapphireGroupPolicy getRootGroupPolicy(SapphireObjectID oid)
+            throws SapphireObjectNotFoundException {
+        SapphireInstanceManager instanceManager = sapphireObjects.get(oid);
+        if (instanceManager == null) {
+            throw new SapphireObjectNotFoundException("Not a valid Sapphire object id.");
+        }
+        return instanceManager.getRootGroupPolicy();
+    }
+
     public void setRootGroupPolicy(
             SapphireObjectID oid, SapphirePolicy.SapphireGroupPolicy rootGroupPolicy)
             throws SapphireObjectNotFoundException {

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
@@ -39,11 +39,6 @@ public class LoadBalancedMasterSlaveSyncPolicy extends LoadBalancedMasterSlaveBa
         }
 
         @Override
-        public void initialize() {
-            this.start();
-        }
-
-        @Override
         public void start() {
             logger = Logger.getLogger(ServerPolicy.class.getName());
             GroupPolicy groupPolicy = (GroupPolicy) getGroup();
@@ -141,6 +136,17 @@ public class LoadBalancedMasterSlaveSyncPolicy extends LoadBalancedMasterSlaveBa
         protected void finalize() throws Throwable {
             if (commitExecutor != null) {
                 commitExecutor.close();
+                commitExecutor = null;
+            }
+
+            if (processor != null) {
+                processor.close();
+                processor = null;
+            }
+
+            if (stateMgr != null) {
+                stateMgr.halt();
+                stateMgr = null;
             }
             super.finalize();
         }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/masterslave/Processor.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/masterslave/Processor.java
@@ -174,6 +174,7 @@ public class Processor implements Closeable {
                             "processor shut down time out after {0} milliseconds",
                             config.getShutdownGracePeriodInMillis());
                 }
+                processor = null;
             } catch (Exception e) {
                 logger.log(
                         Level.SEVERE,

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/masterslave/StateManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/masterslave/StateManager.java
@@ -191,6 +191,7 @@ public final class StateManager {
                 lockingExecutor.shutdown();
                 lockingExecutor.awaitTermination(
                         config.getShutdownGracePeriodInMillis(), TimeUnit.MILLISECONDS);
+                lockingExecutor = null;
             }
         } catch (InterruptedException e) {
             logger.log(
@@ -214,6 +215,10 @@ public final class StateManager {
             logger.log(Level.FINE, "unable to {0} lock: {1}", new Object[] {mode, e});
         }
         return lockObtained;
+    }
+
+    public void halt() {
+        shutdownLockingExecutor();
     }
 
     @Override


### PR DESCRIPTION
Following issues are fixed with this PR.
1. Sapphire object deletion was not happening because `rootGroupPolicy` of `SapphireInstanceManager` was not set for inner SOs.
2. LoadbalanceMasterSlaveSync DM was not stopping its Executors which were running upon onDestroy().
3. start() for each server policy is called from groupPolicy's onCreate() upon replicate/pin and again from initialize(). Lead to dangling executors being run forever for the old instance.

Note: SO with Multi DM deletion issue is not fixed in this PR.