### PR TITLE
[Part 1 of issue #386] DCAP Sapphire Docker Base Image 

### DIFF
--- a/sapphire/Dockerfile
+++ b/sapphire/Dockerfile
@@ -16,7 +16,7 @@ RUN  wget $GRAAL_URL && \
      tar -xzf $GRAAL_VERSION-linux-amd64.tar.gz && \
      rm $GRAAL_VERSION-linux-amd64.tar.gz
 
-COPY  ./ /DCAP-Sapphire/
+COPY  ./ /DCAP-Sapphire/sapphire
 
 WORKDIR /DCAP-Sapphire/sapphire
 


### PR DESCRIPTION
This is the part 1 of issue #386 Docker file for  creating the Sapphire Base image including all dependencies (Graalvm and Gradle )  and same will be used as Base for Google Cloud Builder  CI and CD.

Graalvm  version & download  url  passed as build argument and build command is  
docker build --build-arg GRAAL_VERSION=graalvm-ce-1.0.0-rc5 --build-arg GRAAL_URL=https://github.com/oracle/graal/releases/download/vm-1.0.0-rc5/graalvm-ce-1.0.0-rc5-linux-amd64.tar.gz  -t  sapphire_base .

When gradle build is executed for  first time  all the dependencies will be downloaded  ,during the download it verifies   Java certificates  to support   this  java is installed at beginning phase and at the last it has been  removed   
Screen shot of failure during certificate verification is attached 
![image](https://user-images.githubusercontent.com/39764768/48925763-6beaa600-eeed-11e8-9e20-9f48b24303e9.png)

After the PR is reviewed the  docker image created needs to be uploaded in the docker hub and same will  be referred as base  for gcd docker file which is  addressed in next PR 

Known issue : 
During the gradle build  random ut's  are failing 

Please find the supporting  screen shot

![screenshot from 2018-11-22 18-56-02](https://user-images.githubusercontent.com/39764768/48925900-fd0e4c80-eeee-11e8-9351-330c28bec464.png)

