### PR TITLE
Changed server list from arraylist to concurrent hashmap

### DIFF
--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
@@ -262,14 +262,7 @@ public class ScaleUpFrontendPolicy extends LoadBalancedFrontendPolicy {
                         "Cannot scale down. Current replica count is " + serverList.size());
             }
 
-            Policy.ServerPolicy serverToRemove = null;
-            for (Policy.ServerPolicy serverPolicyStub : serverList) {
-                if (serverPolicyStub.$__getKernelOID().equals(server.$__getKernelOID())) {
-                    serverToRemove = serverPolicyStub;
-                    break;
-                }
-            }
-
+            Policy.ServerPolicy serverToRemove = getServer(server.getReplicaId());
             if (serverToRemove != null) {
                 try {
                     terminate(serverToRemove);

--- a/sapphire/sapphire-core/src/test/java/amino/run/policy/DefaultPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/policy/DefaultPolicyTest.java
@@ -1,6 +1,9 @@
 package amino.run.policy;
 
+import amino.run.common.MicroServiceID;
+import amino.run.common.ReplicaID;
 import amino.run.kernel.common.KernelOID;
+import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,12 +19,14 @@ public class DefaultPolicyTest {
     public void setup() throws Exception {
         cnt = 1000;
         group = new DefaultPolicy.DefaultGroupPolicy();
+        MicroServiceID serviceId = new MicroServiceID(UUID.randomUUID());
         addThreads = new Thread[cnt];
         delThreads = new Thread[cnt];
         servers = new DefaultPolicy.DefaultServerPolicy[cnt];
         for (int i = 0; i < addThreads.length; i++) {
             servers[i] = new DefaultPolicy.DefaultServerPolicy();
             servers[i].$__setKernelOID(new KernelOID(i));
+            servers[i].setReplicaId(new ReplicaID(serviceId, UUID.randomUUID()));
         }
 
         for (int i = 0; i < addThreads.length; i++) {

--- a/sapphire/sapphire-core/src/test/java/amino/run/policy/replication/ConsensusRSMPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/policy/replication/ConsensusRSMPolicyTest.java
@@ -22,6 +22,8 @@ import amino.run.app.Language;
 import amino.run.app.MicroServiceSpec;
 import amino.run.app.NodeSelectorSpec;
 import amino.run.common.BaseTest;
+import amino.run.common.MicroServiceID;
+import amino.run.common.ReplicaID;
 import amino.run.common.Utils;
 import amino.run.kernel.common.KernelOID;
 import amino.run.policy.Policy;
@@ -32,6 +34,7 @@ import amino.run.sampleSO.SO;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -158,6 +161,9 @@ public class ConsensusRSMPolicyTest extends BaseTest {
     public void groupPolicyOnCreateFailure() throws Exception {
         Policy.ServerPolicy server = spy(ConsensusRSMPolicy.ServerPolicy.class);
         Policy.GroupPolicy group = spy(ConsensusRSMPolicy.GroupPolicy.class);
+        when(server.getReplicaId())
+                .thenReturn(
+                        new ReplicaID(new MicroServiceID(UUID.randomUUID()), UUID.randomUUID()));
         when(group.getServers()).thenThrow(new RemoteException());
         thrown.expect(Error.class);
         group.onCreate("", server, new MicroServiceSpec());


### PR DESCRIPTION
Prior to MultiDM version of code, `servers` maintained in group policy used to be a Set backed by Hashmap. During MultiDM it was changed to array list due to some problems encountered because of too many calls to addServer/updateServer/removeServer from different context. 
Going forward we would have a need to find the specific server policy with in the group policy by key(i.e., oid). For example, in object monitoring when OMS receives the status reports from Kernel Server for the server policies it has, respective DM group policy would have to handle and process  report for that particular server policy. So, search to find the server from its `servers` should be efficient.
After PR #532, addServer() and removeServer() are local calls within group policy context. So it is fine to make `servers` a hashmap now.  
                       