### PR TITLE
Disable genStubs for examples/HanksTodoRuby properly, fixes #376

### DIFF
--- a/sapphire/dependencies/build.gradle
+++ b/sapphire/dependencies/build.gradle
@@ -1,6 +1,6 @@
 // Disable stub generation for dependencies
 subprojects {
     genStubs {
-        main = ''
+        onlyIf() { false } // Disable
     }
 }

--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -7,12 +7,7 @@ apply plugin: 'java'
 */
 // Customize app stub generation for this example - disable it for now - see above.
 genStubs {
-    def src = "/tmp"
-    def dst = "/tmp/stubs"
-    def pkg = ''
-    args src, pkg, dst
-    // outputs.dir '' // Declare outputs, so gradle will run if they have been changed
-    // inputs.dir ''   // Declare inputs, so gradle will run if they have been changed
+    onlyIf() { false } // Disable
 }
 // Customize stub compilation for this example
 compileStubs {


### PR DESCRIPTION
$ ./gradlew examples:hanksTodoRuby:genStubs

> Configure project :

> Task :sapphire-core:compileJava

> Task :sapphire-core:genStubs

BUILD SUCCESSFUL in 3s
