### PR TITLE
[AutoMigration] Added Metric interface and client in kernel server 

### DIFF
--- a/sapphire/examples/kvstore/src/main/resources/KeyValueStore.yaml
+++ b/sapphire/examples/kvstore/src/main/resources/KeyValueStore.yaml
@@ -9,4 +9,6 @@ dmList:
 javaClassName: amino.run.demo.KeyValueStore
 lang: java
 name: null
+labels: {name: KVStore}
+annotations: {amino.metric : {amino.metric.frequency: 20000, amino.metrics: ["rpc_count", "avg_execution_time"]}}
 sourceFileLocation: null

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/MicroServiceSpec.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/MicroServiceSpec.java
@@ -2,6 +2,7 @@ package amino.run.app;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import org.yaml.snakeyaml.Yaml;
@@ -23,6 +24,7 @@ import org.yaml.snakeyaml.Yaml;
  *                                      .setName("soname")
  *                                      .setLang(Language.Java)
  *                                      .addDMSpec(dm)
+ *                                      .setLabels(labels)
  *                                      .create();
  * </code> Yaml of one MicroService Object Specification Example: <code>
  * !!amino.run.app.MicroServiceSpec
@@ -37,6 +39,8 @@ import org.yaml.snakeyaml.Yaml;
  * lang: js
  * name: com.org.College
  * sourceFileLocation: src/main/js/college.js
+ * labels: {key1: value1, key2: value2}
+ * annotations: {amino.metric : {amino.metric.frequency: 20000, amino.metrics: ["rpc_count"]}}
  * </code>
  */
 public class MicroServiceSpec implements Serializable {
@@ -57,6 +61,12 @@ public class MicroServiceSpec implements Serializable {
 
     /** List of Deployment Managers to be applied on microservice */
     private List<DMSpec> dmList = new ArrayList<DMSpec>();
+
+    /** List of tags (key-value) applied on microservice */
+    private HashMap<String, String> labels;
+
+    /** add specific meta information with microservice */
+    private HashMap<String, Object> annotations;
 
     private NodeSelectorSpec nodeSelectorSpec;
 
@@ -124,6 +134,22 @@ public class MicroServiceSpec implements Serializable {
         this.nodeSelectorSpec = nodeSelectorSpec;
     }
 
+    public HashMap<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(HashMap<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public HashMap<String, Object> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(HashMap<String, Object> annotations) {
+        this.annotations = annotations;
+    }
+
     public static MicroServiceSpec fromYaml(String yamlString) {
         Yaml yaml = new Yaml();
         return yaml.loadAs(yamlString, MicroServiceSpec.class);
@@ -139,7 +165,9 @@ public class MicroServiceSpec implements Serializable {
                 && Objects.equals(javaClassName, that.javaClassName)
                 && Objects.equals(sourceFileLocation, that.sourceFileLocation)
                 && Objects.equals(constructorName, that.constructorName)
-                && Objects.equals(dmList, that.dmList);
+                && Objects.equals(dmList, that.dmList)
+                && Objects.equals(labels, that.labels)
+                && Objects.equals(annotations, that.annotations);
     }
 
     @Override
@@ -151,7 +179,9 @@ public class MicroServiceSpec implements Serializable {
                 sourceFileLocation,
                 constructorName,
                 dmList,
-                nodeSelectorSpec);
+                nodeSelectorSpec,
+                labels,
+                annotations);
     }
 
     @Override
@@ -168,6 +198,8 @@ public class MicroServiceSpec implements Serializable {
         private String constructorName;
         private List<DMSpec> dmList = new ArrayList<DMSpec>();
         private NodeSelectorSpec nodeSelectorSpec;
+        private HashMap<String, String> labels = new HashMap<String, String>();
+        private HashMap<String, Object> annotations = new HashMap<String, Object>();
 
         public Builder setName(String name) {
             this.name = name;
@@ -208,6 +240,16 @@ public class MicroServiceSpec implements Serializable {
             return this;
         }
 
+        public Builder setLabels(HashMap<String, String> labels) {
+            this.labels = labels;
+            return this;
+        }
+
+        public Builder setAnnotations(HashMap<String, Object> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
         public MicroServiceSpec create() {
             MicroServiceSpec spec = new MicroServiceSpec();
             spec.setName(name);
@@ -217,6 +259,8 @@ public class MicroServiceSpec implements Serializable {
             spec.setConstructorName(constructorName);
             spec.setDmList(dmList);
             spec.setNodeSelectorSpec(nodeSelectorSpec);
+            spec.setLabels(labels);
+            spec.setAnnotations(annotations);
             return spec;
         }
     }

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/GlobalKernelReferences.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/GlobalKernelReferences.java
@@ -1,5 +1,6 @@
 package amino.run.kernel.common;
 
+import amino.run.kernel.common.metric.MetricClient;
 import amino.run.kernel.server.KernelServerImpl;
 
 /**
@@ -14,4 +15,5 @@ import amino.run.kernel.server.KernelServerImpl;
  */
 public class GlobalKernelReferences {
     public static KernelServerImpl nodeServer;
+    public static MetricClient metricClient = null;
 }

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/Metric.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/Metric.java
@@ -1,0 +1,28 @@
+package amino.run.kernel.common.metric;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+/** Interface used for metric reporting */
+public interface Metric extends Serializable {
+    /**
+     * Return name of Metric
+     *
+     * @return name
+     */
+    String getName();
+
+    /**
+     * Return labels of metric
+     *
+     * @return labels
+     */
+    HashMap<String, String> getLabels();
+
+    /**
+     * Return true if metric empty
+     *
+     * @return status
+     */
+    boolean isEmpty();
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricClient.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricClient.java
@@ -1,0 +1,39 @@
+package amino.run.kernel.common.metric;
+
+import java.util.ArrayList;
+
+/** Interface used by Kernel server and AppObjects for Metric server interaction */
+public interface MetricClient {
+    /**
+     * Post metric to metric server
+     *
+     * @param metric object maintaining metric information
+     * @throws Exception
+     */
+    void send(Metric metric) throws Exception;
+
+    /**
+     * Post metrics to metric server
+     *
+     * @param metrics object maintaining metric information
+     * @throws Exception
+     */
+    void send(ArrayList<Metric> metrics) throws Exception;
+
+    /**
+     * Check metric registration with Metric server
+     *
+     * @param schema which need to check for registration status
+     * @return registration status
+     */
+    boolean isRegistered(MetricSchema schema);
+
+    /**
+     * Register metric schema with Metric server
+     *
+     * @param schema which need to register
+     * @return registration status
+     * @throws SchemaAlreadyRegistered if already registered
+     */
+    boolean register(MetricSchema schema) throws SchemaAlreadyRegistered;
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricCollector.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricCollector.java
@@ -1,0 +1,20 @@
+package amino.run.kernel.common.metric;
+
+import java.io.Serializable;
+
+/** */
+public interface MetricCollector extends Serializable {
+    /**
+     * Return latest collected metric data
+     *
+     * @return metric
+     */
+    Metric getMetric();
+
+    /**
+     * Return schema of Metrics collected
+     *
+     * @return schema
+     */
+    MetricSchema getSchema();
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricConstants.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricConstants.java
@@ -1,0 +1,11 @@
+package amino.run.kernel.common.metric;
+
+/** Metric specific constants. */
+public class MetricConstants {
+    /** Constant for enabling metric collection */
+    public static String METRIC_ANNOTATION = "amino.metric";
+    /** Constant for metric collection frequency configuration */
+    public static String METRIC_FREQUENCY = "amino.metric.frequency";
+    /** Constant for list of enabled metrics */
+    public static String METRIC_LIST = "amino.metrics";
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricLoggingClient.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricLoggingClient.java
@@ -1,0 +1,43 @@
+package amino.run.kernel.common.metric;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.logging.Logger;
+
+/**
+ * Metric client implementation which prints Metrics on Console.
+ *
+ * <p>If no Metric client configured on kernel server, Kernel server by default initializes
+ * MetricLoggingClient specially for printing Kernel server Metric.
+ */
+public class MetricLoggingClient implements MetricClient {
+    private static Logger logger = Logger.getLogger(MetricLoggingClient.class.getName());
+    private HashSet<MetricSchema> schemas = new HashSet<MetricSchema>();
+
+    @Override
+    public void send(Metric metric) throws Exception {
+        logger.info(String.format("Metric collected : %s", metric));
+    }
+
+    @Override
+    public void send(ArrayList<Metric> metrics) throws Exception {
+        for (Metric metric : metrics) {
+            logger.info(String.format("Metric collected : %s", metric));
+        }
+    }
+
+    @Override
+    public boolean isRegistered(MetricSchema schema) {
+        return schemas.contains(schema);
+    }
+
+    @Override
+    public boolean register(MetricSchema schema) throws SchemaAlreadyRegistered {
+        if (schemas.contains(schema)) {
+            throw new SchemaAlreadyRegistered();
+        }
+        schemas.add(schema);
+        logger.info(String.format("Metric schema %s registered", schema));
+        return true;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricSchema.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/MetricSchema.java
@@ -1,0 +1,32 @@
+package amino.run.kernel.common.metric;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+/** Interface used for Metric metadata replay to Metric server */
+public interface MetricSchema extends Serializable {
+    /**
+     * Return Metric name
+     *
+     * @return name
+     */
+    String getName();
+
+    /**
+     * Return Metric labels
+     *
+     * @return labels
+     */
+    HashMap<String, String> getLabels();
+
+    /**
+     * Return kind of Metric.
+     *
+     * <p>Type of metric determine format of Metric getting send and stored. Counter, Gauge,
+     * Histogram or WMA are some example of some type. With Type of metric Metric server creates
+     * Object to store the incoming Metric information.
+     *
+     * @return
+     */
+    String getMetricType();
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/SchemaAlreadyRegistered.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/SchemaAlreadyRegistered.java
@@ -1,0 +1,23 @@
+package amino.run.kernel.common.metric;
+
+/** Thrown when Schema already present on Metric server. */
+public class SchemaAlreadyRegistered extends Exception {
+    public SchemaAlreadyRegistered() {
+        // TODO Auto-generated constructor stub
+    }
+
+    public SchemaAlreadyRegistered(String message) {
+        super(message);
+        // TODO Auto-generated constructor stub
+    }
+
+    public SchemaAlreadyRegistered(Throwable cause) {
+        super(cause);
+        // TODO Auto-generated constructor stub
+    }
+
+    public SchemaAlreadyRegistered(String message, Throwable cause) {
+        super(message, cause);
+        // TODO Auto-generated constructor stub
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/ExecutionTimeHandler.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/ExecutionTimeHandler.java
@@ -1,0 +1,68 @@
+package amino.run.kernel.common.metric.metricHandler;
+
+import amino.run.kernel.common.metric.Metric;
+import amino.run.kernel.common.metric.MetricSchema;
+import amino.run.kernel.common.metric.schema.SummarySchema;
+import amino.run.kernel.common.metric.type.SummaryMetric;
+import amino.run.policy.DefaultPolicy;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * RPC metric collector which collects execution time metric.
+ *
+ * <p>This should be last RPC metric handler in chain as this performs actual onRPC call. Execution
+ * time metric collection can be enabled with {@link
+ * amino.run.kernel.common.metric.MetricConstants}.METRIC_LIST.
+ */
+public class ExecutionTimeHandler extends RPCMetricHandler {
+    public static transient String metricName = "avg_execution_time";
+    private transient DefaultPolicy.DefaultServerPolicy policy;
+    private long totalExecutionTime = 0;
+    private int rpcCount = 0;
+    private transient HashMap<String, String> labels;
+    private transient boolean enabled;
+
+    public ExecutionTimeHandler(
+            HashMap<String, String> labels,
+            DefaultPolicy.DefaultServerPolicy policy,
+            boolean enabled) {
+        this.policy = policy;
+        this.labels = labels;
+        this.enabled = enabled;
+    }
+
+    @Override
+    public Object handle(String method, ArrayList<Object> params) throws Exception {
+        if (!enabled) {
+            return policy.getAppObject().invoke(method, params);
+        }
+        long startTime = System.nanoTime();
+        Object object = policy.getAppObject().invoke(method, params);
+        synchronized (this) {
+            totalExecutionTime = System.nanoTime() - startTime;
+            rpcCount++;
+        }
+        return object;
+    }
+
+    @Override
+    public Metric getMetric() {
+        if (!enabled || rpcCount == 0) {
+            return null;
+        }
+
+        synchronized (this) {
+            SummaryMetric metric =
+                    new SummaryMetric(metricName, labels, totalExecutionTime, rpcCount);
+            totalExecutionTime = 0;
+            rpcCount = 0;
+            return metric;
+        }
+    }
+
+    @Override
+    public MetricSchema getSchema() {
+        return new SummarySchema(metricName, labels);
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/MetricHandler.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/MetricHandler.java
@@ -1,0 +1,166 @@
+package amino.run.kernel.common.metric.metricHandler;
+
+import amino.run.app.MicroServiceSpec;
+import amino.run.common.ReplicaID;
+import amino.run.kernel.common.GlobalKernelReferences;
+import amino.run.kernel.common.metric.*;
+import amino.run.policy.DefaultPolicy;
+import amino.run.policy.util.ResettableTimer;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.TimerTask;
+import java.util.logging.Logger;
+
+public class MetricHandler implements Serializable {
+    private static Logger logger = Logger.getLogger(MetricHandler.class.getName());
+    private transient DefaultPolicy.DefaultServerPolicy policy;
+    private transient HashMap<String, Object> metricMetadata;
+    private transient RPCMetricHandler rpcMetricHandler;
+    private transient ResettableTimer metricSendTimer;
+    private transient HashMap<String, String> labels;
+    private transient int metricUpdateFrequency = 10000;
+    public static transient String REPLICA_ID_LABEL = "ReplicaID";
+    public static transient String MICRO_SERVICE_ID_LABEL = "MicroServiceID";
+
+    private MetricHandler(
+            DefaultPolicy.DefaultServerPolicy policy,
+            HashMap<String, Object> metricMetadata,
+            HashMap<String, String> microServiceLabels) {
+        this.policy = policy;
+        this.metricMetadata = metricMetadata;
+
+        // construct metric label
+        ReplicaID replicaID = policy.getReplicaId();
+        HashMap<String, String> labels = new HashMap<String, String>();
+        labels.put(REPLICA_ID_LABEL, replicaID.getID().toString());
+        labels.put(MICRO_SERVICE_ID_LABEL, replicaID.getOID().getID().toString());
+        labels.putAll(microServiceLabels);
+        this.labels = labels;
+
+        // update metric update frequency
+        Object object = metricMetadata.get(MetricConstants.METRIC_FREQUENCY);
+        if (object instanceof Integer) {
+            metricUpdateFrequency = (Integer) object;
+        }
+    }
+
+    public Object onRPC(String method, ArrayList<Object> params) throws Exception {
+        return rpcMetricHandler.handle(method, params);
+    }
+
+    public static MetricHandler create(
+            DefaultPolicy.DefaultServerPolicy policy, MicroServiceSpec spec) {
+        HashMap<String, Object> annotations = spec.getAnnotations();
+        if (annotations == null
+                || annotations.isEmpty()
+                || !annotations.containsKey(MetricConstants.METRIC_ANNOTATION)) {
+            return null;
+        }
+
+        if (GlobalKernelReferences.metricClient == null) {
+            logger.warning(
+                    String.format(
+                            "Metric client not initialize. Skipping metric collection for %s",
+                            spec.getLabels()));
+            return null;
+        }
+
+        Object object = annotations.get(MetricConstants.METRIC_ANNOTATION);
+        if (!(object instanceof HashMap)) {
+            return null;
+        }
+        HashMap<String, Object> metricMetadata = (HashMap<String, Object>) object;
+
+        MetricHandler handler = new MetricHandler(policy, metricMetadata, spec.getLabels());
+        handler.initialize();
+        return handler;
+    }
+
+    private void initialize() {
+        // TODO initialize metrics which need to get collected based on Developer input
+        rpcMetricHandler = constructRPCMetricHandlerChain();
+
+        metricSendTimer =
+                new ResettableTimer(
+                        new TimerTask() {
+                            public void run() {
+                                ArrayList<Metric> metrics = new ArrayList<Metric>();
+                                Metric metric;
+                                try {
+                                    // collect metric for all RPC specific Metric
+                                    RPCMetricHandler handler = rpcMetricHandler;
+                                    while (handler != null) {
+                                        metric = handler.getMetric();
+                                        if (metric != null && !metric.isEmpty()) {
+                                            metrics.add(metric);
+                                        }
+                                        handler = handler.getNextHandler();
+                                    }
+
+                                    // collect DM specific metrics
+                                    metrics.addAll(policy.getDMMetrics());
+
+                                    GlobalKernelReferences.metricClient.send(metrics);
+                                } catch (Exception e) {
+                                    logger.warning(
+                                            String.format(
+                                                    "%s: Sending metric failed", e.toString()));
+                                    return;
+                                }
+                                // reset the count value and timer after push is done
+                                metricSendTimer.reset();
+                            }
+                        },
+                        metricUpdateFrequency);
+        metricSendTimer.start();
+    }
+
+    private void registerSchema(MetricSchema schema) {
+        try {
+            // register memory stat metric
+            if (!GlobalKernelReferences.metricClient.isRegistered(schema)) {
+                GlobalKernelReferences.metricClient.register(schema);
+            }
+        } catch (SchemaAlreadyRegistered e) {
+            logger.warning(e.getMessage());
+        }
+    }
+
+    private RPCMetricHandler constructRPCMetricHandlerChain() {
+        RPCMetricHandler prevHandler;
+
+        Object object = metricMetadata.get(MetricConstants.METRIC_LIST);
+        ArrayList<String> enabledMetric = new ArrayList<String>();
+        if (object instanceof ArrayList) {
+            enabledMetric.addAll((ArrayList<String>) object);
+        }
+
+        // execution time handler should be last in chain
+        RPCMetricHandler handler;
+        if (enabledMetric.contains(ExecutionTimeHandler.metricName)) {
+            handler = new ExecutionTimeHandler(labels, policy, true);
+        } else {
+            handler = new ExecutionTimeHandler(labels, policy, false);
+        }
+        registerSchema(handler.getSchema());
+        prevHandler = handler;
+
+        // rpc data handler creation
+        if (enabledMetric.contains(RPCDataHandler.metricName)) {
+            handler = new RPCDataHandler(labels);
+            registerSchema(handler.getSchema());
+            handler.setNextHandler(prevHandler);
+            prevHandler = handler;
+        }
+
+        // rpc counter creation
+        if (enabledMetric.contains(RPCCountHandler.metricName)) {
+            handler = new RPCCountHandler(labels);
+            registerSchema(handler.getSchema());
+            handler.setNextHandler(prevHandler);
+        }
+
+        return handler;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/RPCCountHandler.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/RPCCountHandler.java
@@ -1,0 +1,50 @@
+package amino.run.kernel.common.metric.metricHandler;
+
+import amino.run.kernel.common.metric.Metric;
+import amino.run.kernel.common.metric.MetricSchema;
+import amino.run.kernel.common.metric.schema.CounterSchema;
+import amino.run.kernel.common.metric.type.CounterMetric;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/** Counter is a cumulative metric that represents a single monotonically increasing counter. */
+public class RPCCountHandler extends RPCMetricHandler {
+    public static transient String metricName = "rpc_count";
+    private long count = 0;
+    private transient HashMap<String, String> labels;
+    private boolean refreshed;
+
+    @Override
+    public String toString() {
+        return metricName + "<" + labels.toString() + ":" + count + ">";
+    }
+
+    public RPCCountHandler(HashMap<String, String> labels) {
+        this.labels = labels;
+    }
+
+    @Override
+    public Object handle(String method, ArrayList<Object> params) throws Exception {
+        synchronized (this) {
+            refreshed = true;
+            count++;
+        }
+        return nextHandler.handle(method, params);
+    }
+
+    @Override
+    public Metric getMetric() {
+        if (!refreshed) {
+            return null;
+        }
+        synchronized (this) {
+            refreshed = false;
+            return new CounterMetric(metricName, labels, count);
+        }
+    }
+
+    @Override
+    public MetricSchema getSchema() {
+        return new CounterSchema(metricName, labels);
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/RPCDataHandler.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/RPCDataHandler.java
@@ -1,0 +1,68 @@
+package amino.run.kernel.common.metric.metricHandler;
+
+import amino.run.kernel.common.metric.Metric;
+import amino.run.kernel.common.metric.MetricSchema;
+import amino.run.kernel.common.metric.schema.SummarySchema;
+import amino.run.kernel.common.metric.type.SummaryMetric;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/** RPC metric handler for collecting average metric data processes over RPC. */
+public class RPCDataHandler extends RPCMetricHandler {
+    public static transient String metricName = "avg_rpc_data";
+    private long totalVolume = 0; // in byte
+    private int rpcCount = 0;
+    private transient HashMap<String, String> labels;
+
+    @Override
+    public String toString() {
+        return metricName + "<" + labels.toString() + ":" + totalVolume + ">";
+    }
+
+    public RPCDataHandler(HashMap<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public Object handle(String method, ArrayList<Object> params) throws Exception {
+        Object object = nextHandler.handle(method, params);
+        synchronized (this) {
+            totalVolume += sizeOf(method, params, object);
+            rpcCount++;
+        }
+        return object;
+    }
+
+    @Override
+    public Metric getMetric() {
+        if (rpcCount == 0) {
+            return null;
+        }
+        synchronized (this) {
+            SummaryMetric metric = new SummaryMetric(metricName, labels, totalVolume, rpcCount);
+            totalVolume = 0;
+            rpcCount = 0;
+            return metric;
+        }
+    }
+
+    @Override
+    public MetricSchema getSchema() {
+        return new SummarySchema(metricName, labels);
+    }
+
+    private int sizeOf(String method, ArrayList<Object> params, Object object) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(object);
+        out.writeObject(method);
+        out.writeObject(params);
+        out.flush();
+        /*  Subtract 4 bytes from the length, because the serialization
+        magic number (2 bytes) and version number (2 bytes) are
+        both written to the stream before the object
+        */
+        return baos.toByteArray().length - 4;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/RPCMetricHandler.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/metricHandler/RPCMetricHandler.java
@@ -1,0 +1,41 @@
+package amino.run.kernel.common.metric.metricHandler;
+
+import amino.run.kernel.common.metric.MetricCollector;
+import java.util.ArrayList;
+
+/**
+ * Base implementation for RPC metric handling.
+ *
+ * <p>All RPC metric handler should extends this class.
+ */
+public abstract class RPCMetricHandler implements MetricCollector {
+    protected RPCMetricHandler nextHandler;
+
+    /**
+     * Collect metric processing and call next metric handler for further metric collection in chain
+     *
+     * @param method rpc method
+     * @param params rpc parameters
+     * @return rpc response
+     * @throws Exception
+     */
+    public abstract Object handle(String method, ArrayList<Object> params) throws Exception;
+
+    /**
+     * set next rpc metric handler in chain
+     *
+     * @param handler
+     */
+    public void setNextHandler(RPCMetricHandler handler) {
+        nextHandler = handler;
+    }
+
+    /**
+     * get next rpc metric handler
+     *
+     * @return rpc metric handler
+     */
+    public RPCMetricHandler getNextHandler() {
+        return nextHandler;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/CounterSchema.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/CounterSchema.java
@@ -1,0 +1,14 @@
+package amino.run.kernel.common.metric.schema;
+
+import java.util.HashMap;
+
+public class CounterSchema extends Schema {
+    public CounterSchema(String metricName, HashMap<String, String> labels) {
+        super(metricName, labels);
+    }
+
+    @Override
+    public String getMetricType() {
+        return "CounterMetric";
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/GaugeSchema.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/GaugeSchema.java
@@ -1,0 +1,14 @@
+package amino.run.kernel.common.metric.schema;
+
+import java.util.HashMap;
+
+public class GaugeSchema extends Schema {
+    public GaugeSchema(String metricName, HashMap<String, String> labels) {
+        super(metricName, labels);
+    }
+
+    @Override
+    public String getMetricType() {
+        return "GaugeMetric";
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/Schema.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/Schema.java
@@ -1,0 +1,30 @@
+package amino.run.kernel.common.metric.schema;
+
+import amino.run.kernel.common.metric.MetricSchema;
+import java.util.HashMap;
+
+public abstract class Schema implements MetricSchema {
+    private String metricName;
+    private HashMap<String, String> labels;
+
+    public Schema(String metricName, HashMap<String, String> labels) {
+        this.labels = labels;
+        this.metricName = metricName;
+    }
+
+    @Override
+    public String getName() {
+        return metricName;
+    }
+
+    @Override
+    public HashMap<String, String> getLabels() {
+        return labels;
+    }
+
+    public abstract String getMetricType();
+
+    public String toString() {
+        return "<" + metricName + ":" + labels + ">";
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/SummarySchema.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/schema/SummarySchema.java
@@ -1,0 +1,14 @@
+package amino.run.kernel.common.metric.schema;
+
+import java.util.HashMap;
+
+public class SummarySchema extends Schema {
+    public SummarySchema(String metricName, HashMap<String, String> labels) {
+        super(metricName, labels);
+    }
+
+    @Override
+    public String getMetricType() {
+        return "SummarySchema";
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/CounterMetric.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/CounterMetric.java
@@ -1,0 +1,35 @@
+package amino.run.kernel.common.metric.type;
+
+import amino.run.kernel.common.metric.Metric;
+import java.util.HashMap;
+
+/** Counter metric reporting class */
+public class CounterMetric extends MetricValue implements Metric {
+    private String metricName;
+    private HashMap<String, String> labels;
+
+    public CounterMetric(String metricName, HashMap<String, String> labels, long count) {
+        super(count, System.currentTimeMillis());
+        this.metricName = metricName;
+        this.labels = labels;
+    }
+
+    @Override
+    public String getName() {
+        return metricName;
+    }
+
+    @Override
+    public HashMap<String, String> getLabels() {
+        return labels;
+    }
+
+    public String toString() {
+        return "<" + metricName + ":" + labels + ":" + value + ">";
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return value == null;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/GaugeMetric.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/GaugeMetric.java
@@ -1,0 +1,34 @@
+package amino.run.kernel.common.metric.type;
+
+import amino.run.kernel.common.metric.Metric;
+import java.util.HashMap;
+
+/** Gauge metric reporting class */
+public class GaugeMetric extends MetricValue implements Metric {
+    private String metricName;
+    private HashMap<String, String> labels;
+
+    public GaugeMetric(String metricName, HashMap<String, String> labels, Object value) {
+        super(value, System.currentTimeMillis());
+        this.metricName = metricName;
+        this.labels = labels;
+    }
+
+    @Override
+    public String getName() {
+        return metricName;
+    }
+
+    @Override
+    public HashMap<String, String> getLabels() {
+        return labels;
+    }
+
+    public boolean isEmpty() {
+        return value == null;
+    }
+
+    public String toString() {
+        return "<" + metricName + ":" + labels + ":" + value + ">";
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/MetricValue.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/MetricValue.java
@@ -1,0 +1,29 @@
+package amino.run.kernel.common.metric.type;
+
+/** Class maintains Metric data and time */
+public class MetricValue {
+    protected Object value;
+    protected long time;
+
+    public MetricValue(Object value, long time) {
+        this.time = time;
+        this.value = value;
+    }
+    /**
+     * return metric data
+     *
+     * @return
+     */
+    public Object getValue() {
+        return value;
+    }
+
+    /**
+     * return time
+     *
+     * @return
+     */
+    public long getTime() {
+        return time;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/SummaryMetric.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/common/metric/type/SummaryMetric.java
@@ -1,0 +1,43 @@
+package amino.run.kernel.common.metric.type;
+
+import amino.run.kernel.common.metric.Metric;
+import java.util.HashMap;
+
+public class SummaryMetric extends MetricValue implements Metric {
+    private String metricName;
+    private HashMap<String, String> labels;
+    private int observationCount;
+
+    public SummaryMetric(
+            String metricName,
+            HashMap<String, String> labels,
+            long observationSum,
+            int observationCount) {
+        super(observationSum, System.currentTimeMillis());
+        this.metricName = metricName;
+        this.labels = labels;
+        this.observationCount = observationCount;
+    }
+
+    @Override
+    public String getName() {
+        return metricName;
+    }
+
+    @Override
+    public HashMap<String, String> getLabels() {
+        return labels;
+    }
+
+    public int getObservationCount() {
+        return observationCount;
+    }
+
+    public boolean isEmpty() {
+        return observationCount == 0;
+    }
+
+    public String toString() {
+        return "<" + metricName + ":" + labels + ":" + value + ">";
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/server/KernelServerStat.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/server/KernelServerStat.java
@@ -1,0 +1,109 @@
+package amino.run.kernel.server;
+
+import amino.run.kernel.common.GlobalKernelReferences;
+import amino.run.kernel.common.ServerInfo;
+import amino.run.kernel.common.metric.*;
+import amino.run.kernel.common.metric.schema.GaugeSchema;
+import amino.run.kernel.common.metric.type.GaugeMetric;
+import amino.run.policy.util.ResettableTimer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.TimerTask;
+import java.util.logging.Logger;
+
+/**
+ * Update Kernel server statistics to Metric server.
+ *
+ * <p>Reports Kernel server statistics to Metric server.
+ */
+public class KernelServerStat {
+    public static final String KERNEL_SERVER_MEMORY_STAT = "kernel_server_memory_stat";
+    public static final String KERNEL_SERVER_HOST = "host";
+    public static final String KERNEL_SERVER_PORT = "port";
+    public static final long KERNEL_SERVER_MEMORY_STAT_FREQUENCY = 100000;
+    private static Logger logger = Logger.getLogger(KernelServerStat.class.getName());
+    private ServerInfo srvInfo;
+    private MetricClient client = GlobalKernelReferences.metricClient;
+    private HashMap<String, String> kernelServerMetricLabels;
+    private ResettableTimer timer;
+    private ArrayList<MetricCollector> collectors = new ArrayList<MetricCollector>();
+
+    KernelServerStat(ServerInfo srvInfo) {
+        this.srvInfo = srvInfo;
+    }
+
+    /**
+     * Initialize and start kernel server metric collection.
+     *
+     * @throws Exception
+     */
+    public void start() throws Exception {
+        if (client == null) {
+            logger.warning("Metric client not initialize. Skipping kernel server stat monitoring");
+            return;
+        }
+
+        kernelServerMetricLabels = new HashMap<String, String>();
+        kernelServerMetricLabels.put(KERNEL_SERVER_HOST, srvInfo.getHost().getHostName());
+        kernelServerMetricLabels.put(
+                KERNEL_SERVER_PORT, String.valueOf(srvInfo.getHost().getPort()));
+
+        // Memory stat collection
+        MemoryStat memStat = new MemoryStat();
+        registerSchema(memStat.getSchema());
+        collectors.add(memStat);
+
+        timer =
+                new ResettableTimer(
+                        new TimerTask() {
+                            public void run() {
+                                ArrayList<Metric> metrics = new ArrayList<Metric>();
+                                Metric metric;
+                                try {
+                                    for (MetricCollector collector : collectors) {
+                                        metric = collector.getMetric();
+                                        if (!metric.isEmpty()) {
+                                            metrics.add(collector.getMetric());
+                                        }
+                                    }
+                                    client.send(metrics);
+                                } catch (Exception e) {
+                                    logger.warning(
+                                            String.format(
+                                                    "%s: Sending metric failed", e.toString()));
+                                    return;
+                                }
+                                // reset the count value and timer after push is done
+                                timer.reset();
+                            }
+                        },
+                        KERNEL_SERVER_MEMORY_STAT_FREQUENCY);
+        timer.start();
+    }
+
+    private class MemoryStat implements MetricCollector {
+        @Override
+        public Metric getMetric() {
+            return new GaugeMetric(
+                    KERNEL_SERVER_MEMORY_STAT,
+                    kernelServerMetricLabels,
+                    Runtime.getRuntime().freeMemory());
+        }
+
+        @Override
+        public MetricSchema getSchema() {
+            return new GaugeSchema(KERNEL_SERVER_MEMORY_STAT, kernelServerMetricLabels);
+        }
+    }
+
+    private void registerSchema(MetricSchema schema) throws Exception {
+        try {
+            // register memory stat metric
+            if (!client.isRegistered(schema)) {
+                client.register(schema);
+            }
+        } catch (SchemaAlreadyRegistered e) {
+            logger.warning(e.getMessage());
+        }
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveBase.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveBase.java
@@ -148,7 +148,7 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultPolicy {
          */
         public MethodInvocationResponse onRPC(MethodInvocationRequest request) {
             try {
-                Object ret = getAppObject().invoke(request.getMethodName(), request.getParams());
+                Object ret = super.onRPC(request.getMethodName(), request.getParams());
                 return new MethodInvocationResponse(
                         MethodInvocationResponse.ReturnCode.SUCCESS, ret);
             } catch (Exception e) {

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveSyncPolicy.java
@@ -55,7 +55,7 @@ public class LoadBalancedMasterSlaveSyncPolicy extends LoadBalancedMasterSlaveBa
             RequestReplicator replicator = new RequestReplicator(config, groupPolicy);
             replicator.open();
 
-            commitExecutor = new Committer(appObject, 0L, config);
+            commitExecutor = new Committer(this, 0L, config);
             commitExecutor.open();
             processor = new Processor(config, groupPolicy, commitExecutor, replicator);
             processor.open();

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/serializability/SerializableRPCPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/serializability/SerializableRPCPolicy.java
@@ -28,7 +28,7 @@ public class SerializableRPCPolicy extends DefaultPolicy {
          */
         @Override
         public synchronized Object onRPC(String method, ArrayList<Object> params) throws Exception {
-            return appObject.invoke(method, params);
+            return super.onRPC(method, params);
         }
     }
 


### PR DESCRIPTION
This PR is sub part of PR #530 and build on top of #560 
Following are code changes introduced:
1. Added ```label``` field in MicroserviceSpec. Same labels are used for tagging metric data as well.
2. With MicroService labels, ReplicaID and MicroServiceID are also used for tagging Metric data.
3. Added ```Annotations``` which is used for enabling and configuring Metric collection. Annotations will be used for enabling Migration for MicroService.
4. Added Metric client for each kernel server. This client will get initialized during KernelServer bootstrapping. Currently ```MetricLoggingClient``` is used which pushes Metric data on console.
5. Following interfaces are introduced:
	a. Metric interface: This interface represent Metric object which will be pushed to Metric server.
	b. MetricClient interface: Represent operations required by any Metric client.
	c. MetricCollector interface: Represents objects which collects metrics
	d. MetricSchema interface: Represents different type(counter, gauge, summary) of metric getting collected. Basically ```Metrischema``` is used to inform MetricServer about nature of incoming metric Data.
6. This PR has Counter, Gauge and Summary metric types implementation.
7. Currently following metrics are managed:
	a. RPC count
	b. Volume of RPC data 
	c. RPC execution time
8. This PR has removed ```getMemoryStatThread``` which prints KernelServer Memory stat on console. Introduced ```KernelServerStat``` class which currently pushes Memory stat to metric client.
9. Added MetricHandler class with following responsibility:
	1. Create a RPC ```MetricCollector``` chain which intercept normal onRPC call and collect metric.
	2. Maintain a Timer thread which collects Metric from each Metric collector and push them to Metric client.
	3. It also call ```getDMMetrics``` which collects metric from each DM chain and push them to Metric client.
9. Modification introduced in ```DefaultServerPolicy```:
	a. Added ```MetricHandler``` variable. This variable is only initialized for first policy in policy chain. 
	b. Override onRPC call where ```MetricHandler``` is called if already initialized.
	c. Added ```getDMMetric``` method which return DM specific Metric . Each DM whished to maintain DM specific Metric must overrides this method and call super.getDMMetric
           and append metric returned metric.
Fixes #643