### PR TITLE
[WIP] Region variable removed from Group policy

### DIFF
--- a/sapphire/sapphire-core/src/main/java/amino/run/app/DMSpec.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/DMSpec.java
@@ -15,6 +15,7 @@ import org.yaml.snakeyaml.Yaml;
 public final class DMSpec implements Serializable {
     private String name;
     private List<SapphirePolicyConfig> configs = new ArrayList<>();
+    private NodeSelectorSpec nodeSpec;
 
     /**
      * Returns a builder class for DMSpec.
@@ -32,6 +33,10 @@ public final class DMSpec implements Serializable {
      */
     public String getName() {
         return name;
+    }
+
+    public NodeSelectorSpec getNodeSpec() {
+        return nodeSpec;
     }
 
     /**

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/NodeSelectorSpec.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/NodeSelectorSpec.java
@@ -30,6 +30,7 @@ import org.yaml.snakeyaml.Yaml;
 public class NodeSelectorSpec implements Serializable {
     public Set<String> orLabels = new HashSet<>();
     public Set<String> andLabels = new HashSet<>();
+    public boolean topologicalAffinity = true;
 
     public Set<String> getOrLabels() {
         return Collections.unmodifiableSet(orLabels);
@@ -39,6 +40,13 @@ public class NodeSelectorSpec implements Serializable {
         return Collections.unmodifiableSet(andLabels);
     }
 
+    public boolean isTopologicalAffinity() {
+        return topologicalAffinity;
+    }
+
+    public void enableTopologicalAffinity() {
+        topologicalAffinity = true;
+    }
     /**
      * Adds the label into {@code andLabels} set Null label or empty label is ignored.
      *

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
@@ -48,16 +48,10 @@ public abstract class DefaultUpcallImpl extends Library {
             return appObject.invoke(method, params);
         }
 
-        @Deprecated
+        @Override
         public Policy.ServerPolicy sapphire_replicate(List<PolicyContainer> processedPolicies)
                 throws RemoteException {
-            return super.sapphire_replicate(processedPolicies, "");
-        }
-
-        @Override
-        public Policy.ServerPolicy sapphire_replicate(
-                List<PolicyContainer> processedPolicies, String region) throws RemoteException {
-            return super.sapphire_replicate(processedPolicies, region);
+            return super.sapphire_replicate(processedPolicies);
         }
 
         /* This function is added here just to generate the stub for this function in all Policies server policy */
@@ -75,6 +69,11 @@ public abstract class DefaultUpcallImpl extends Library {
 
         @Override
         public void onDestroy() {}
+
+        @Override
+        public String sapphire_getRegion() {
+            return super.sapphire_getRegion();
+        }
     }
 
     public abstract static class GroupPolicy extends GroupPolicyLibrary {

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
@@ -135,8 +135,8 @@ public abstract class Library implements Upcalls {
         }
 
         /** Creates a replica of this server and registers it with the group. */
-        public ServerPolicy sapphire_replicate(
-                List<PolicyContainer> processedPolicies, String region) throws RemoteException {
+        public ServerPolicy sapphire_replicate(List<PolicyContainer> processedPolicies)
+                throws RemoteException {
             KernelObjectStub serverPolicyStub = null;
 
             // Construct list of policies that will come after this policy on the server side.
@@ -149,7 +149,6 @@ public abstract class Library implements Upcalls {
                         spec,
                         processedPolicies,
                         processedPoliciesReplica,
-                        region,
                         null);
 
                 // Last policy in the returned chain is replica of this policy.
@@ -165,7 +164,6 @@ public abstract class Library implements Upcalls {
                         spec,
                         this.nextPolicies,
                         processedPoliciesReplica,
-                        region,
                         null);
             } catch (ClassNotFoundException e) {
                 // TODO Auto-generated catch block

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/Upcalls.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/Upcalls.java
@@ -187,8 +187,7 @@ public interface Upcalls {
          * @param spec sapphire object spec. This contains configuration parameters that may be used
          *     to configure this group policy.
          */
-        void onCreate(String region, Policy.ServerPolicy server, MicroServiceSpec spec)
-                throws RemoteException;
+        void onCreate(Policy.ServerPolicy server, MicroServiceSpec spec) throws RemoteException;
 
         /**
          * Event handler for sapphire object destruction. Called immediately before the group policy

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
@@ -3,7 +3,9 @@ package amino.run.policy.scalability;
 import amino.run.app.MicroServiceSpec;
 import amino.run.common.MicroServiceNotFoundException;
 import amino.run.common.MicroServiceReplicaNotFoundException;
+import amino.run.common.NoKernelServerFoundException;
 import amino.run.common.Utils;
+import amino.run.kernel.common.KernelObjectNotFoundException;
 import amino.run.kernel.common.KernelObjectStub;
 import amino.run.policy.Policy;
 import amino.run.policy.util.ResettableTimer;
@@ -174,9 +176,9 @@ public class ScaleUpFrontendPolicy extends LoadBalancedFrontendPolicy {
         private transient ResettableTimer timer; // Timer for limiting
 
         @Override
-        public void onCreate(String region, Policy.ServerPolicy server, MicroServiceSpec spec)
+        public void onCreate(Policy.ServerPolicy server, MicroServiceSpec spec)
                 throws RemoteException {
-            super.onCreate(region, server, spec);
+            super.onCreate(server, spec);
 
             Config config = getConfig(spec);
             if (config != null) {
@@ -238,13 +240,17 @@ public class ScaleUpFrontendPolicy extends LoadBalancedFrontendPolicy {
                      * is set to false for now but may need to be updated properly when run-time
                      * addition is supported.
                      */
-                    replicate(servers.get(0), addressList.get(0), region);
+                    replicate(servers.get(0));
                 } catch (MicroServiceNotFoundException e) {
                     throw new ScaleUpException(
                             "Failed to find sapphire object. Probably deleted.", e);
                 } catch (MicroServiceReplicaNotFoundException e) {
                     throw new ScaleUpException(
                             "Failed to find replicate sapphire object. Probably deleted.", e);
+                } catch (NoKernelServerFoundException e) {
+                    e.printStackTrace();
+                } catch (KernelObjectNotFoundException e) {
+                    e.printStackTrace();
                 }
             } else {
                 throw new ScaleUpException(

--- a/sapphire/sapphire-core/src/main/java/amino/run/runtime/Sapphire.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/runtime/Sapphire.java
@@ -77,9 +77,7 @@ public class Sapphire {
 
             /* Get the region of current server */
             String region = GlobalKernelReferences.nodeServer.getRegion();
-            appStub =
-                    createPolicy(
-                            microServiceId, spec, policyNameChain, processedPolicies, region, args);
+            appStub = createPolicy(microServiceId, spec, policyNameChain, processedPolicies, args);
         } catch (Exception e) {
             String msg = String.format("Failed to create sapphire object '%s'", spec);
             logger.log(Level.SEVERE, msg, e);
@@ -123,10 +121,8 @@ public class Sapphire {
                     GlobalKernelReferences.nodeServer.oms.registerSapphireObject();
 
             /* Get the region of current server */
-            String region = GlobalKernelReferences.nodeServer.getRegion();
             AppObjectStub appStub =
-                    createPolicy(
-                            microServiceId, spec, policyNameChain, processedPolicies, region, args);
+                    createPolicy(microServiceId, spec, policyNameChain, processedPolicies, args);
             logger.info("Sapphire Object created: " + appObjectClass.getName());
             return appStub;
         } catch (Exception e) {
@@ -181,7 +177,6 @@ public class Sapphire {
      * @param policyNameChain List of policies that need to be created
      * @param processedPolicies List of policies that were already created. Policies created with
      *     this invocation gets appended to existing list
-     * @param region Region
      * @param appArgs Arguments for application object
      * @return client side appObjectStub
      * @throws IOException
@@ -199,7 +194,6 @@ public class Sapphire {
             MicroServiceSpec spec,
             List<PolicyContainer> policyNameChain,
             List<PolicyContainer> processedPolicies,
-            String region,
             Object[] appArgs)
             throws IOException, ClassNotFoundException, KernelObjectNotFoundException,
                     KernelObjectNotCreatedException, MicroServiceNotFoundException,
@@ -282,15 +276,14 @@ public class Sapphire {
         serverPolicyStub.setProcessedPolicies(processedPoliciesSoFar);
 
         if (nextPoliciesToCreate.size() != 0) {
-            createPolicy(
-                    microServiceId, spec, nextPoliciesToCreate, processedPolicies, region, appArgs);
+            createPolicy(microServiceId, spec, nextPoliciesToCreate, processedPolicies, appArgs);
         }
 
         AppObjectStub appStub = null;
 
         // server policy stub at this moment has the full policy chain; safe to add to group
         if (existingGroupPolicy == null) {
-            groupPolicyStub.onCreate(region, serverPolicyStub, spec);
+            groupPolicyStub.onCreate(serverPolicyStub, spec);
 
             /* Build client side appObjectStub from appObjectStub within AppObject of first DM's server policy in chain
             and inject its client policy into it. An instance of Client side AppObjectStub is created at the end of

--- a/sapphire/sapphire-core/src/test/java/amino/run/policy/replication/ConsensusRSMPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/policy/replication/ConsensusRSMPolicyTest.java
@@ -166,7 +166,7 @@ public class ConsensusRSMPolicyTest extends BaseTest {
                         new ReplicaID(new MicroServiceID(UUID.randomUUID()), UUID.randomUUID()));
         when(group.getServers()).thenThrow(new RemoteException());
         thrown.expect(Error.class);
-        group.onCreate("", server, new MicroServiceSpec());
+        group.onCreate(server, new MicroServiceSpec());
     }
 
     /**

--- a/sapphire/sapphire-core/src/test/java/amino/run/policy/scalability/LoadBalancedFrontendPolicyTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/policy/scalability/LoadBalancedFrontendPolicyTest.java
@@ -123,7 +123,7 @@ public class LoadBalancedFrontendPolicyTest extends BaseTest {
         // Expecting error message- Configured replicas count: 5, created replica count : 2
         thrown.expectMessage("Configured replicas count: 5, created replica count : 2");
         setFieldValueOnInstance(group1, "replicaCount", 5);
-        group1.onCreate("", client.getServer(), new MicroServiceSpec());
+        group1.onCreate(client.getServer(), new MicroServiceSpec());
     }
 
     @After

--- a/sapphire/sapphire-core/src/test/java/amino/run/runtime/SapphireMultiPolicyChainTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/runtime/SapphireMultiPolicyChainTest.java
@@ -58,7 +58,7 @@ public class SapphireMultiPolicyChainTest extends BaseTest {
         MicroServiceID microServiceId = spiedOms.registerSapphireObject();
 
         policyNameChain.add(new PolicyContainer("amino.run.policy.dht.DHTPolicy", null));
-        Sapphire.createPolicy(microServiceId, spec, policyNameChain, processedPolicies, "", null);
+        Sapphire.createPolicy(microServiceId, spec, policyNameChain, processedPolicies, null);
         assertEquals(1, processedPolicies.size());
     }
 
@@ -73,7 +73,7 @@ public class SapphireMultiPolicyChainTest extends BaseTest {
         policyNameChain.add(new PolicyContainer("amino.run.policy.dht.DHTPolicy", null));
         policyNameChain.add(new PolicyContainer("amino.run.policy.DefaultPolicy", null));
 
-        Sapphire.createPolicy(microServiceId, spec, policyNameChain, processedPolicies, "", null);
+        Sapphire.createPolicy(microServiceId, spec, policyNameChain, processedPolicies, null);
         assertEquals(2, processedPolicies.size());
     }
 


### PR DESCRIPTION
Currently we are maintaining "region" variable in group policy. This variable is redundant here as Group Policy do not belongs to any region.
Code modifications:
1. Removed region parameter from ```sapphire_replicate```
2. Removed region variable from GroupPolicy
3. Removed region argument from `GroupPolicy.onCreate`
4. Removed region argument from ```Sapphire.createPolicy```
Note : 
Tagged ```sapphire_replicate``` method with region parameter as Deprecated

Report: 
Build Success:
![removeregion](https://user-images.githubusercontent.com/9818606/53092634-45afc300-353b-11e9-907c-f865996b0067.png)
Integration Test success:
![removeregion2](https://user-images.githubusercontent.com/9818606/53092635-45afc300-353b-11e9-85af-ae54ab664a08.png)
