### PR TITLE
Cleaned up the extractAppStub fixes #261

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
@@ -653,27 +653,31 @@ public class Sapphire {
 
     private static AppObjectStub getAppStub(
             SapphireObjectSpec spec, SapphireServerPolicy serverPolicy, Object[] args)
-            throws IllegalAccessException, CloneNotSupportedException {
+            throws CloneNotSupportedException {
         AppObjectStub appObjectStub = serverPolicy.$__initialize(spec, args);
         // TODO(multi-lang): We may need to create a clone for non-java app object stub.
-        return spec.getLang() == Language.java ? extractAppStub(appObjectStub) : appObjectStub;
+        return spec.getLang() == Language.java ? createClientAppStub(appObjectStub) : appObjectStub;
     }
 
-    public static AppObjectStub extractAppStub(AppObjectStub appObject)
-            throws CloneNotSupportedException, IllegalAccessException {
-        // Return shallow copy of the kernel object
-        AppObjectStub obj = (AppObjectStub) appObject.$__clone();
+    public static AppObjectStub createClientAppStub(AppObjectStub template)
+            throws CloneNotSupportedException {
+        AppObjectStub obj = (AppObjectStub) template.$__clone();
 
-        // Replace all superclass fields with null
+        // clean up inherited fields from application object to be GC'd
         Field[] fields = obj.getClass().getSuperclass().getFields();
         for (Field f : fields) {
-            f.setAccessible(true);
-            f.set(obj, null);
+            if (!f.getType().isPrimitive()) {
+                f.setAccessible(true);
+                try {
+                    f.set(obj, null);
+                } catch (IllegalAccessException e) {
+                    // We set accessible so should not happen, but also
+                    // only for performance, so not critical to succeed
+                }
+            }
         }
 
-        // Replace the values in stub with new values - is this necessary?
-
-        // Update the directInvocation
+        // Route requests through DM
         obj.$__initialize(false);
         return obj;
     }

--- a/sapphire/sapphire-core/src/test/java/sapphire/common/BaseTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/common/BaseTest.java
@@ -194,7 +194,8 @@ public class BaseTest {
                                             invocation.getArguments()[1];
                             Object[] args = (Object[]) invocation.getArguments()[2];
 
-                            return Sapphire.extractAppStub(serverPolicy.$__initialize(spec, args));
+                            return Sapphire.createClientAppStub(
+                                    serverPolicy.$__initialize(spec, args));
                         }
                         if (!(invocation.getMethod().getName().equals("getPolicyStub")))
                             return invocation.callRealMethod();

--- a/sapphire/sapphire-core/src/test/java/sapphire/common/MultiPolicyChainBaseTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/common/MultiPolicyChainBaseTest.java
@@ -177,7 +177,8 @@ public class MultiPolicyChainBaseTest {
                                             invocation.getArguments()[1];
                             Object[] args = (Object[]) invocation.getArguments()[2];
 
-                            return Sapphire.extractAppStub(serverPolicy.$__initialize(spec, args));
+                            return Sapphire.createClientAppStub(
+                                    serverPolicy.$__initialize(spec, args));
                         }
                         if (!(invocation.getMethod().getName().equals("getPolicyStub")))
                             return invocation.callRealMethod();


### PR DESCRIPTION
Cleaned up the extractAppStub method in Sapphire runtime to be better documented and support primitive fields. Address issue #261.

Build Log:
ackeris-MacBook-Pro:sapphire ackeri$ ./gradlew build

> Configure project :
Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0
        at build_3o84lprwcmtj2uu46yivz4vm$_run_closure2$_closure8.doCall(/Users/ackeri/Code/DCAP-Sapphire/sapphire/build.gradle:113)

> Task :sapphire-core:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :sapphire-core:genStubs
Nov 02, 2018 11:13:56 AM sapphire.compiler.StubGenerator main
INFO: Generated stubs. src: /Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/build/classes/java/main/sapphire/policy, package: sapphire.policy, dst: /Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs

> Task :sapphire-core:compileStubs
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :sapphire-core:genGraalStub
Nov 02, 2018 11:13:58 AM sapphire.compiler.GraalStubGenerator generateStub
INFO: Generating stub for class Student in language js
got key id
got key name
got key buddies
Nov 02, 2018 11:13:58 AM sapphire.compiler.GraalStubGenerator generateStub
WARNING: Stub already exists, will be overwritten. /Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/test/java/sapphire/stubs/Student_Stub.java
Nov 02, 2018 11:14:00 AM sapphire.compiler.GraalStubGenerator generateStub
INFO: Could not find class Student in language python
Nov 02, 2018 11:14:02 AM sapphire.compiler.GraalStubGenerator generateStub
INFO: Could not find class Student in language ruby

/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/test/java/sapphire/stubs/Student_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/test/java/sapphire/common/BaseTest.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/test/java/sapphire/common/MultiPolicyChainBaseTest.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/OptConcurrentTransactPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/PeriodicCheckpointPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DHTPolicy$DHTGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ImmutablePolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DefaultSapphirePolicy$DefaultServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DHTPolicy2$DHTGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ExplicitMigrationPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DurableOnDemandCachedList$DurableOnDemandCachedListGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ExplicitCachingPolicy$ExplicitCachingServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/SerializableRPCPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ShiftPolicy$ShiftServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/CacheLeasePolicy$CacheLeaseGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DurableOnDemandCachedList$DurableOnDemandCachedListServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/LoadBalancedMasterSlaveSyncPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/TwoPCCohortPolicy$TwoPCCohortServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/TwoPCExtResourceCohortPolicy$TwoPCExtResourceCohortServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ConsensusRSMPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/AtLeastOnceRPCPolicy$AtLeastOnceRPCServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/OptConcurrentTransactPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/LoadBalancedFrontendPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/SerializableRPCPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ExplicitCheckpointPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/WriteThroughCachePolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DHTPolicy2$DHTServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DurableSerializableRPCPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/LoadBalancedMasterSlaveSyncPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ImmutablePolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ExplicitCachingPolicy$ExplicitCachingGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/TwoPCExtResourceCohortPolicy$TwoPCExtResourceCohortGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/AtLeastOnceRPCPolicy$AtLeastOnceRPCGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ScaleUpFrontendPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/LockingTransactionPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DHTPolicy$DHTServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/CacheLeasePolicy$CacheLeaseServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/WriteThroughCachePolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ExplicitMigrationPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/LockingTransactionPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/TwoPCCoordinatorPolicy$TwoPCCoordinatorServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ExplicitCheckpointPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DurableSerializableRPCPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/DefaultSapphirePolicy$DefaultGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/LoadBalancedFrontendPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/TwoPCCoordinatorPolicy$TwoPCCoordinatorGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ScaleUpFrontendPolicy$GroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ShiftPolicy$ShiftGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/TwoPCCohortPolicy$TwoPCCohortGroupPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/PeriodicCheckpointPolicy$ServerPolicy_Stub.java: formatted successfully
/Users/ackeri/Code/DCAP-Sapphire/sapphire/sapphire-core/src/main/java/sapphire/policy/stubs/ConsensusRSMPolicy$ServerPolicy_Stub.java: formatted successfully

> Task :sapphire-core:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :examples:helloworld:genStubs
Nov 02, 2018 11:14:05 AM sapphire.compiler.StubGenerator main
INFO: Generated stubs. src: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/helloworld/build/classes/java/main/sapphire/appexamples/helloworld/, package: sapphire.appexamples.helloworld, dst: src/main/java/sapphire/appexamples/helloworld/stubs/

> Task :examples:example-minnietwitter:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :examples:example-minnietwitter:genStubs
Nov 02, 2018 11:15:07 AM sapphire.compiler.StubGenerator main
INFO: Generated stubs. src: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/example-minnietwitter/build/classes/java/main/sapphire/appexamples/minnietwitter, package: sapphire.appexamples.minnietwitter, dst: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/example-minnietwitter/src/main/java/sapphire/appexamples/minnietwitter/stubs

> Task :examples:example-minnietwitter:compileStubs
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :examples:hanksTodo:compileJava
Note: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/stubs/TodoList_Stub.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :examples:hanksTodo:genStubs
Nov 02, 2018 11:15:08 AM sapphire.compiler.StubGenerator main
INFO: Generated stubs. src: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/hanksTodo/build/classes/java/main/sapphire/appexamples/hankstodo, package: sapphire.appexamples.hankstodo, dst: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/stubs/

> Task :examples:hanksTodo:compileStubs
Note: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/hanksTodo/src/main/java/sapphire/appexamples/hankstodo/stubs/TodoList_Stub.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :examples:kvstore:genStubs
Nov 02, 2018 11:15:08 AM sapphire.compiler.StubGenerator main
INFO: Generated stubs. src: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/kvstore/build/classes/java/main/sapphire/demo/, package: sapphire.demo, dst: /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/kvstore/src/main/java/sapphire/demo/stubs/

> Task :examples:kvstorejs:genStubs
Nov 02, 2018 11:15:09 AM sapphire.compiler.GraalStubGenerator generateStub
INFO: Generating stub for class KeyValueStore in language js
got key map
Nov 02, 2018 11:15:09 AM sapphire.compiler.GraalStubGenerator generateStub
WARNING: Stub already exists, will be overwritten. /Users/ackeri/Code/DCAP-Sapphire/sapphire/examples/kvstorejs/src/main/java/sapphire/appdemo/stubs/KeyValueStore_Stub.java
Nov 02, 2018 11:15:12 AM sapphire.compiler.GraalStubGenerator generateStub
INFO: Could not find class KeyValueStore in language python
Nov 02, 2018 11:15:14 AM sapphire.compiler.GraalStubGenerator generateStub
INFO: Could not find class KeyValueStore in language ruby


BUILD SUCCESSFUL in 1m 25s
49 actionable tasks: 27 executed, 22 up-to-date