### PR TITLE
Gradle reorg and cleanup

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -92,6 +92,11 @@ subprojects {
         }
     }
 
+    // Common rules for all JavaExec tasks, being added before execution.
+    tasks.withType(JavaExec).whenTaskAdded {
+        classpath += sourceSets.main.runtimeClasspath
+    }
+
     // SourceSet for generated stubs
     sourceSets {
         stubs
@@ -101,7 +106,6 @@ subprojects {
     // Run `gradlew genStubs` to generate stub files
     task genStubs(type: JavaExec) {
         main = "amino.run.compiler.StubGenerator"
-        classpath = sourceSets.main.runtimeClasspath
     }
 
     // Configure "stubs" sourceSet compile task, with additional rules.
@@ -121,5 +125,12 @@ subprojects {
     // Include stubs sourceSet classes in the jar file.
     jar {
         from sourceSets.stubs.output.classesDir
+        // Java jar file depends on compile tasks of all sourceSets.
+        // Currently there are two sourceSets - "main" and "stubs".
+        // Java modules will have "main" and "stubs" sourceSets and
+        // non-Java examples will have only "main" sourceSet.
+        inputs.dir tasks.withType(AbstractCompile)   // jar needs to be rebuilt if any compileTask gets executed.
     }
+
+    check.dependsOn tasks.withType(AbstractCompile)  // Ensure that all compileTasks are executed, as part of check.
 }

--- a/sapphire/examples/build.gradle
+++ b/sapphire/examples/build.gradle
@@ -7,59 +7,44 @@ subprojects {
         compile project(':sapphire-core')
     }
 
-    // Java jar file depends on compile tasks of all sourceSets.
-    // Currently there are two sourceSets - "main" and "stubs".
-    // Java examples will have "main" and "stubs" sourceSets and
-    // non-Java examples will have only "main" sourceSet.
-    jar.dependsOn tasks.withType(AbstractCompile)
-
-    // Run OMS
-    task runoms(type: JavaExec) {
-        classpath = sourceSets.main.runtimeClasspath
+    // Common rules for all JavaExec tasks, are added before execution.
+    tasks.withType(JavaExec).whenTaskAdded {
         classpath += sourceSets.stubs.runtimeClasspath
         jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
+    }
+    
+    // Run OMS
+    task runoms(type: JavaExec) {
         main = 'amino.run.oms.OMSServerImpl'
         args project.property('omsIp'), project.property('omsPort')
     }
 
     // Run a kernel server
     task runks(type: JavaExec) {
-        classpath = sourceSets.main.runtimeClasspath
-        classpath += sourceSets.stubs.runtimeClasspath
-        jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
         main = 'amino.run.kernel.server.KernelServerImpl'
         args project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort'), project.property("kernelServerRegion")
     }
 
     // Run a second kernel server
     task runks2(type: JavaExec) {
-        classpath = runks.classpath // TODO: How do we create a new task that inherits from an existing task, or takes a parameter?  Hack for now.
-        jvmArgs runks.jvmArgs
-        main = runks.main
+        main = 'amino.run.kernel.server.KernelServerImpl'
         args project.property('kernelServerIp'), project.property('kernelServerPort2'), project.property('omsIp'), project.property('omsPort'), project.property("kernelServerRegion2")
     }
 
     // Run a third kernel server
     task runks3(type: JavaExec) {
-        classpath = runks.classpath
-        jvmArgs runks.jvmArgs
-        main = runks.main
+        main = 'amino.run.kernel.server.KernelServerImpl'
         args project.property('kernelServerIp'), project.property('kernelServerPort3'), project.property('omsIp'), project.property('omsPort'), project.property("kernelServerRegion3")
     }
 
     // Run a fourth kernel server
     task runks4(type: JavaExec) {
-        classpath = runks.classpath
-        jvmArgs runks.jvmArgs
-        main = runks.main
+        main = 'amino.run.kernel.server.KernelServerImpl'
         args project.property('kernelServerIp'), project.property('kernelServerPort4'), project.property('omsIp'), project.property('omsPort'), project.property("kernelServerRegion4")
     }
 
     // Run application
     task runapp(type: JavaExec) {
-        classpath = sourceSets.main.runtimeClasspath
-        classpath += sourceSets.stubs.runtimeClasspath
-        jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
         args project.property('omsIp'), project.property('omsPort'), project.property('embeddedKernelServerIp'), project.property('kernelServerPort')
     }
 }

--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -46,4 +46,3 @@ runapp {
 }
 
 compileJava.dependsOn genStubs
-runapp.dependsOn compileJava

--- a/sapphire/examples/kvstorejs/build.gradle
+++ b/sapphire/examples/kvstorejs/build.gradle
@@ -36,4 +36,3 @@ runapp {
 }
 
 compileJava.dependsOn genStubs
-runapp.dependsOn compileJava

--- a/sapphire/sapphire-core/build.gradle
+++ b/sapphire/sapphire-core/build.gradle
@@ -122,67 +122,71 @@ genStubs {
     inputs.dir src   // Declare inputs, so gradle will run if they have been changed
 }
 
-task genUnitTestStubs(type :JavaExec){
-    main = "amino.run.compiler.StubGenerator"
+task compileSampleSO(type: JavaCompile) {
+    source = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO')
+    exclude('**/*_Stub*')  // Added for excluding older Stub files, while compiling Sample SO package.
     classpath = sourceSets.main.runtimeClasspath
-    classpath += files("$projectDir/build/classes/java/test/")
+    destinationDir = sourceSets.test.output.classesDir
+    options.incremental = true
+}
+
+task genUnitTestStubs(type :JavaExec){
+    dependsOn compileSampleSO
+    main = "amino.run.compiler.StubGenerator"
+    classpath += files(sourceSets.test.output.classesDir)
+
     def pkg = 'amino.run.sampleSO'
     def src = file(project.buildDir.toString() + '/classes/java/test/amino/run/sampleSO/')
     def dst = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO/stubs/')
     args src.toString(), pkg, dst.toString()
-    outputs.dir dst
     inputs.dir src
-}
-
-task compileSampleSO(type: JavaCompile) {
-    source = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO')
-    exclude('**/*_Stub*')  // Added for excluding older Stub files, while compiling Sample SO package.
-    classpath = files(sourceSets.main.output.classesDir)
-    destinationDir = file(project.buildDir.toString() + '/classes/java/test/')
-    options.incremental = true
+    outputs.dir dst
 }
 
 // Task for Graal Test Stubs Generation:
 // Run `gradlew genGraalTestStubs` to generate Graal test stub files
 task genGraalTestStubs(type: JavaExec) {
+    dependsOn compileJava
     main = "amino.run.compiler.GraalStubGenerator"
-    classpath += files(sourceSets.main.output.classesDir)
+
     def sapphireObjectPath = "$projectDir/src/test/resources/student.js"
     def outPath = "$projectDir/src/test/java"
     def packageName = "amino.run.stubs"
     def sapphireClasses = "Student"
     args sapphireObjectPath, outPath, packageName, sapphireClasses
-    outputs.dir outPath + "/amino/run/stubs" // Declare outputs, so gradle will run if they have been changed
     inputs.dir sapphireObjectPath   // Declare inputs, so gradle will run if they have been changed
+    outputs.dir outPath + "/amino/run/stubs" // Declare outputs, so gradle will run if they have been changed
 }
 // Task for Graal Test stubs compilation
 task compileGraalTestStubs(type: JavaCompile) {
+    dependsOn genGraalTestStubs
     source = "$projectDir/src/test/java/amino/run/stubs"
-    classpath = files(sourceSets.main.output.classesDir)
+    classpath = sourceSets.main.runtimeClasspath
     destinationDir = sourceSets.test.output.classesDir
     options.incremental = true
     inputs.dir genGraalTestStubs.outputs
     outputs.dir destinationDir
 }
 
-task genIntegTestStubs(type :JavaExec) {
-    main = "amino.run.compiler.StubGenerator"
-    classpath = sourceSets.main.runtimeClasspath
-    classpath += files("$projectDir/build/classes/java/integrationTest/")
-    def pkg = 'amino.run.demo'
-    def src = file(project.buildDir.toString() + '/classes/java/integrationTest/amino/run/demo')
-    def dst = file(project.projectDir.toString() + '/src/integrationTest/java/amino/run/demo/stubs')
-    args src.toString(), pkg, dst.toString()
-    outputs.dir dst // Declare outputs, so gradle will run if they have been changed
-    inputs.dir src // Declare inputs, so gradle will run if they have been change
-}
-
 task compileIntegTestDemoPkg(type: JavaCompile) {
     source = file(project.projectDir.toString() + '/src/integrationTest/java/amino/run/demo/')
     exclude('**/*_Stub*')  // Added for excluding older Stub files, while compiling Integration Test Demo package.
     classpath = sourceSets.integrationTest.compileClasspath
-    destinationDir = file(project.buildDir.toString() + '/classes/java/integrationTest/')
+    destinationDir = sourceSets.integrationTest.output.classesDir
     options.incremental = true
+}
+
+task genIntegTestStubs(type :JavaExec) {
+    dependsOn compileIntegTestDemoPkg
+    main = "amino.run.compiler.StubGenerator"
+    classpath += files(sourceSets.integrationTest.output.classesDir)
+
+    def pkg = 'amino.run.demo'
+    def src = file(project.buildDir.toString() + '/classes/java/integrationTest/amino/run/demo')
+    def dst = file(project.projectDir.toString() + '/src/integrationTest/java/amino/run/demo/stubs')
+    args src.toString(), pkg, dst.toString()
+    inputs.dir src // Declare inputs, so gradle will run if they have been changed
+    outputs.dir dst // Declare outputs, so gradle will run if they have been changed
 }
 
 clean {
@@ -195,25 +199,15 @@ clean {
     }
 }
 
-tasks.googleJavaFormat.mustRunAfter genStubs
-tasks.googleJavaFormat.mustRunAfter genGraalTestStubs
-tasks.googleJavaFormat.mustRunAfter genUnitTestStubs
-tasks.googleJavaFormat.mustRunAfter genIntegTestStubs
-
-genGraalTestStubs.dependsOn compileJava
-compileGraalTestStubs.dependsOn genGraalTestStubs
-compileTestJava.dependsOn compileGraalTestStubs
-genUnitTestStubs.dependsOn compileSampleSO
-compileTestJava.dependsOn genUnitTestStubs
-genIntegTestStubs.dependsOn compileIntegTestDemoPkg
+compileJava.dependsOn checkGraalVmVersion
+compileTestJava {
+    dependsOn compileGraalTestStubs
+    dependsOn genUnitTestStubs
+}
 compileIntegrationTestJava.dependsOn genIntegTestStubs
 
-tasks.googleJavaFormat.dependsOn genStubs
-tasks.googleJavaFormat.dependsOn genGraalTestStubs
-tasks.googleJavaFormat.dependsOn genIntegTestStubs
-
+tasks.googleJavaFormat.dependsOn tasks.withType(AbstractCompile)
 check.dependsOn tasks.googleJavaFormat
-check.dependsOn integTest
-compileJava.dependsOn checkGraalVmVersion
+
 integTest.mustRunAfter test
-jar.inputs.dir compileStubsJava.outputs // jar needs to be rebuilt if stubs got recompiled
+check.dependsOn integTest


### PR DESCRIPTION
This PR does reorganisation and cleanup of the various gradle tasks across the gradle build files.

This PR has been raised on top of the earlier PR #571 
Hence the modified files are shown as more over here.

This PR need to be merged after merging PR #571
