### PR TITLE
Gradle Changes for genIntegTestStub failure   fixes#509

### DIFF
--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -153,9 +153,9 @@ task genIntegTestStubs(type :JavaExec) {
 }
 
 task compileIntegTestDemoPkg(type: JavaCompile) {
-    source = file(project.buildDir.toString() + '/src/integrationTest/java/sapphire/demo/')
+    source = file(project.projectDir.toString() + '/src/integrationTest/java/sapphire/demo/')
     classpath = sourceSets.integrationTest.compileClasspath
-    destinationDir =file(project.buildDir.toString() + '/classes/java/integrationTest/sapphire/demo')
+    destinationDir = file(project.buildDir.toString() + '/classes/java/integrationTest/')
     options.incremental = true
 }
 


### PR DESCRIPTION
It has been observed that after merge of #506  when gradle build executed after the gradle clean  
genIntegTestStubs task  ,
To rectify this some changes made in the gradle file  
Please find the screen shot of verification of changes 
gradle build is executed after the gradle clean 

![gradle clean](https://user-images.githubusercontent.com/39764768/49918526-733c1880-fec9-11e8-8382-5ebf63369701.png)
![gradle build](https://user-images.githubusercontent.com/39764768/49918532-76370900-fec9-11e8-8caa-62d1965c57bc.png)
![genintegstubs](https://user-images.githubusercontent.com/39764768/49918541-7afbbd00-fec9-11e8-91a0-6b40a17bf272.png)
