### PR TITLE
Fix Issue if no matching label are received from the app

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
@@ -208,6 +208,11 @@ public class KernelServerManager {
         }
         // if nodeSelector is null then returns all the kernelserver's addresses
         List<InetSocketAddress> hosts = getServers(nodeSelector);
+
+        if (hosts.size() <= 0) {
+            logger.log(Level.SEVERE, "Could not find kernel server forthe given requirements");
+            return null;
+        }
         // In future we can consider some other specific things to select the
         // best one among the list
         return hosts.get(randgen.nextInt(hosts.size()));

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -185,7 +185,7 @@ public class OMSServerImpl implements OMSServer {
         InetSocketAddress host = serverManager.getBestSuitableServer(spec);
         if (host == null) {
             throw new SapphireObjectCreationException(
-                    "Failed to create sapphire object. Kernel server is not available in the region");
+                    "Failed to create sapphire object. Kernel server is not available  with the given requirements");
         }
 
         /* Get the kernel server stub */


### PR DESCRIPTION
If the app sends no matching labels then currently  we are throwing the IllegalArgumentException because of  the  return hosts.get(randgen.nextInt(hosts.size()));  but we supposed to validate the hosts and return SapphireObjectCreationException with the valid reason.