### PR TITLE
Removed hard coded class name in logger fixes #495

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/graal/io/GraalContext.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/graal/io/GraalContext.java
@@ -11,7 +11,7 @@ import sapphire.app.Language;
 public class GraalContext {
     private static Context context;
     private static String sapphireObjectPath;
-    private static Logger logger = Logger.getLogger("sapphire.kernel.server.KernelServerImpl");
+    private static Logger logger = Logger.getLogger(GraalContext.class.getName());
 
     public static void main(String[] args) throws Exception {
         getContext();

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelObjectManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelObjectManager.java
@@ -14,7 +14,7 @@ import sapphire.kernel.common.KernelObjectNotFoundException;
  * @author iyzhang
  */
 public class KernelObjectManager {
-    Logger logger = Logger.getLogger("sapphire.kernel.server.KernelObjectManager");
+    Logger logger = Logger.getLogger(KernelObjectManager.class.getName());
     private ConcurrentHashMap<KernelOID, KernelObject> objects;
 
     public KernelObjectManager() {

--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelServerImpl.java
@@ -32,7 +32,7 @@ import sapphire.runtime.Sapphire;
  * @author iyzhang
  */
 public class KernelServerImpl implements KernelServer {
-    private static Logger logger = Logger.getLogger("sapphire.kernel.server.KernelServerImpl");
+    private static Logger logger = Logger.getLogger(KernelServerImpl.class.getName());
     private static String LABEL_OPT = "--label";
     private static String OPT_SEPARATOR = "=";
     private static String LABEL_SEPARATOR = ",";

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/KernelServerManager.java
@@ -24,7 +24,7 @@ import sapphire.policy.util.ResettableTimer;
  * @author iyzhang
  */
 public class KernelServerManager {
-    Logger logger = Logger.getLogger("sapphire.oms.KernelServerManager");
+    Logger logger = Logger.getLogger(KernelServerManager.class.getName());
 
     private ConcurrentHashMap<InetSocketAddress, KernelServer> servers;
     private ConcurrentHashMap<String, ArrayList<InetSocketAddress>> regions;

--- a/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/oms/OMSServerImpl.java
@@ -46,7 +46,7 @@ import sapphire.runtime.Sapphire;
  */
 public class OMSServerImpl implements OMSServer, SapphireObjectServer {
 
-    private static Logger logger = Logger.getLogger("sapphire.oms.OMSServerImpl");
+    private static Logger logger = Logger.getLogger(OMSServerImpl.class.getName());
     private static String SERVICE_PORT = "--servicePort";
 
     private GlobalKernelObjectManager kernelObjectManager;
@@ -376,10 +376,11 @@ public class OMSServerImpl implements OMSServer, SapphireObjectServer {
             // to get all the kernel server's addresses passing null in oms.getServers
             for (Iterator<InetSocketAddress> it = oms.getServers(null).iterator(); it.hasNext(); ) {
                 InetSocketAddress address = it.next();
-                logger.fine("   " + address.getHostName().toString() + ":" + address.getPort());
+                logger.fine(
+                        "   " + address.getHostName().toString() + ":" + address.getPort());
             }
         } catch (Exception e) {
-            logger.severe("Server exception: " + e.toString());
+            logger.severe("Server exception: " + e.toString()); 
             e.printStackTrace();
         }
     }

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/ShiftPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/ShiftPolicy.java
@@ -18,7 +18,7 @@ public class ShiftPolicy extends DefaultSapphirePolicy {
     public static class ShiftClientPolicy extends DefaultSapphirePolicy.DefaultClientPolicy {}
 
     public static class ShiftServerPolicy extends DefaultSapphirePolicy.DefaultServerPolicy {
-        private static Logger logger = Logger.getLogger(SapphireServerPolicy.class.getName());
+        private static Logger logger = Logger.getLogger(ShiftServerPolicy.class.getName());
 
         private static int LOAD = 5;
         private static int shiftRPCLoad = 0;

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/cache/CacheLeasePolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/cache/CacheLeasePolicy.java
@@ -164,8 +164,7 @@ public class CacheLeasePolicy extends DefaultSapphirePolicy {
      * @author iyzhang
      */
     public static class CacheLeaseServerPolicy extends DefaultServerPolicy {
-        private static Logger logger =
-                Logger.getLogger("sapphire.policy.cache.CacheLeasePolicy.CacheLeaseServerPolicy");
+        private static Logger logger = Logger.getLogger(CacheLeaseServerPolicy.class.getName());
         private UUID lease;
         private Date leaseTimeout;
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/dht/DHTPolicy.java
@@ -45,7 +45,7 @@ public class DHTPolicy extends DefaultSapphirePolicy {
     }
 
     public static class DHTClientPolicy extends DefaultClientPolicy {
-        private static Logger logger = Logger.getLogger(DHTPolicy.DHTClientPolicy.class.getName());
+        private static Logger logger = Logger.getLogger(DHTClientPolicy.class.getName());
         private DHTChord dhtChord;
 
         @Override

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/mobility/explicitmigration/ExplicitMigrationPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/mobility/explicitmigration/ExplicitMigrationPolicy.java
@@ -72,8 +72,7 @@ public class ExplicitMigrationPolicy extends DefaultSapphirePolicy {
     }
 
     public static class ClientPolicy extends DefaultClientPolicy {
-        private static Logger logger =
-                Logger.getLogger(ExplicitMigrationPolicy.ClientPolicy.class.getName());
+        private static Logger logger = Logger.getLogger(ClientPolicy.class.getName());
 
         // Maximum time interval for wait before timing out (in milliseconds)
         private long retryTimeoutInMillis = RETRYTIMEOUTINMILLIS;
@@ -126,8 +125,7 @@ public class ExplicitMigrationPolicy extends DefaultSapphirePolicy {
     }
 
     public static class ServerPolicy extends DefaultServerPolicy {
-        private static Logger logger =
-                Logger.getLogger(ExplicitMigrationPolicy.ServerPolicy.class.getName());
+        private static Logger logger = Logger.getLogger(ServerPolicy.class.getName());
         private String migrateObjectMethodName = MIGRATEOBJECTMETHODNAME;
 
         @Override

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/scalability/LoadBalancedMasterSlaveBase.java
@@ -175,7 +175,7 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultSapphirePolicy 
         @Override
         public void onCreate(String region, SapphireServerPolicy server, SapphireObjectSpec spec)
                 throws RemoteException {
-            logger = Logger.getLogger(this.getClass().getName());
+            logger = Logger.getLogger(GroupBase.class.getName());
             super.onCreate(region, server, spec);
             logger.info(String.format("Creating master and slave instance in region %s", region));
 

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TLS2PCCoordinator.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TLS2PCCoordinator.java
@@ -7,8 +7,7 @@ import sapphire.policy.serializability.TransactionAlreadyStartedException;
 
 /** 2PC Coordinator based on thread local storage */
 public class TLS2PCCoordinator implements TwoPCCoordinator {
-    private static Logger logger =
-            Logger.getLogger("sapphire.policy.transaction.TLS2PCCoordinator");
+    private static Logger logger = Logger.getLogger(TLS2PCCoordinator.class.getName());
 
     private final TransactionValidator validator;
     private final TwoPCLocalParticipants localParticipantsManager = new TwoPCLocalParticipants();

--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TLSTransactionManager.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/transaction/TLSTransactionManager.java
@@ -9,8 +9,7 @@ import java.util.logging.Logger;
 
 /** Transaction Manager based on thread local storage context */
 public class TLSTransactionManager implements TransactionManager, Serializable {
-    private static Logger logger =
-            Logger.getLogger("sapphire.policy.transaction.TLSTransactionManager");
+    private static Logger logger = Logger.getLogger(TLSTransactionManager.class.getName());
 
     private final TwoPCLocalStatus localStatusManager = new TwoPCLocalStatus();
     private final TwoPCLocalParticipants localParticipantsManager = new TwoPCLocalParticipants();


### PR DESCRIPTION
Removed hard coded class name in logger and updated policies to use SapphirePolicyLibrary.class.getName()

fixes #495