### PR TITLE
[MultiDM] server policy object migration doesn't need to make explicit remove server policy list

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -225,9 +225,19 @@ public class KernelServerImpl implements KernelServer {
          * the OMS.
          */
         KernelObject object = objectManager.lookupObject(oid);
-        // TODO: Coalesce only the first server policy is enough ?? Moving complete chain of
-        // associated server policies.
+
+        /* Coalesce all the server policies in chain before moving them */
         object.coalesce();
+        SapphirePolicy.SapphireServerPolicy nextPolicy = serverPolicy;
+        while ((nextPolicy = nextPolicy.getNextServerPolicy()) != null) {
+            try {
+                objectManager.lookupObject(nextPolicy.$__getKernelOID()).coalesce();
+            } catch (KernelObjectNotFoundException e) {
+                logger.warning(
+                        "Could not find object in this server. Oid:"
+                                + nextPolicy.$__getKernelOID().getID());
+            }
+        }
 
         logger.fine("Moving object " + oid.toString() + " to " + host.toString());
 


### PR DESCRIPTION
Modification details:
1. No explicit need to make list of serverPoliciesToRemove in moveKernelObjectToServer.
2. No need to uncoalesce() immediately after instantiating a KernelObject()
3. Coalesce all the server policy objects in the chain before moving to other kernel server