### PR TITLE
Removing the Installation of Ruby from GCB Docker file  fixes #479

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
 
-FROM dcap/sapphire_base:0.1
+FROM dcap/sapphire_base:0.2
 
 COPY ./ /DCAP-Sapphire/
 
 WORKDIR /DCAP-Sapphire/sapphire
-
-# Install GraalVM ruby component
-# NOTE: This is a temporary measure until dcap/sapphire_base:0.2 has been updated.
-# Once that has been done, the following command should be removed.
-RUN bash gu install ruby
 
 # Verifying the build
 RUN bash gradlew build


### PR DESCRIPTION
Fix #479 

Sapphire base image 0.2  with ruby  is uploaded  (#480) 

base image version  updated  and  ruby installation  removed in Google Cloud Builder Docker file (#481)

Please find the screen shot of docker  build 
![gradle build verification](https://user-images.githubusercontent.com/39764768/49271967-c8be0180-f495-11e8-9933-88fa3d201c3b.png)
