### PR TITLE
Consistent order of object addition to object manager after chain is copied.

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -148,11 +148,6 @@ public class KernelServerImpl implements KernelServer {
             serverPolicy.onCreate(serverPolicy.getGroup(), serverPolicy.getConfigMap());
         }
 
-        // TODO (9/27/2018, Sungwook): Move uncoalesce logic to separate loop at the end of code.
-        objectManager.addObject(oid, object);
-        object.uncoalesce();
-        oms.registerKernelObject(oid, host);
-
         // To add Kernel Object to local object manager
         Serializable realObj = object.getObject();
 
@@ -173,10 +168,6 @@ public class KernelServerImpl implements KernelServer {
                 oms.setSapphireReplicaDispatcher(serverPolicy.getReplicaId(), policyHandler);
 
                 KernelOID koid = serverPolicy.$__getKernelOID();
-                if (oid == koid) {
-                    continue;
-                }
-
                 KernelObject newko = new KernelObject(serverPolicy);
 
                 objectManager.addObject(koid, newko);
@@ -194,19 +185,6 @@ public class KernelServerImpl implements KernelServer {
                     logger.severe(exceptionMsg);
                     throw new RemoteException(exceptionMsg, e);
                 }
-            }
-
-            // First server policy is initialized at the end as the order is executed backwards from
-            // app object.
-            try {
-                firstServerPolicy.initialize();
-            } catch (Exception e) {
-                String exceptionMsg =
-                        String.format(
-                                "Initialization for first server policy failed at copyKernelObject for KernelObject(%d)",
-                                oid.getID());
-                logger.severe(exceptionMsg);
-                throw new RemoteException(exceptionMsg, e);
             }
         } else {
             logger.log(Level.WARNING, "Added " + oid.getID() + " as unknown type.");


### PR DESCRIPTION
This corrects the logic and implementation of adding objects to the object manager after copying the chain to the target server. It will make object addition consistent. Tested fully.

This takes care of the following todo:
// TODO (9/27/2018, Sungwook): Move uncoalesce logic to separate loop at the end of code.

Unit & integration tests
<img width="1557" alt="screen shot 2018-10-27 at 2 21 07 pm" src="https://user-images.githubusercontent.com/12723038/47609625-5b7f0280-d9f7-11e8-80d3-554b4aa822b1.png">

KVstore with 4 kernel servers
<img width="1680" alt="screen shot 2018-10-27 at 2 24 11 pm" src="https://user-images.githubusercontent.com/12723038/47609626-5fab2000-d9f7-11e8-92c0-f6ff76c123fa.png">

HanksTdo with 1 kernel server (this is due to multi-server situation broken for DHT2+Consensus until onMigration change comes).
<img width="1680" alt="screen shot 2018-10-27 at 2 26 57 pm" src="https://user-images.githubusercontent.com/12723038/47609628-62a61080-d9f7-11e8-8aca-7cb9db76796b.png">

MinnieTwitter
<img width="1680" alt="screen shot 2018-10-27 at 2 31 12 pm" src="https://user-images.githubusercontent.com/12723038/47609629-65086a80-d9f7-11e8-95cb-15569d5036eb.png">
