### PR TITLE
hanksTodoRuby fix with updated GraalObjectStub #398

### DIFF
--- a/sapphire/examples/hanksTodoRuby/src/main/java/sapphire/appexamples/hankstodo/stubs/TodoListManager_Stub.java
+++ b/sapphire/examples/hanksTodoRuby/src/main/java/sapphire/appexamples/hankstodo/stubs/TodoListManager_Stub.java
@@ -1,6 +1,6 @@
 package sapphire.appexamples.hankstodo.stubs;
 
-public final class TodoListManager_Stub extends sapphire.common.GraalObject implements sapphire.common.AppObjectStub {
+public final class TodoListManager_Stub extends sapphire.common.GraalObject implements sapphire.common.GraalAppObjectStub {
 
     sapphire.policy.SapphirePolicy.SapphireClientPolicy $__client = null;
     boolean $__directInvocation = false;
@@ -16,7 +16,7 @@ public final class TodoListManager_Stub extends sapphire.common.GraalObject impl
     }
 
     public Object $__clone() throws CloneNotSupportedException {
-        return super.clone();
+        return clone();
     }
 
     public void $__initializeGraal(sapphire.app.SapphireObjectSpec spec, java.lang.Object[] params){
@@ -26,6 +26,10 @@ public final class TodoListManager_Stub extends sapphire.common.GraalObject impl
             throw new java.lang.RuntimeException(e);
         }
 
+    }
+
+    public boolean $__directInvocation(){
+        return $__directInvocation;
     }
 
     public java.lang.Object newTodoList(Object... args) {


### PR DESCRIPTION
This PR fix broken `TodoListManager_Stub` stub after replication fix in #373.

UT Report
![hankstodorubyissuefixut](https://user-images.githubusercontent.com/9818606/47786199-07df2280-dd31-11e8-82ce-3a0c3f46e020.png)
 Report:

App Report:
![hanktodorubystubfix](https://user-images.githubusercontent.com/9818606/47786201-09104f80-dd31-11e8-92c4-c7164270c3bc.png)
