### PR TITLE
Corrected graal genStubs dependency. Fixes #564

### DIFF
--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -3,8 +3,7 @@ apply plugin: 'java'
 // Customize app stub generation for this example.
 genStubs {
     main = "amino.run.compiler.GraalStubGenerator"
-    classpath =  files("$projectDir/../../sapphire-core/build/libs/sapphire-core-1.0.0.jar")
-    // TODO: Quinton: Remove: classpath sourceSets.main.output.classesDir
+    classpath = files("$projectDir/../../sapphire-core/build/classes/java/main/")
     def sapphireObjectPath = "$projectDir/src/main/ruby/amino/run/appexamples/hankstodo/todo_list_manager.rb"
     def outPath = "$projectDir/src/main/java"
     def packageName = "amino.run.appexamples.hankstodo.stubs"
@@ -13,13 +12,6 @@ genStubs {
     outputs.dir "$projectDir/src/main/java/amino/run/appexamples/hankstodo/stubs" // Declare outputs, so gradle will run if they have been changed
     inputs.dir sapphireObjectPath   // Declare inputs, so gradle will run if they have been changed
 }
-
-// Customize stub compilation for this example
-compileStubs {
-    outputs.dir "$buildDir/classes/java/main/amino/run/appexamples/hankstodo/stubs/"
-}
-
-jar.dependsOn compileStubs
 
 // Task to run Ruby app
 task runrubyapp(type: Exec) {
@@ -56,4 +48,4 @@ runapp {
 }
 
 compileJava.dependsOn genStubs
-runapp.dependsOn compileStubs
+runapp.dependsOn compileJava

--- a/sapphire/examples/kvstorejs/build.gradle
+++ b/sapphire/examples/kvstorejs/build.gradle
@@ -1,14 +1,9 @@
 apply plugin: 'java-library'
 
-dependencies {
-    compile project(':sapphire-core')
-}
-
 // Task for app stub generation
 genStubs {
     main = "amino.run.compiler.GraalStubGenerator"
-    classpath =  files("$projectDir/../../sapphire-core/build/libs/sapphire-core-1.0.0.jar")
-    // classpath sourceSets.main.output.classesDir
+    classpath = files("$projectDir/../../sapphire-core/build/classes/java/main/")
     def sapphireObjectPath = "$projectDir/src/main/js/amino/run/appdemo/KeyValueStore.js"
     def outPath = "$projectDir/src/main/java"
     def packageName = "amino.run.appdemo.stubs"
@@ -17,8 +12,6 @@ genStubs {
     outputs.dir "$projectDir/src/main/java/amino/run/appdemo/stubs" // Declare outputs, so gradle will run if they have been changed
     inputs.dir sapphireObjectPath   // Declare inputs, so gradle will run if they have been changed
 }
-
-jar.dependsOn compileStubs
 
 // task for run javascript kvstore client
 task runjsapp(type: Exec) {
@@ -45,4 +38,4 @@ runapp {
 }
 
 compileJava.dependsOn genStubs
-runapp.dependsOn compileStubs
+runapp.dependsOn compileJava

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -157,9 +157,10 @@ task genGraalTestStubs(type: JavaExec) {
 task compileGraalTestStubs(type: JavaCompile) {
     source = "$projectDir/src/test/java/amino/run/stubs"
     classpath = files(sourceSets.main.output.classesDir)
-    destinationDir = sourceSets.main.output.classesDir
+    destinationDir = sourceSets.test.output.classesDir
     options.incremental = true
     inputs.dir genGraalTestStubs.outputs
+    outputs.dir destinationDir
 }
 
 task genIntegTestStubs(type :JavaExec) {


### PR DESCRIPTION
In this PR the genStubs task's dependency has been corrected for non-java examples (hanksTodoRuby and kvstorejs).
This PR fixes issue #564 

Also has updated the destinationDir of sapphire-core task compileGraalTestStubs, as the generated stubs were getting added in both main and test sourceSets.

1). gradlew check
![gradlew_check](https://user-images.githubusercontent.com/34733024/52326630-62161080-2a0f-11e9-8444-07d04806beed.jpg)

2). hanksTodoruby build
![hankstodoruby_build_success](https://user-images.githubusercontent.com/34733024/52326646-6fcb9600-2a0f-11e9-83cc-4ccc53ce549b.jpg)

3). kvstorejs build
![kvstorejs_build_success](https://user-images.githubusercontent.com/34733024/52326664-79ed9480-2a0f-11e9-9969-cb8165b87ea7.jpg)
