### PR TITLE
[Partial Fix to Issue #391] Increase max concurrent rate in scaleup DM

### DIFF
--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/complex-dm/ScaleUpFrontend.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/complex-dm/ScaleUpFrontend.yaml
@@ -4,7 +4,7 @@
 constructorName: null
 dmList:
 - configs:
-  - !!sapphire.policy.scalability.LoadBalancedFrontendPolicy$Config {maxConcurrentReq: 1}
+  - !!sapphire.policy.scalability.LoadBalancedFrontendPolicy$Config {maxConcurrentReq: 10}
   name: sapphire.policy.scalability.ScaleUpFrontendPolicy
 javaClassName: sapphire.demo.KVStore
 lang: java


### PR DESCRIPTION
 This PR is a partial fix to issue #391. It prevents the intermittent integration test failure of scaleup DM by increasing the max concurrent rate.  

This is not a root cause fix. Someone still needs to fix the scaleup integration test.

<img width="607" alt="screen shot 2018-11-01 at 10 34 51 pm" src="https://user-images.githubusercontent.com/1460413/47895576-5e7a5880-de26-11e8-8cd7-cbdd43de49a1.png">
