### PR TITLE
[Fix Issue 379] Delete empty examples/settings.gradle

### DIFF
--- a/sapphire/examples/settings.gradle
+++ b/sapphire/examples/settings.gradle
@@ -1,3 +1,0 @@
-// Settings specific to all examples subprojects go here.
-// NOTE: Unfortunately gradle doesn't seem to handle imports in this file correctly - not sure why?
-//       So imports are still explicitly in the root project's settings.gradle file.


### PR DESCRIPTION
Fix Issue #379.

Not sure what the purpose of having a `settings.gradle` in `DCAP_Sapphire/sapphire/examples` dir. Deleting it allows us to build in subprojects.

<img width="900" alt="screen shot 2018-10-28 at 6 43 05 pm" src="https://user-images.githubusercontent.com/1460413/47625281-6f069800-dae1-11e8-9346-3e1391e98b64.png">

 