### PR TITLE
[MultiDM]Removal of AppObjectStub from SapphireServerPolicyLibrary

### DIFF
--- a/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
+++ b/sapphire/sapphire-core/src/main/java/sapphire/policy/SapphirePolicyLibrary.java
@@ -44,7 +44,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
     public abstract static class SapphireServerPolicyLibrary
             implements SapphireServerPolicyUpcalls {
         protected AppObject appObject;
-        protected AppObjectStub appObjectStub;
         protected KernelOID oid;
         protected SapphireReplicaID replicaId;
         protected SapphirePolicy.SapphireGroupPolicy group;
@@ -156,14 +155,13 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
 
                 // Complete the chain by creating new instances of server policies and stub that
                 // should be created after this policy.
-                List<SapphirePolicyContainer> nextPolicyList =
-                        Sapphire.createPolicy(
-                                this.getGroup().sapphireObjId,
-                                spec,
-                                this.nextPolicies,
-                                processedPoliciesReplica,
-                                region,
-                                null);
+                Sapphire.createPolicy(
+                        this.getGroup().sapphireObjId,
+                        spec,
+                        this.nextPolicies,
+                        processedPoliciesReplica,
+                        region,
+                        null);
 
                 getGroup().addServer((SapphireServerPolicy) serverPolicyStub);
             } catch (ClassNotFoundException e) {
@@ -199,10 +197,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
 
         public AppObject sapphire_getAppObject() {
             return appObject;
-        }
-
-        public AppObjectStub sapphire_getAppObjectStub() {
-            return appObjectStub;
         }
 
         /**
@@ -381,10 +375,6 @@ public abstract class SapphirePolicyLibrary implements SapphirePolicyUpcalls {
 
         public void $__initialize(AppObject appObject) {
             this.appObject = appObject;
-        }
-
-        public void $__initialize(AppObjectStub appObjectStub) {
-            this.appObjectStub = appObjectStub;
         }
 
         public void $__setKernelOID(KernelOID oid) {

--- a/sapphire/sapphire-core/src/test/java/sapphire/common/BaseTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/common/BaseTest.java
@@ -218,14 +218,18 @@ public class BaseTest {
                 new Answer<Object>() {
                     @Override
                     public Object answer(InvocationOnMock invocation) throws Throwable {
-                        if ((invocation.getMethod().getName().equals("getAppStub"))) {
+                        if ((invocation.getMethod().getName().equals("initAppStub"))) {
+                            SapphireObjectSpec spec =
+                                    (SapphireObjectSpec) invocation.getArguments()[0];
                             SapphirePolicy.SapphireServerPolicy serverPolicy =
                                     (SapphirePolicy.SapphireServerPolicy)
                                             invocation.getArguments()[1];
                             Object[] args = (Object[]) invocation.getArguments()[2];
 
-                            return Sapphire.createClientAppStub(
-                                    serverPolicy.$__initialize(spec, args));
+                            if (invocation.getArguments()[3] == null) {
+                                serverPolicy.$__initialize(spec, args);
+                                return null;
+                            }
                         }
                         if (!(invocation.getMethod().getName().equals("getPolicyStub")))
                             return invocation.callRealMethod();

--- a/sapphire/sapphire-core/src/test/java/sapphire/runtime/SapphireMultiPolicyChainTest.java
+++ b/sapphire/sapphire-core/src/test/java/sapphire/runtime/SapphireMultiPolicyChainTest.java
@@ -191,7 +191,7 @@ public class SapphireMultiPolicyChainTest extends BaseTest {
 
     @Test
     public void testNew_() throws Exception {
-        Object temp = Sapphire.new_(DefaultSO.class);
+        Object temp = Sapphire.new_(SO.class);
         assertNotEquals(null, temp);
     }
 
@@ -204,11 +204,8 @@ public class SapphireMultiPolicyChainTest extends BaseTest {
         SapphireObjectID sapphireObjId = spiedOms.registerSapphireObject();
 
         policyNameChain.add(new SapphirePolicyContainer("sapphire.policy.dht.DHTPolicy", null));
-        List<SapphirePolicyContainer> policyList =
-                Sapphire.createPolicy(
-                        sapphireObjId, spec, policyNameChain, processedPolicies, "", null);
-
-        assertEquals(1, policyList.size());
+        Sapphire.createPolicy(sapphireObjId, spec, policyNameChain, processedPolicies, "", null);
+        assertEquals(1, processedPolicies.size());
     }
 
     @Test
@@ -223,11 +220,8 @@ public class SapphireMultiPolicyChainTest extends BaseTest {
         policyNameChain.add(
                 new SapphirePolicyContainer("sapphire.policy.DefaultSapphirePolicy", null));
 
-        List<SapphirePolicyContainer> policyList =
-                Sapphire.createPolicy(
-                        sapphireObjId, spec, policyNameChain, processedPolicies, "", null);
-
-        assertEquals(2, policyList.size());
+        Sapphire.createPolicy(sapphireObjId, spec, policyNameChain, processedPolicies, "", null);
+        assertEquals(2, processedPolicies.size());
     }
 
     @After


### PR DESCRIPTION
appObjectStub field in SapphireServerPolicyLibrary is being used to temporarily store the app-client side appstub. So that, the stub can be returned to app-client upon successful creation of SO. In fact, this field is not required to be present in server policy object as it is only for the temporary storage.
             Instead, removed this appObjectStub field from SapphireServerPolicyLibrary now and App-client side stub is cloned from appObjectStub within AppObject of first DM's server policy in chain, injected its client policy into it at the end of successful creation of SO.