### PR TITLE
Clean outputs of gen*Stubs gradle tasks, fixes #550 

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -102,7 +102,7 @@ subprojects {
     clean {
         delete genStubs.outputs.files // Add generated stubs to what the clean task must delete
         doLast {
-            println 'DEBUG: Clean will also delete ' + genStubs.outputs.files.asCollection()
+            logger.info('Clean will delete ' + clean.targetFiles.asCollection())
         }
     }
 

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -149,14 +149,13 @@ task genGraalTestStubs(type: JavaExec) {
     def packageName = "amino.run.stubs"
     def sapphireClasses = "Student"
     args sapphireObjectPath, outPath, packageName, sapphireClasses
-    outputs.dir outPath // Declare outputs, so gradle will run if they have been changed
+    outputs.dir outPath + "/amino/run/stubs" // Declare outputs, so gradle will run if they have been changed
     inputs.dir sapphireObjectPath   // Declare inputs, so gradle will run if they have been changed
 }
 // Task for Graal Test stubs compilation
 task compileGraalTestStubs(type: JavaCompile) {
     source = "$projectDir/src/test/java/amino/run/stubs"
     classpath = files(sourceSets.main.output.classesDir)
-    // TODO: Quinton: Remove: classpath = files(sourceSets.main.output.classesDir)
     destinationDir = sourceSets.main.output.classesDir
     options.incremental = true
     inputs.dir genGraalTestStubs.outputs
@@ -179,6 +178,16 @@ task compileIntegTestDemoPkg(type: JavaCompile) {
     classpath = sourceSets.integrationTest.compileClasspath
     destinationDir = file(project.buildDir.toString() + '/classes/java/integrationTest/')
     options.incremental = true
+}
+
+clean {
+    delete genUnitTestStubs.outputs.files // Add generated stubs to what the clean task must delete
+    delete genGraalTestStubs.outputs.files
+    delete genIntegTestStubs.outputs.files
+
+    doLast {
+        logger.info('Clean will delete ' + clean.targetFiles.asCollection())
+    }
 }
 
 tasks.googleJavaFormat.mustRunAfter genStubs


### PR DESCRIPTION
Added the outputs of code generation tasks in sapphire-core/build.gradle to clean.delete list, so that they get properly deleted.

I also had to fix the outputs.dir of genGraalTestStubs which was incorrect, and causing all our test code to be deleted when clean task is run.

I also improved the logging output of the clean task to log at INFO level, and list all files to be deleted (not just the added ones).