### PR TITLE
Fix intermittent failure of unit tests in AtLeastOnceRPCPolicyTest and LockTest, fixes #269 fixes #444

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
@@ -2,8 +2,11 @@ package sapphire.policy.atleastoncerpc;
 
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import sapphire.policy.DefaultSapphirePolicy;
 
 // AtLeastOnceRPC: automatically retry RPCs for bounded amount of time
@@ -29,7 +32,7 @@ public class AtLeastOnceRPCPolicy extends DefaultSapphirePolicy {
         }
 
         @Override
-        public Object onRPC(String method, ArrayList<Object> params) throws Exception {
+        public Object onRPC(String method, ArrayList<Object> params) throws TimeoutException, ExecutionException, InterruptedException {
             FutureTask<?> timeoutTask = null;
             final AtLeastOnceRPCClientPolicy clientPolicy = this;
             final String method_ = method;

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/atleastoncerpc/AtLeastOnceRPCPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/atleastoncerpc/AtLeastOnceRPCPolicyTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import sapphire.policy.SapphirePolicy;
 
@@ -22,7 +23,7 @@ public class AtLeastOnceRPCPolicyTest {
     }
 
     @org.junit.Test
-    public void atleaseOnceRPC() throws Exception {
+    public void atLeastOnceRPC() throws Exception {
         // normal case: call goes well
         when(this.serverPolicy.onRPC("foo", new ArrayList<Object>())).thenReturn("OK");
 
@@ -37,7 +38,7 @@ public class AtLeastOnceRPCPolicyTest {
     }
 
     @org.junit.Test
-    public void atleaseOnceRPCRetries() throws Exception {
+    public void atLeastOnceRPCRetries() throws Exception {
         // transient failure case: first call gets exception; second call goes through
         when(this.serverPolicy.onRPC("foo", new ArrayList<Object>()))
                 .thenThrow(new Exception("transient; should've been resolved after 2 retries"))
@@ -55,7 +56,7 @@ public class AtLeastOnceRPCPolicyTest {
     }
 
     @org.junit.Test(timeout = 500, expected = TimeoutException.class)
-    public void atleaseOnceRPCGivesupAfterTimeout() throws Exception {
+    public void atLeastOnceRPCGivesupAfterTimeout() throws Exception {
         // persistent failure case
         when(this.serverPolicy.onRPC("foo", new ArrayList<Object>()))
                 .thenThrow(new Exception("persistent"));
@@ -64,7 +65,21 @@ public class AtLeastOnceRPCPolicyTest {
         ((AtLeastOnceRPCPolicy.AtLeastOnceRPCClientPolicy) this.clientPolicy).setTimeout(100);
 
         Object result = null;
-        result = this.clientPolicy.onRPC("foo", new ArrayList<Object>());
-        fail("exception should have been thrown; should never come at this point");
+        try {
+            result = this.clientPolicy.onRPC("foo", new ArrayList<Object>());
+        }
+        catch(ExecutionException e) { // Sometimes the TimeoutException is wrapped in one or more ExecutionExceptions.
+            while (e != null) {
+                if (e.getCause() instanceof TimeoutException) {
+                    throw (TimeoutException) e.getCause();
+                }
+                if (e.getCause() instanceof ExecutionException) {
+                    e = (ExecutionException) e.getCause();
+                    continue;
+                }
+                throw e;
+            }
+        }
+        fail("exception should have been thrown; should never get to this point");
     }
 }

--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LockTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/scalability/LockTest.java
@@ -11,39 +11,45 @@ public class LockTest {
 
     @Test
     public void testLockNotExpired() throws Exception {
+        long startTime = System.currentTimeMillis();
         Lock lock = new Lock(clientId, lockTimeoutInMillis);
+        // sleep for less than lockTimeout
         Thread.sleep(Math.max(0, lockTimeoutInMillis - 20));
-        Assert.assertFalse("lock should not be expired", lock.isExpired());
+        // Note: sleep is not accurate, so we check below against currentTimeMillis to avoid false failures.
+        Assert.assertFalse("lock should not expire within timeout",
+                System.currentTimeMillis() - startTime < lockTimeoutInMillis && lock.isExpired());
     }
 
     @Test
     public void testLockExpired() throws Exception {
         Lock lock = new Lock(clientId, lockTimeoutInMillis);
+        // sleep for longer than lockTimeout to let lock expire
         Thread.sleep(lockTimeoutInMillis + 20);
         Assert.assertTrue("lock should have expired", lock.isExpired());
     }
 
     @Test
     public void testLockRenewSucceeded() throws Exception {
+        long startTime = System.currentTimeMillis();
         Lock lock = new Lock(clientId, lockTimeoutInMillis);
+        // sleep for less than lockTimeout
         Thread.sleep(Math.max(0, lockTimeoutInMillis - 20));
-        Assert.assertTrue("renew should succeed", lock.renew(clientId));
+        // Note: sleep is not accurate, so we check below against currentTimeMillis to avoid false failures.
+        Assert.assertTrue("renew should succeed within timeout",
+                System.currentTimeMillis() - startTime < lockTimeoutInMillis && lock.renew(clientId));
     }
 
     @Test
     public void testLockRenewFailedWithInvalidClientId() throws Exception {
         Lock lock = new Lock(clientId, lockTimeoutInMillis);
-        Thread.sleep(Math.max(0, lockTimeoutInMillis - 20));
-        Assert.assertFalse(
-                "renew should fail because client id not match", lock.renew("invalidclient"));
-        Assert.assertEquals(
-                "client id of the lock should not change", clientId, lock.getClientId());
+        Assert.assertFalse("renew should fail because client id does not match", lock.renew("invalidclient"));
+        Assert.assertEquals("client id of the lock should not change", clientId, lock.getClientId());
     }
 
     @Test
     public void testLockRenewFailedWithLockTimeout() throws Exception {
         Lock lock = new Lock(clientId, lockTimeoutInMillis);
-        // sleep for 50 milliseconds to let lock expire
+        // sleep for longer than lockTimeout to let lock expire
         Thread.sleep(lockTimeoutInMillis + 20);
         Assert.assertFalse("renew should fail because lock has expired", lock.renew(clientId));
         Assert.assertEquals("lock client id should not change", clientId, lock.getClientId());
@@ -53,7 +59,7 @@ public class LockTest {
     public void testObtainLockSucceeded() throws Exception {
         String newClientId = "newClientId";
         Lock lock = new Lock(clientId, lockTimeoutInMillis);
-        // sleep for 50 milliseconds to let lock expire
+        // sleep for longer than lockTimeout to let lock expire
         Thread.sleep(lockTimeoutInMillis + 20);
         Assert.assertTrue("obtain lock should succeed", lock.obtain(newClientId));
         Assert.assertEquals("lock client id should match", newClientId, lock.getClientId());
@@ -62,7 +68,7 @@ public class LockTest {
     @Test
     public void testObtainLockSucceededWithSameClientId() throws Exception {
         Lock lock = new Lock(clientId, lockTimeoutInMillis);
-        // sleep for 50 milliseconds to let lock expire
+        // sleep for longer than lockTimeout to let lock expire
         Thread.sleep(lockTimeoutInMillis + 20);
         Assert.assertTrue("obtain lock should succeed", lock.obtain(clientId));
         Assert.assertEquals("lock client id should match", clientId, lock.getClientId());
@@ -71,9 +77,13 @@ public class LockTest {
     @Test
     public void testObtainLockFailedWithUnexpiredLock() throws Exception {
         String newClientId = "newClientId";
+        long startTime = System.currentTimeMillis();
+        // sleep for less than lockTimeout
         Lock lock = new Lock(clientId, Math.max(0, lockTimeoutInMillis - 20));
         Assert.assertFalse(
-                "obtain lock should fail because lock is not expired", lock.obtain(newClientId));
-        Assert.assertEquals("lock client id should not changed", clientId, lock.getClientId());
+                "obtain lock should fail if lock is not expired", System.currentTimeMillis() - startTime < lockTimeoutInMillis && lock.obtain(newClientId));
+        if (System.currentTimeMillis() - startTime < lockTimeoutInMillis) {
+            Assert.assertEquals("lock client id should not changed", clientId, lock.getClientId());
+        }
     }
 }


### PR DESCRIPTION
$ for ((i=0; i<50; i++)) ; do ./gradlew sapphire-core:cleanTest sapphire-core:test ; done
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
BUILD SUCCESSFUL in 36s
