### PR TITLE
Install GraalVM ruby component in Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,10 @@ COPY ./ /DCAP-Sapphire/
 
 WORKDIR /DCAP-Sapphire/sapphire
 
+# Install GraalVM ruby component
+# NOTE: This is a temporary measure until dcap/sapphire_base:0.2 has been updated.
+# Once that has been done, the following command should be removed.
+RUN bash gu install ruby
+
 # Verifying the build
 RUN bash gradlew build


### PR DESCRIPTION
Temporary measure until dcap/sapphire_base has been updated. 

See https://github.com/Huawei-PaaS/DCAP-Sapphire/pull/480