### PR TITLE
Simple log change for Consensus.

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/Server.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/util/consensus/raft/Server.java
@@ -353,7 +353,7 @@ public class Server
     }
 
     public Object applyToStateMachine(Object operation) throws java.lang.Exception {
-        logger.info(String.format("%s: applyToStateMachine(%s)", pState.myServerID, operation));
+        logger.fine(String.format("%s: applyToStateMachine(%s)", pState.myServerID, operation));
         if (vState.getState() == Server.State.LEADER) {
             return leader.applyToStateMachine(operation);
         } else {


### PR DESCRIPTION
Consensus shows appToStateMachine in the log which is not helpful in debugging for most of the situations with too many messages. Adjust the level to fine.

<img width="962" alt="screen shot 2018-11-08 at 4 10 20 pm" src="https://user-images.githubusercontent.com/12723038/48235010-d38ee600-e370-11e8-8ebb-dee678d09790.png">
