### PR TITLE
Removed demo hack and added getServersInDefaultRegion

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
@@ -163,6 +163,15 @@ public class KernelServerManager {
         return new ArrayList<String>(regions.keySet());
     }
 
+    /**
+     * Gets default region, which will be the first region in regions HashMap
+     *
+     * @return First region in regions HashMap
+     */
+    public String getDefaultRegion() {
+        return (String) regions.keySet().toArray()[0];
+    }
+
     public KernelServer getServer(InetSocketAddress address) {
         if (address.equals(GlobalKernelReferences.nodeServer.getLocalHost())) {
             return GlobalKernelReferences.nodeServer;

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServer.java
@@ -42,6 +42,8 @@ public interface OMSServer extends Remote {
 
     InetSocketAddress getServerInRegion(String region) throws RemoteException;
 
+    List<InetSocketAddress> getServersInDefaultRegion() throws RemoteException;
+
     List<InetSocketAddress> getServers(NodeSelectorSpec spec) throws RemoteException;
 
     void registerKernelServer(ServerInfo info) throws RemoteException, NotBoundException;

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -139,6 +139,18 @@ public class OMSServerImpl implements OMSServer {
     }
 
     /**
+     * Gets all servers in the default region
+     *
+     * @return List of servers in the default region
+     * @throws RemoteException
+     */
+    public List<InetSocketAddress> getServersInDefaultRegion() throws RemoteException {
+        NodeSelectorSpec spec = new NodeSelectorSpec();
+        spec.addAndLabel(serverManager.getDefaultRegion());
+        return serverManager.getServers(spec);
+    }
+
+    /**
      * Gets all servers matching the specified node selector
      *
      * @param spec

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
@@ -528,7 +528,7 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
                     nodeSelector.addAndLabel(region);
                     serversInRegion = oms().getServers(nodeSelector);
                 } else {
-                    serversInRegion = oms().getServers(null);
+                    serversInRegion = oms().getServersInDefaultRegion();
                 }
             }
             return serversInRegion;

--- a/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/runtime/Sapphire.java
@@ -314,14 +314,6 @@ public class Sapphire {
         previousServerPolicyStub = (KernelObjectStub) serverPolicyStub;
 
         if (nextPoliciesToCreate.size() != 0) {
-            // TODO: hacks for demo
-            if (policyName != null && policyName.contains("DHT")) {
-                if (region == null || region.isEmpty()) {
-                    List<String> regions = GlobalKernelReferences.nodeServer.oms.getRegions();
-                    logger.info("Regions available for DHT: " + regions);
-                    region = regions.get(0);
-                }
-            }
             createPolicy(
                     sapphireObjId,
                     spec,

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/replication/ConsensusRSMPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/replication/ConsensusRSMPolicyTest.java
@@ -109,7 +109,6 @@ public class ConsensusRSMPolicyTest extends BaseTest {
 
     @Before
     public void setUp() throws Exception {
-        this.serversInSameRegion = false;
 
         SapphireObjectSpec spec =
                 SapphireObjectSpec.newBuilder()


### PR DESCRIPTION
Changes in this PR are,
1). The demo hack which was there in Sapphire.java has been removed.
2). Added new OMS interface getServersInDefaultRegion() for retrieving the list of KernelServers when user has not specified the nodeSelector and no region is set.
The first region in the OMS regions HashMap will be considered as the default region.