### PR TITLE
Add NodeSelectorSpec to integration tests, fixes #388

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -143,8 +143,11 @@ task compileGraalStub(type: JavaCompile) {
 
 tasks.googleJavaFormat.mustRunAfter genStubs
 tasks.googleJavaFormat.mustRunAfter genGraalStub
-compileGraalStub.mustRunAfter genGraalStub
+
+compileGraalStub.dependsOn genGraalStub
 compileTestJava.dependsOn compileGraalStub
+tasks.googleJavaFormat.dependsOn genStubs
+tasks.googleJavaFormat.dependsOn genGraalStub
 check.dependsOn tasks.googleJavaFormat
 check.dependsOn integTest
 compileJava.dependsOn checkGraalVmVersion

--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/multidm/MultiDMTestCases.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/multidm/MultiDMTestCases.java
@@ -25,10 +25,12 @@ import sapphire.oms.OMSServer;
  */
 public class MultiDMTestCases {
     OMSServer oms;
+    private static String regionName = "";
+    private static String labels[] = {regionName};
 
     @BeforeClass
     public static void bootstrap() throws Exception {
-        startOmsAndKernelServers("");
+        startOmsAndKernelServers(regionName, labels);
     }
 
     @Before

--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/policy/ScaleUpFrontendDMIntegTest.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/policy/ScaleUpFrontendDMIntegTest.java
@@ -31,11 +31,13 @@ import sapphire.policy.scalability.ServerOverLoadException;
 public class ScaleUpFrontendDMIntegTest {
     private static final int TASK_COUNT = 50;
     private static final int PARALLEL_THREAD_COUNT = 5;
+    private static final String regionName = "IND";
+    private static final String[] labels = {regionName};
     OMSServer oms;
 
     @BeforeClass
     public static void bootstrap() throws Exception {
-        startOmsAndKernelServers("IND");
+        startOmsAndKernelServers(regionName, labels);
     }
 
     @Before

--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/policy/SimpleDMIntegrationTest.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/policy/SimpleDMIntegrationTest.java
@@ -27,7 +27,6 @@ public class SimpleDMIntegrationTest {
     private static String RESOURCE_PATH = "specs/simple-dm/";
     private static String RESOURCE_REAL_PATH;
     private static String kstIp = "127.0.0.1";
-    private static int ksPort = 22345;
     private OMSServer oms;
     private SapphireObjectID sapphireObjId = null;
 
@@ -305,7 +304,7 @@ public class SimpleDMIntegrationTest {
         */
 
         /* Migrate SO to first server and verify the value */
-        store.migrateObject(new InetSocketAddress(ksIp, ks1Port));
+        store.migrateObject(new InetSocketAddress(ksIp, ksPort[0]));
         Assert.assertEquals(value0, store.get(key0));
 
         /* Add another key-value entry and verify */
@@ -315,7 +314,7 @@ public class SimpleDMIntegrationTest {
         Assert.assertEquals(value1, store.get(key1));
 
         /* Migrate SO to second server and verify the values */
-        store.migrateObject(new InetSocketAddress(ksIp, ks2Port));
+        store.migrateObject(new InetSocketAddress(ksIp, ksPort[1]));
         Assert.assertEquals(value0, store.get(key0));
         Assert.assertEquals(value1, store.get(key1));
     }

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNConsensus.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNConsensus.yaml
@@ -10,6 +10,9 @@ dmList:
   name: sapphire.policy.dht.DHTPolicy
 - configs: []
   name: sapphire.policy.replication.ConsensusRSMPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNMasterSlave.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNMasterSlave.yaml
@@ -10,6 +10,9 @@ dmList:
   name: sapphire.policy.dht.DHTPolicy
 - configs: []
   name: sapphire.policy.scalability.LoadBalancedMasterSlaveSyncPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNConsensus.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNConsensus.yaml
@@ -8,6 +8,9 @@ dmList:
   name: sapphire.policy.dht.DHTPolicy
 - configs: []
   name: sapphire.policy.replication.ConsensusRSMPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNMasterSlave.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNMasterSlave.yaml
@@ -8,6 +8,9 @@ dmList:
   name: sapphire.policy.dht.DHTPolicy
 - configs: []
   name: sapphire.policy.scalability.LoadBalancedMasterSlaveSyncPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/AtLeastOnceDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/AtLeastOnceDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.atleastoncerpc.AtLeastOnceRPCPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/CacheLease.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/CacheLease.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.cache.CacheLeasePolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DHTDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DHTDM.yaml
@@ -5,6 +5,9 @@ dmList:
 - configs:
   - !!sapphire.policy.dht.DHTPolicy$Config {numOfShards: 3}
   name: sapphire.policy.dht.DHTPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DurableSerializableRPCDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DurableSerializableRPCDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.checkpoint.durableserializable.DurableSerializableRPCPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCachingDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCachingDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.cache.explicitcaching.ExplicitCachingPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCheckpointDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCheckpointDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.checkpoint.explicitcheckpoint.ExplicitCheckpointPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitMigrationDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitMigrationDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.mobility.explicitmigration.ExplicitMigrationPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/Immutable.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/Immutable.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.primitive.ImmutablePolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/LockingTransaction.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/LockingTransaction.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.serializability.LockingTransactionPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/NoDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/NoDM.yaml
@@ -2,6 +2,9 @@
 !!sapphire.app.SapphireObjectSpec
 constructorName: null
 javaClassName: sapphire.demo.KVStore
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 lang: java
 name: null
 sourceFileLocation: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/OptConcurrentTransactionDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/OptConcurrentTransactionDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.serializability.OptConcurrentTransactPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/PeriodicCheckpointDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/PeriodicCheckpointDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.checkpoint.periodiccheckpoint.PeriodicCheckpointPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/SerializableRPCDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/SerializableRPCDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.serializability.SerializableRPCPolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/WriteThroughCacheDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/WriteThroughCacheDM.yaml
@@ -5,6 +5,9 @@ constructorName: null
 dmList:
 - configs: []
   name: sapphire.policy.cache.WriteThroughCachePolicy
+nodeSelectorSpec:
+  andLabels: !!set {}
+  orLabels: !!set {}
 javaClassName: sapphire.demo.KVStore
 lang: java
 name: null


### PR DESCRIPTION
Still needs some code cleanup, but it currently passes all tests.

NodeSelectorSpecs in integration test SapphireObjectSpecs are currently empty, but the NodeSelectorSpec code is exercised. Next step it to add appropriate node labels and andLabels, orLabels to NodeSelectorSpecs.

