### PR TITLE
Renamed amino.run.policy.Library.SapphireServerPolicyLibrary -> amino.run.policy.Library.ServerPolicyLibrary

### DIFF
--- a/sapphire/sapphire-core/src/main/java/amino/run/compiler/PolicyStub.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/compiler/PolicyStub.java
@@ -17,8 +17,8 @@ public class PolicyStub extends Stub {
         TreeSet<MethodStub> ms = new TreeSet<MethodStub>();
 
         Class<?> ancestorClass = stubClass;
-        while ((!ancestorClass.getSimpleName().equals("SapphireServerPolicyLibrary"))
-                && (!ancestorClass.getSimpleName().equals("SapphireGroupPolicyLibrary"))) {
+        while ((!ancestorClass.getSimpleName().equals("ServerPolicyLibrary"))
+                && (!ancestorClass.getSimpleName().equals("GroupPolicyLibrary"))) {
 
             for (Method m : ancestorClass.getDeclaredMethods()) {
                 // Add public methods to methods vector

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/server/KernelServerImpl.java
@@ -134,17 +134,16 @@ public class KernelServerImpl implements KernelServer {
         // To add Kernel Object to local object manager
         Serializable realObj = object.getObject();
 
-        if (!(realObj instanceof Library.SapphireServerPolicyLibrary)) {
+        if (!(realObj instanceof Library.ServerPolicyLibrary)) {
             logger.log(Level.WARNING, "Added " + oid.getID() + " as unknown type.");
             return;
         }
 
-        Library.SapphireServerPolicyLibrary firstServerPolicy =
-                (Library.SapphireServerPolicyLibrary) realObj;
+        Library.ServerPolicyLibrary firstServerPolicy = (Library.ServerPolicyLibrary) realObj;
 
         for (SapphirePolicyContainer spContainer : firstServerPolicy.getProcessedPolicies()) {
             // Add Server Policy object in the same order as client side has created.
-            Library.SapphireServerPolicyLibrary serverPolicy = spContainer.getServerPolicy();
+            Library.ServerPolicyLibrary serverPolicy = spContainer.getServerPolicy();
 
             // Added for setting the ReplicaId and registering handler for this replica to OMS.
             Policy.ServerPolicy serverPolicyStub =
@@ -160,7 +159,7 @@ public class KernelServerImpl implements KernelServer {
 
             objectManager.addObject(koid, newko);
             oms.registerKernelObject(koid, host);
-            logger.log(Level.INFO, "Added " + koid.getID() + " as SapphireServerPolicyLibrary");
+            logger.log(Level.INFO, "Added " + koid.getID() + " as ServerPolicyLibrary");
 
             try {
                 serverPolicy.onCreate(

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 public abstract class DefaultUpcallImpl extends Library {
 
-    public abstract static class ClientPolicy extends SapphireClientPolicyLibrary {
+    public abstract static class ClientPolicy extends ClientPolicyLibrary {
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
             // only transaction-capable SO is allowed in DCAP transaction -- change of the original
             // behavior
@@ -43,7 +43,7 @@ public abstract class DefaultUpcallImpl extends Library {
         }
     }
 
-    public abstract static class ServerPolicy extends SapphireServerPolicyLibrary {
+    public abstract static class ServerPolicy extends ServerPolicyLibrary {
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
             return appObject.invoke(method, params);
         }
@@ -83,7 +83,7 @@ public abstract class DefaultUpcallImpl extends Library {
         public void onDestroy() {}
     }
 
-    public abstract static class GroupPolicy extends SapphireGroupPolicyLibrary {
+    public abstract static class GroupPolicy extends GroupPolicyLibrary {
 
         /*
          * INTERNAL FUNCTIONS (Used by Sapphire runtime)

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
@@ -33,16 +33,14 @@ import java.util.logging.Logger;
 import org.apache.harmony.rmi.common.RMIUtil;
 
 public abstract class Library implements SapphirePolicyUpcalls {
-    public abstract static class SapphireClientPolicyLibrary
-            implements SapphireClientPolicyUpcalls {
+    public abstract static class ClientPolicyLibrary implements SapphireClientPolicyUpcalls {
 
         /*
          * INTERNAL FUNCTIONS (Used by sapphire runtime system)
          */
     }
 
-    public abstract static class SapphireServerPolicyLibrary
-            implements SapphireServerPolicyUpcalls {
+    public abstract static class ServerPolicyLibrary implements SapphireServerPolicyUpcalls {
         protected AppObject appObject;
         protected KernelOID oid;
         protected SapphireReplicaID replicaId;
@@ -51,7 +49,7 @@ public abstract class Library implements SapphirePolicyUpcalls {
         protected Map<String, SapphirePolicyConfig> configMap;
         protected boolean alreadyPinned;
 
-        static Logger logger = Logger.getLogger(SapphireServerPolicyLibrary.class.getName());
+        static Logger logger = Logger.getLogger(ServerPolicyLibrary.class.getName());
 
         // ServerPolicy that precedes the current policy in the server side chain - this order is
         // reverse in the client side.
@@ -410,13 +408,13 @@ public abstract class Library implements SapphirePolicyUpcalls {
         }
     }
 
-    public abstract static class SapphireGroupPolicyLibrary implements SapphireGroupPolicyUpcalls {
+    public abstract static class GroupPolicyLibrary implements SapphireGroupPolicyUpcalls {
         protected String appObjectClassName;
         protected ArrayList<Object> params;
         protected KernelOID oid;
         protected SapphireObjectID sapphireObjId;
 
-        static Logger logger = Logger.getLogger(SapphireGroupPolicyLibrary.class.getName());
+        static Logger logger = Logger.getLogger(GroupPolicyLibrary.class.getName());
 
         protected OMSServer oms() {
             return GlobalKernelReferences.nodeServer.oms;

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/SapphirePolicyUpcalls.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/SapphirePolicyUpcalls.java
@@ -238,7 +238,7 @@ public interface SapphirePolicyUpcalls {
          * TODO: See above. This method should not be in this interface. It is in intenal/protected
          * method to the DM.
          *
-         * <p>TODO: This is currently only called by SapphireGroupPolicyLibrary.removeReplica and
+         * <p>TODO: This is currently only called by GroupPolicyLibrary.removeReplica and
          * SapphireLoadBalancedMasterSlaveBase. Clean this up and do it consistently across all DM's
          *
          * @param server The server that has been removed from the group.

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/transaction/AppObjectSandboxProvider.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/transaction/AppObjectSandboxProvider.java
@@ -1,6 +1,6 @@
 package amino.run.policy.transaction;
 
-import static amino.run.policy.Library.SapphireServerPolicyLibrary;
+import static amino.run.policy.Library.ServerPolicyLibrary;
 import static amino.run.policy.SapphirePolicyUpcalls.SapphireServerPolicyUpcalls;
 
 import java.io.Serializable;
@@ -13,8 +13,8 @@ public class AppObjectSandboxProvider implements SandboxProvider, Serializable {
             new ConcurrentHashMap<UUID, AppObjectShimServerPolicy>();
 
     @Override
-    public SapphireServerPolicyUpcalls getSandbox(
-            SapphireServerPolicyLibrary origin, UUID transactionId) throws Exception {
+    public SapphireServerPolicyUpcalls getSandbox(ServerPolicyLibrary origin, UUID transactionId)
+            throws Exception {
         if (!this.sandboxes.containsKey(transactionId)) {
             AppObjectShimServerPolicy sandbox =
                     AppObjectShimServerPolicy.cloneInShimServerPolicy(

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/transaction/SandboxProvider.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/transaction/SandboxProvider.java
@@ -15,7 +15,7 @@ public interface SandboxProvider {
      * @return sandbox associated with the transaction
      */
     SapphirePolicyUpcalls.SapphireServerPolicyUpcalls getSandbox(
-            Library.SapphireServerPolicyLibrary origin, UUID transactionId) throws Exception;
+            Library.ServerPolicyLibrary origin, UUID transactionId) throws Exception;
 
     /**
      * gets the sandbox assiated with the specified transaction

--- a/sapphire/sapphire-core/src/main/java/amino/run/runtime/exception/AppExecutionException.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/runtime/exception/AppExecutionException.java
@@ -3,8 +3,7 @@ package amino.run.runtime.exception;
 import amino.run.policy.Library;
 
 /**
- * Exception thrown when method invocation on {@link Library.SapphireServerPolicyLibrary#appObject}
- * failed.
+ * Exception thrown when method invocation on {@link Library.ServerPolicyLibrary#appObject} failed.
  *
  * <p>This exception is caused by application errors, not Sapphire errors. It indicates something
  * wrong in application. Good applications should <em>not</em> cause this exception on method


### PR DESCRIPTION
I would have preferred to rename SapphireServerPolicyLibrary to simply ServerPolicy, but that causes various name clashes and test failures, that will require some manual refactoring, so decided to leave that to a followup PR.

All tests pass:

```
./gradlew check
BUILD SUCCESSFUL in 2m 9s
40 actionable tasks: 25 executed, 15 up-to-date
```