### PR TITLE
[WIP][MultiDM][Option-1]Passing App method name and params to all the DM clients along the chain for onRPC() method using ThreadLocal

### DIFF
--- a/sapphire/sapphire-core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -78,7 +78,6 @@ public class MultiDMTestCases {
      * @throws Exception
      */
     @Test
-    @Ignore
     public void testDHTNMasterSlaveMultiDM() throws Exception {
         File file = getResourceFile("specs/multi-dm/DHTNMasterSlave.yaml");
         MicroServiceSpec spec = readSapphireSpec(file);

--- a/sapphire/sapphire-core/src/main/java/amino/run/compiler/AppStub.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/compiler/AppStub.java
@@ -228,23 +228,16 @@ public final class AppStub extends Stub {
         buffer.append(listParams.toString()); // $NON-NLS-1$
         buffer.append(indenter.tIncrease(tabWidth) + "try {" + EOLN); // $NON-NLS-1$
 
-        // amino.run.common.AppContext ctx = new amino.run.common.AppContext();
-        // ctx.setAppMtdName($__method);
-        // ctx.setAppParams($__params);
-        // amino.run.common.AppObjectStub.context.set(ctx);
         buffer.append(
                 indenter.tIncrease(tabWidth + 1)
                         + "amino.run.common.AppContext ctx = new amino.run.common.AppContext();"
-                        + EOLN
-                        + indenter.tIncrease(tabWidth + 1)
-                        + "ctx.setAppMtdName($__method);"
-                        + EOLN
-                        + indenter.tIncrease(tabWidth + 1)
-                        + "ctx.setAppParams($__params);"
-                        + EOLN
-                        + indenter.tIncrease(tabWidth + 1)
+                        + EOLN);
+        buffer.append(indenter.tIncrease(tabWidth + 1) + "ctx.setAppMtdName($__method);" + EOLN);
+        buffer.append(indenter.tIncrease(tabWidth + 1) + "ctx.setAppParams($__params);" + EOLN);
+        buffer.append(
+                indenter.tIncrease(tabWidth + 1)
                         + "amino.run.common.AppObjectStub.context.set(ctx);"
-                        + EOLN); // $NON-NLS-1$
+                        + EOLN);
 
         buffer.append(
                 indenter.tIncrease(tabWidth + 1)
@@ -312,14 +305,11 @@ public final class AppStub extends Stub {
                         + "} finally {"
                         + EOLN); //$NON-NLS-1$
 
-        // AppObjectStub.context.remove();
         buffer.append(
                 indenter.tIncrease(tabWidth + 1)
                         + "amino.run.common.AppObjectStub.context.remove();"
-                        + EOLN
-                        + indenter.tIncrease(tabWidth)
-                        + "}"
-                        + EOLN); //$NON-NLS-1$
+                        + EOLN);
+        buffer.append(indenter.tIncrease(tabWidth) + "}" + EOLN); // $NON-NLS-1$
 
         buffer.append(indenter.indent() + "}" + EOLN); // $NON-NLS-1$
 

--- a/sapphire/sapphire-core/src/main/java/amino/run/compiler/Stub.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/compiler/Stub.java
@@ -199,8 +199,6 @@ public abstract class Stub implements RmicConstants {
         /** The generic name of the method */
         final String genericName;
 
-        final Method method;
-
         public String getGenericName() {
             return genericName;
         }
@@ -260,8 +258,6 @@ public abstract class Stub implements RmicConstants {
             /* Add the runtime exception at the end such that all the more specific exceptions of
             runtime are added before it */
             catches.add(RuntimeException.class);
-
-            this.method = method;
         }
 
         /**

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveBase.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveBase.java
@@ -82,7 +82,7 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultPolicy {
                         String.format(
                                 "Sending request to master server %s",
                                 ((KernelObjectStub) server).$__getHostname()));
-                MethodInvocationResponse response = server.onRPC(request);
+                MethodInvocationResponse response = server.onRPC(method, params, request);
                 switch (response.getReturnCode()) {
                     case SUCCESS:
                         return response.getResult();
@@ -145,7 +145,15 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultPolicy {
          * @param request method invocation request
          * @return method invocation response
          */
-        public MethodInvocationResponse onRPC(MethodInvocationRequest request) {
+        public MethodInvocationResponse onRPC(
+                String method, ArrayList<Object> params, MethodInvocationRequest request) {
+            request =
+                    new MethodInvocationRequest(
+                            request.getClientId(),
+                            request.getRequestId(),
+                            method,
+                            params,
+                            request.getMethodType());
             try {
                 Object ret =
                         sapphire_getAppObject()

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
@@ -14,6 +14,7 @@ import amino.run.policy.scalability.masterslave.ReplicationResponse;
 import amino.run.policy.scalability.masterslave.RequestReplicator;
 import amino.run.policy.scalability.masterslave.StateManager;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -114,7 +115,15 @@ public class LoadBalancedMasterSlaveSyncPolicy extends LoadBalancedMasterSlaveBa
          * @param request method invocation request
          * @return method invocation response
          */
-        public MethodInvocationResponse onRPC(MethodInvocationRequest request) {
+        public MethodInvocationResponse onRPC(
+                String method, ArrayList<Object> params, MethodInvocationRequest request) {
+            request =
+                    new MethodInvocationRequest(
+                            request.getClientId(),
+                            request.getRequestId(),
+                            method,
+                            params,
+                            request.getMethodType());
             if (request.isImmutable()) {
                 return commitExecutor.applyRead(request);
             }

--- a/sapphire/sapphire-core/src/test/java/amino/run/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/policy/scalability/LoadBalancedMasterSlaveSyncPolicyIntegTest.java
@@ -135,7 +135,7 @@ public class LoadBalancedMasterSlaveSyncPolicyIntegTest {
                 LoadBalancedMasterSlaveBase.ServerBase server =
                         (LoadBalancedMasterSlaveBase.ServerBase) group.getMaster();
 
-                return server.onRPC(request);
+                return server.onRPC(methodName, params, request);
             } catch (Exception e) {
                 try {
                     Thread.sleep(waitInMilliseconds);


### PR DESCRIPTION
In case of DM chaining, App method name and parameters are passed as argument to clientPolicy.onRPC() method of only first DM. Rest of the DM's clientPolicy.onRPC() receive previous DM's method name and parameters as argument instead of actual app method name and args. 
                           This PR aims to address the issue using threadlocal storage to preserve the stack of parameters pushed from Appstub till it reach current DM server stub(i.e., preserving stack across client.onRPC() calls). And all DMs clientPolicy.onRPC() are passed with actual app name and param.


NOTE:After passing app mtd name and params to onRPC(), DHT + LoadBalanceMasterSlaveSync combination is not working. Because,MethodInvocationRequest is constructed at client.onRPC() which stores actual appMethod name in it after this PR modification(prior to this PR it could have been DHT server stub mtd name), And on the LoadBalanceMasterSlaveSync server side, method name is used to find and invoke on appObject(i.e., DHT server policy object in this case) and fails with method not found exception. 
  Hence modified LoadBalanceMasterSlaveSync DM code to make it work.