### PR TITLE
Removed unnecessary recursion and unbounded thread spawning from AtLeastOnceRpcPolicy, fixes #269.

### DIFF
--- a/sapphire/sapphire-core/src/test/java/sapphire/policy/atleastoncerpc/AtLeastOnceRPCPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/policy/atleastoncerpc/AtLeastOnceRPCPolicyTest.java
@@ -6,14 +6,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import sapphire.policy.SapphirePolicy;
+import sapphire.common.AppExceptionWrapper;
 
 public class AtLeastOnceRPCPolicyTest {
-    SapphirePolicy.SapphireClientPolicy clientPolicy;
-    SapphirePolicy.SapphireServerPolicy serverPolicy;
-    SapphirePolicy.SapphireGroupPolicy groupPolicy;
+    AtLeastOnceRPCPolicy.AtLeastOnceRPCClientPolicy clientPolicy;
+    AtLeastOnceRPCPolicy.AtLeastOnceRPCServerPolicy serverPolicy;
 
     @org.junit.Before
     public void setUp() throws Exception {
@@ -23,7 +21,7 @@ public class AtLeastOnceRPCPolicyTest {
     }
 
     @org.junit.Test
-    public void atLeastOnceRPC() throws Exception {
+    public void happyCase() throws Exception {
         // normal case: call goes well
         when(this.serverPolicy.onRPC("foo", new ArrayList<Object>())).thenReturn("OK");
 
@@ -38,8 +36,8 @@ public class AtLeastOnceRPCPolicyTest {
     }
 
     @org.junit.Test
-    public void atLeastOnceRPCRetries() throws Exception {
-        // transient failure case: first call gets exception; second call goes through
+    public void retriesSucceed() throws Exception {
+        // transient failure case: first, second call gets exception; third call goes through
         when(this.serverPolicy.onRPC("foo", new ArrayList<Object>()))
                 .thenThrow(new Exception("transient; should've been resolved after 2 retries"))
                 .thenThrow(new Exception("transient; should've been resolved after 1 retry"))
@@ -56,32 +54,26 @@ public class AtLeastOnceRPCPolicyTest {
     }
 
     @org.junit.Test(timeout = 500, expected = TimeoutException.class)
-    public void atLeastOnceRPCGivesupAfterTimeout() throws Exception {
+    public void givesUpAfterTimeout() throws Exception {
         // persistent failure case
         when(this.serverPolicy.onRPC("foo", new ArrayList<Object>()))
-                .thenThrow(new Exception("persistent"));
+                .thenThrow(new Exception("persistent non-app error"));
 
         // to shorten RPC timeout allowance for unit test
-        ((AtLeastOnceRPCPolicy.AtLeastOnceRPCClientPolicy) this.clientPolicy).setTimeout(100);
+        this.clientPolicy.setTimeout(100);
+        this.clientPolicy.onRPC("foo", new ArrayList<Object>());
+        fail("TimeoutException should have been thrown; should never get to this point");
+    }
 
-        Object result = null;
-        try {
-            result = this.clientPolicy.onRPC("foo", new ArrayList<Object>());
-        } catch (
-                ExecutionException
-                        e) { // Sometimes the TimeoutException is wrapped in one or more
-                             // ExecutionExceptions.
-            while (e != null) {
-                if (e.getCause() instanceof TimeoutException) {
-                    throw (TimeoutException) e.getCause();
-                }
-                if (e.getCause() instanceof ExecutionException) {
-                    e = (ExecutionException) e.getCause();
-                    continue;
-                }
-                throw e;
-            }
-        }
-        fail("exception should have been thrown; should never get to this point");
+    @org.junit.Test(timeout = 500, expected = AppExceptionWrapper.class)
+    public void doesNotRetryApplicationExceptions() throws Exception {
+        // persistent failure case
+        when(this.serverPolicy.onRPC("foo", new ArrayList<Object>()))
+                .thenThrow(new AppExceptionWrapper(new Exception("persistent app error")));
+
+        // to shorten RPC timeout allowance for unit test
+        this.clientPolicy.setTimeout(100);
+        this.clientPolicy.onRPC("foo", new ArrayList<Object>());
+        fail("AppExceptionWrapper should have been thrown; should never get to this point");
     }
 }


### PR DESCRIPTION
$ ./gradlew sapphire-core:cleanTest sapphire-core:test

Task :sapphire-core:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.


BUILD SUCCESSFUL in 26s
19 actionable tasks: 5 executed, 14 up-to-date
