### PR TITLE
Updated stub compilation and corresponding tasks.

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -102,22 +102,20 @@ subprojects {
     task genStubs(type: JavaExec) {
         main = "amino.run.compiler.StubGenerator"
         classpath = sourceSets.main.runtimeClasspath
-     }
+    }
+
+    // Configure "stubs" sourceSet compile task, with additional rules.
+    compileStubsJava {
+        classpath = sourceSets.main.runtimeClasspath
+        options.incremental = true
+        inputs.dir genStubs.outputs
+    }
 
     clean {
         delete genStubs.outputs.files // Add generated stubs to what the clean task must delete
         doLast {
             logger.info('Clean will delete ' + clean.targetFiles.asCollection())
         }
-    }
-
-    // Task for stub compilation
-    task compileStubs(type: JavaCompile) {
-        source = sourceSets.stubs.java.srcDirs  // Added generated stubs sourceSet, to the source list for compilation.
-        classpath = sourceSets.main.runtimeClasspath
-        destinationDir = sourceSets.stubs.output.classesDir
-        options.incremental = true
-        inputs.dir genStubs.outputs
     }
 
     // Include stubs sourceSet classes in the jar file.

--- a/sapphire/dependencies/build.gradle
+++ b/sapphire/dependencies/build.gradle
@@ -3,8 +3,4 @@ allprojects {
     genStubs {
         onlyIf() { false } // Disable
     }
-
-    compileStubs {
-        onlyIf() { false } // Disable
-    }
 }

--- a/sapphire/examples/build.gradle
+++ b/sapphire/examples/build.gradle
@@ -1,26 +1,34 @@
 // All default build scripts common to all examples go here.
 // These defaults can be overridden in build.gradle files of individual examples where necessary.
 subprojects {
+    apply plugin: 'java-library'
+
     dependencies {
         compile project(':sapphire-core')
     }
 
+    // Java jar file depends on compile tasks of all sourceSets.
+    // Currently there are two sourceSets - "main" and "stubs".
+    // Java examples will have "main" and "stubs" sourceSets and
+    // non-Java examples will have only "main" sourceSet.
+    jar.dependsOn tasks.withType(AbstractCompile)
+
     // Run OMS
     task runoms(type: JavaExec) {
         classpath = sourceSets.main.runtimeClasspath
+        classpath += sourceSets.stubs.runtimeClasspath
         jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
         main = 'amino.run.oms.OMSServerImpl'
         args project.property('omsIp'), project.property('omsPort')
-        inputs.dir compileStubs
     }
 
     // Run a kernel server
     task runks(type: JavaExec) {
         classpath = sourceSets.main.runtimeClasspath
+        classpath += sourceSets.stubs.runtimeClasspath
         jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
         main = 'amino.run.kernel.server.KernelServerImpl'
         args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort'), project.property("kernelServerRegion")
-        inputs.dir compileStubs
     }
 
     // Run a second kernel server
@@ -50,17 +58,13 @@ subprojects {
     // Run application
     task runapp(type: JavaExec) {
         classpath = sourceSets.main.runtimeClasspath
+        classpath += sourceSets.stubs.runtimeClasspath
         jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
         args project.property('omsIp'), project.property('omsPort'), project.property('embeddedKernelServerIp'), project.property('kernelServerPort')
-        inputs.dir compileStubs
     }
 }
 
 // For the parent examples project itself, we disable inherited tasks that don't make sense at this level.
 genStubs {
-    onlyIf() { false } // Disable
-}
-
-compileStubs {
     onlyIf() { false } // Disable
 }

--- a/sapphire/examples/example-minnietwitter/build.gradle
+++ b/sapphire/examples/example-minnietwitter/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'java-library'
-
 // Customize app stub generation for this example
 genStubs {
     def src = file(project.buildDir.toString() + '/classes/java/main/amino/run/appexamples/minnietwitter/')
@@ -10,14 +8,7 @@ genStubs {
     outputs.dir dst
 }
 
-// Customize stub compilation for this example
-compileStubs {
-    outputs.dir "$buildDir/classes/java/stubs/amino/run/appexamples/minnietwitter/stubs/"
-}
-
 // Customize runapp for this example
 runapp {
     main = "amino.run.appexamples.minnietwitter.MinnieTwitterMain"
 }
-
-jar.dependsOn compileStubs

--- a/sapphire/examples/fundmover/build.gradle
+++ b/sapphire/examples/fundmover/build.gradle
@@ -1,9 +1,8 @@
-apply plugin: 'java-library'
-
 // Customize app stub generation for this example
 dependencies{
     compile 'org.mariadb.jdbc:mariadb-java-client:2.3.0'
 }
+
 genStubs {
     def src =  "$buildDir/classes/java/main/amino/run/appexamples/fundmover"
     def dst = "$projectDir/src/stubs/java/amino/run/appexamples/fundmover/stubs/"
@@ -13,14 +12,7 @@ genStubs {
     inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
-// Customize stub compilation for this example
-compileStubs {
-    outputs.dir "$buildDir/classes/java/stubs/amino/run/appexamples/fundmover/stubs/"
-}
-
 // Customize runapp for this example
 runapp {
     main = "amino.run.appexamples.fundmover.FundmoverMain"
 }
-jar.dependsOn compileStubs
-

--- a/sapphire/examples/hanksTodo/build.gradle
+++ b/sapphire/examples/hanksTodo/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'java-library'
-
 // Customize app stub generation for this example
 genStubs {
     def src = "$buildDir/classes/java/main/amino/run/appexamples/hankstodo"
@@ -10,14 +8,7 @@ genStubs {
     inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
-// Customize stub compilation for this example
-compileStubs {
-    outputs.dir "$buildDir/classes/java/stubs/amino/run/appexamples/hankstodo/stubs/"
-}
-
 // Customize runapp for this example
 runapp {
     main = "amino.run.appexamples.hankstodo.HanksTodoMain"
 }
-jar.dependsOn compileStubs
-

--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'java'
-
 // Customize app stub generation for this example.
 genStubs {
     main = "amino.run.compiler.GraalStubGenerator"

--- a/sapphire/examples/helloworld/build.gradle
+++ b/sapphire/examples/helloworld/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'java-library'
-
 // Customize app stub generation for this example
 genStubs {
     def src = "$buildDir/classes/java/main/amino/run/appexamples/helloworld/"
@@ -9,13 +7,6 @@ genStubs {
     outputs.dir dst // Declare outputs, so gradle will run if they have been changed
     inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
-
-// Customize stub compilation for this example
-compileStubs {
-    outputs.dir "$buildDir/classes/java/stubs/amino/run/appexamples/helloworld/stubs/"
-}
-
-jar.dependsOn compileStubs
 
 // Customise task to run app
 runapp {

--- a/sapphire/examples/kvstore/build.gradle
+++ b/sapphire/examples/kvstore/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'java-library'
-
 // Customize app stub generation for this example
 genStubs {
     def pkg = 'amino.run.demo'
@@ -9,13 +7,6 @@ genStubs {
     outputs.dir dst // Declare outputs, so gradle will run if they have been changed
     inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
-
-// Customize stub compilation for this example
-compileStubs {
-    outputs.dir "$buildDir/classes/java/stubs/amino/run/appexamples/demo/stubs/"
-}
-
-jar.dependsOn compileStubs
 
 // Customize runapp for this example
 runapp {

--- a/sapphire/examples/kvstorejs/build.gradle
+++ b/sapphire/examples/kvstorejs/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'java-library'
-
 // Task for app stub generation
 genStubs {
     main = "amino.run.compiler.GraalStubGenerator"

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -216,4 +216,4 @@ check.dependsOn tasks.googleJavaFormat
 check.dependsOn integTest
 compileJava.dependsOn checkGraalVmVersion
 integTest.mustRunAfter test
-jar.inputs.dir compileStubs.outputs // jar needs to be rebuilt if stubs got recompiled
+jar.inputs.dir compileStubsJava.outputs // jar needs to be rebuilt if stubs got recompiled


### PR DESCRIPTION
This PR has been created for fixing the issue raised in #570 

In this PR the following set of changes has been done, 
1). The "stubs" sourceSet compilation has been mapped to the default Java task "compileStubsJava".
2). The earlier task which was created for compiling stubs "compileStubs" has been removed.
3). The "stubs" sourcSet classpath has been added to the standalone examples tasks (runoms, runks and runapp) so that the execution of standalone tasks are successful.
4). Cleaned up examples module gradle tasks.