### PR TITLE
Fix KeyValueStore_Stub in kvstorejs.

### DIFF
--- a/sapphire/examples/kvstorejs/src/main/java/sapphire/appdemo/stubs/KeyValueStore_Stub.java
+++ b/sapphire/examples/kvstorejs/src/main/java/sapphire/appdemo/stubs/KeyValueStore_Stub.java
@@ -15,7 +15,6 @@ import sapphire.common.SapphireObjectID;
 import sapphire.graal.io.SerializeValue;
 import sapphire.kernel.server.KernelServerImpl;
 
-
 public final class KeyValueStore_Stub extends sapphire.common.GraalObject implements sapphire.common.GraalAppObjectStub {
 
     sapphire.policy.SapphirePolicy.SapphireClientPolicy $__client = null;
@@ -61,6 +60,7 @@ public final class KeyValueStore_Stub extends sapphire.common.GraalObject implem
 
     public java.util.List<SerializeValue> serializeParams(Object... args) throws Exception {
         java.util.List<SerializeValue> res = new ArrayList<>();
+        getContext().enter();
         for (Object o : args) {
             res.add(SerializeValue.getSerializeValue(Value.asValue(o), getLanguage()));
         }


### PR DESCRIPTION
TODO: stub files should be generated by gradle script rather than checked in. Note that compilation fails without this stub file for kvstorejs. Need more look into this.

Auto styling corrects this stub file when gradle build stript runs. This is not a permanent fix since any changes in generation may alter this. Need deeper look into this. This commit simply corrects the styling to prevent from developers continuosly unchecking for commit until root cause is found.