### PR TITLE
Use waitForValue() instead of sleep in integration tests 

### DIFF
--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/kernel/IntegrationTestBase.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/kernel/IntegrationTestBase.java
@@ -7,7 +7,9 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.util.List;
+import org.junit.Assert;
 import sapphire.app.SapphireObjectSpec;
+import sapphire.demo.KVStore;
 
 public class IntegrationTestBase {
     public static String omsIp = "127.0.0.1";
@@ -58,6 +60,31 @@ public class IntegrationTestBase {
         }
     }
 
+    /**
+     * Wait the specified time for a key in the store to have a desired value
+     *
+     * @param store
+     * @param key
+     * @param desiredValue
+     * @param timeoutMs How long to try for, in ms. If <= 0, use the default.
+     * @throws InterruptedException
+     */
+    public static void waitForValue(KVStore store, String key, Object desiredValue, long timeoutMs)
+            throws InterruptedException {
+        long DEFAULT_TIMEOUT_MS = 1000;
+        long DEFAULT_SLEEP_BETWEEN_TRIES_MS = 100;
+        if (timeoutMs <= 0) {
+            timeoutMs = DEFAULT_TIMEOUT_MS;
+        }
+        long startTime = System.currentTimeMillis();
+        Object value;
+        do {
+            sleep(DEFAULT_SLEEP_BETWEEN_TRIES_MS);
+            value = store.get(key);
+        } while (!desiredValue.equals(value)
+                && (System.currentTimeMillis() - startTime) < timeoutMs);
+        Assert.assertEquals(value, desiredValue);
+    }
     /**
      * start the OMS process
      *

--- a/sapphire/sapphire-core/src/integrationTest/java/sapphire/multidm/MultiDMTestCases.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/sapphire/multidm/MultiDMTestCases.java
@@ -53,6 +53,7 @@ public class MultiDMTestCases {
             String key = "k1_" + i;
             String value = "v1_" + i;
             store.set(key, value);
+            waitForValue(store, key, value, -1);
             Assert.assertEquals(value, store.get(key));
         }
     }
@@ -89,8 +90,8 @@ public class MultiDMTestCases {
      *
      * @throws Exception
      */
-    @Ignore("Test is ignored will be removed once the multi DM issues are resolved")
     @Test
+    @Ignore("Test is ignored will be removed once the multi DM issues are resolved")
     public void testAtleastOnceRPCDHTNMasterSlaveMultiDM() throws Exception {
         File file = getResourceFile("specs/multi-dm/AtleastRPCDHTNMasterSlave.yaml");
         SapphireObjectSpec spec = readSapphireSpec(file);
@@ -103,8 +104,8 @@ public class MultiDMTestCases {
      *
      * @throws Exception
      */
-    @Ignore("Test is ignored will be removed once the multi DM issues are resolved")
     @Test
+    @Ignore("Test is ignored will be removed once the multi DM issues are resolved")
     public void testAtleastOnceRPCDHTNConsensusMultiDM() throws Exception {
         File file = getResourceFile("specs/multi-dm/AtleastRPCDHTNConsensus.yaml");
         SapphireObjectSpec spec = readSapphireSpec(file);


### PR DESCRIPTION
I tried to re-enable some integration tests, but they still fail intermittently.  
But at least we can use waitForValue() once we re-enable them.