### PR TITLE
(WIP) Iterative creation of Sapphire chain by deployment kernel (iteration 1)

### DIFF
--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
@@ -61,6 +61,8 @@ public abstract class Library implements Upcalls {
         // (farthest from actual app object).
         // It means these were the last in order in the client side of chain. New groups should be
         // created for this list of chain.
+        // TODO: this will no longer be needed once sapphire_replicate() is updated to iterative
+        // logic.
         protected List<SapphirePolicyContainer> nextPolicies =
                 new ArrayList<SapphirePolicyContainer>();
 


### PR DESCRIPTION
Added CreatePolicyChain which creates a SO chain for new_.
This is the first phase of an effort to change multi-DM to create SO in an iterative fashion.
Not ready to get merged - just a place holder for now.

Status:
All unit tests/integration tests pass.
Manual test of DHT+MasterSlave fails due to pinning attempt by DHT.

TODO1: either resolve issue #535 or update to skip pinning if downstream DM has done it. It is different in iterative solution since pinned flag is not passed from kernel server where downstream group created a replica is different from the kernel server where deployment kernel is creating SO (OMS).
TODO2: update sapphire_replicate() to work in iterative fashion.