### PR TITLE
Disable stub generation for all dependencies and examples parent project,  fixes #411 , fixes #410

### DIFF
--- a/sapphire/dependencies/build.gradle
+++ b/sapphire/dependencies/build.gradle
@@ -1,6 +1,10 @@
-// Disable stub generation for dependencies
-subprojects {
+// Disable stub generation for dependencies and all it's sub-projects
+allprojects {
     genStubs {
+        onlyIf() { false } // Disable
+    }
+
+    compileStubs {
         onlyIf() { false } // Disable
     }
 }

--- a/sapphire/examples/build.gradle
+++ b/sapphire/examples/build.gradle
@@ -55,3 +55,12 @@ subprojects {
         inputs.dir compileStubs
     }
 }
+
+// For the parent examples project itself, we disable inherited tasks that don't make sense at this level.
+genStubs {
+    onlyIf() { false } // Disable
+}
+
+compileStubs {
+    onlyIf() { false } // Disable
+}


### PR DESCRIPTION
We should not try to generate stubs for dependencies or any of it's subprojects. 
Similarly we should not try to generate stubs for the parent examples project, only for it's subprojects.

This also fixes #411 