### PR TITLE
Removed catch block and severe level log from kernelobject's invoke method as it can occur in normal execution flow

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelObject.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/kernel/server/KernelObject.java
@@ -2,7 +2,6 @@ package sapphire.kernel.server;
 
 import java.util.ArrayList;
 import java.util.concurrent.Semaphore;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import sapphire.common.ObjectHandler;
 import sapphire.kernel.common.KernelObjectMigratingException;
@@ -41,11 +40,6 @@ public class KernelObject extends ObjectHandler {
         // then we safely release the rpcCounter
         try {
             ret = super.invoke(method, params);
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "Invocation failed for " + method, e);
-            // Throwing the exception again so that the same exception is returned to the client.
-            // The client is expected to take appropriate action based on this exception.
-            throw e;
         } finally {
             rpcCounter.release();
         }


### PR DESCRIPTION
In `invoke()` method in KernelObject.java file, `super.invoke(method, params);` can throw exception in normal processing. Exceptions could be between DM components or may be APP specific exceptions.  Seems like, we have added a catch block and a severe log in some recent PR. Actual base code do not have it.
![Uploading Selection_116.png…]()
Removing the catch block and severe level log with this PR.
