### PR TITLE
Rename SapphireUtils package to TestUtils.

### DIFF
--- a/sapphire/sapphire-core/src/test/java/amino/run/common/BaseTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/common/BaseTest.java
@@ -1,8 +1,8 @@
 package amino.run.common;
 
-import static amino.run.common.SapphireUtils.addHost;
-import static amino.run.common.SapphireUtils.startSpiedKernelServer;
-import static amino.run.common.SapphireUtils.startSpiedOms;
+import static amino.run.common.TestUtils.addHost;
+import static amino.run.common.TestUtils.startSpiedKernelServer;
+import static amino.run.common.TestUtils.startSpiedOms;
 import static amino.run.common.UtilsTest.extractFieldValueOnInstance;
 import static org.mockito.Mockito.spy;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -42,7 +42,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
     Sapphire.class,
     KernelObjectFactory.class,
     LocateRegistry.class,
-    SapphireUtils.class,
+    TestUtils.class,
     OMSServerImpl.class,
     Utils.ObjectCloner.class
 })

--- a/sapphire/sapphire-core/src/test/java/amino/run/common/TestUtils.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/common/TestUtils.java
@@ -31,7 +31,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /** Created by Vishwajeet on 4/4/18. */
-public class SapphireUtils {
+public class TestUtils {
     public static Registry dummyRegistry =
             new Registry() {
                 @Override

--- a/sapphire/sapphire-core/src/test/java/amino/run/oms/OMSTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/oms/OMSTest.java
@@ -7,7 +7,7 @@ import amino.run.app.MicroServiceSpec;
 import amino.run.common.BaseTest;
 import amino.run.common.SapphireObjectID;
 import amino.run.common.SapphireReplicaID;
-import amino.run.common.SapphireUtils;
+import amino.run.common.TestUtils;
 import amino.run.kernel.common.KernelOID;
 import amino.run.kernel.server.KernelServerImpl;
 import amino.run.runtime.EventHandler;
@@ -66,7 +66,7 @@ public class OMSTest extends BaseTest {
         SO appObjstub = (SO) sapphireObjServer.acquireSapphireObjectStub(sid);
         assertEquals(
                 1,
-                SapphireUtils.getOmsSapphireInstance(spiedOms, group.getSapphireObjId())
+                TestUtils.getOmsSapphireInstance(spiedOms, group.getSapphireObjId())
                         .getReferenceCount());
 
         /* setI on the client side stub */
@@ -85,7 +85,7 @@ public class OMSTest extends BaseTest {
         /* Reference count must become 2. Once user created it and other attached to it */
         assertEquals(
                 2,
-                SapphireUtils.getOmsSapphireInstance(spiedOms, group.getSapphireObjId())
+                TestUtils.getOmsSapphireInstance(spiedOms, group.getSapphireObjId())
                         .getReferenceCount());
 
         /* setI on the client side stub */
@@ -98,7 +98,7 @@ public class OMSTest extends BaseTest {
         sapphireObjServer.detachFromSapphireObject("MySapphireObject");
         assertEquals(
                 1,
-                SapphireUtils.getOmsSapphireInstance(spiedOms, group.getSapphireObjId())
+                TestUtils.getOmsSapphireInstance(spiedOms, group.getSapphireObjId())
                         .getReferenceCount());
     }
 


### PR DESCRIPTION
This is part of the exercise to rename the project Amino.Run, in the process removing the name Sapphire.

The SapphireUtils package is actually just a utils package used for testing only.  