### PR TITLE
Object Monitoring[3] UT and example app modifications for health check

### DIFF
--- a/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/TagManager.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/TagManager.java
@@ -5,10 +5,10 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
-import amino.run.app.SapphireObject;
+import amino.run.app.StatusReporter;
 import amino.run.policy.dht.DHTKey;
 
-public class TagManager implements SapphireObject {
+public class TagManager extends StatusReporter {
     Map<DHTKey, Tag> tags = new Hashtable<DHTKey, Tag>();
 
     public TagManager() {

--- a/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/Timeline.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/Timeline.java
@@ -3,12 +3,12 @@ package amino.run.appexamples.minnietwitter;
 import java.util.ArrayList;
 import java.util.List;
 
-import amino.run.app.SapphireObject;
+import amino.run.app.StatusReporter;
 import amino.run.runtime.SapphireConfiguration;
 
 
 @SapphireConfiguration(Policies = "amino.run.policy.atleastoncerpc.AtLeastOnceRPCPolicy")
-public class Timeline implements SapphireObject {
+public class Timeline extends StatusReporter {
     //private User user;
     private String userName;
 

--- a/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/TwitterManager.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/TwitterManager.java
@@ -1,11 +1,11 @@
 package amino.run.appexamples.minnietwitter;
 
-import amino.run.app.SapphireObject;
+import amino.run.app.StatusReporter;
 
 import static amino.run.runtime.Sapphire.delete_;
 import static amino.run.runtime.Sapphire.new_;
 
-public class TwitterManager implements SapphireObject {
+public class TwitterManager extends StatusReporter {
     private UserManager userManager;
     private TagManager tagManager;
 
@@ -26,4 +26,8 @@ public class TwitterManager implements SapphireObject {
         delete_(tagManager);
         delete_(userManager);
     }
+	@Override
+	public boolean getStatus() {
+		return true;
+	}
 }

--- a/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/User.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/User.java
@@ -3,12 +3,12 @@ package amino.run.appexamples.minnietwitter;
 import java.util.ArrayList;
 import java.util.List;
 
-import amino.run.app.SapphireObject;
+import amino.run.app.StatusReporter;
 
 import static amino.run.runtime.Sapphire.delete_;
 import static amino.run.runtime.Sapphire.new_;
 
-public class User implements SapphireObject {
+public class User extends StatusReporter {
     private Timeline timeline;
     private UserInfo ui;
     List<User> followers;

--- a/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/UserManager.java
+++ b/sapphire/examples/example-minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/UserManager.java
@@ -6,11 +6,8 @@ import java.util.Map;
 
 import amino.run.app.SapphireObject;
 import amino.run.policy.dht.DHTKey;
-import amino.run.app.SapphireObject;
 import static amino.run.runtime.Sapphire.*;
 
-import amino.run.policy.dht.DHTKey;
-import amino.run.policy.dht.DHTPolicy;
 import amino.run.runtime.SapphireConfiguration;
 
 

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/StatusReporter.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/StatusReporter.java
@@ -1,0 +1,16 @@
+package amino.run.app;
+
+import java.io.Serializable;
+
+/** Created by Venugopal Reddy K 00900280 on 28/8/18. */
+
+/**
+ * StatusReporter class. Extended by application class to become a Microservice
+ *
+ * @param <T>
+ */
+public class StatusReporter<T> implements Serializable {
+    public boolean getStatus() {
+        return true;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/compiler/StubGenerator.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/compiler/StubGenerator.java
@@ -1,6 +1,7 @@
 package amino.run.compiler;
 
 import amino.run.app.SapphireObject;
+import amino.run.app.StatusReporter;
 import amino.run.policy.Policy;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -101,6 +102,8 @@ public class StubGenerator {
                         StubGenerator.generateStub("policy", sapphireServerPolicyClass, destFolder);
                         StubGenerator.generateStub("policy", sapphireGroupPolicyClass, destFolder);
                     } else if (SapphireObject.class.isAssignableFrom(c))
+                        StubGenerator.generateStub("app", c, destFolder);
+                    else if (StatusReporter.class.isAssignableFrom(c))
                         StubGenerator.generateStub("app", c, destFolder);
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/sapphire/sapphire-core/src/test/java/amino/run/sampleSO/SO.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/sampleSO/SO.java
@@ -1,11 +1,12 @@
 package amino.run.sampleSO;
 
 /** Created by Venugopal Reddy K on 6/9/18. */
-import amino.run.app.SapphireObject;
+import amino.run.app.StatusReporter;
 import amino.run.runtime.SapphireConfiguration;
 
 @SapphireConfiguration(Policies = "amino.run.policy.DefaultPolicy")
-public class SO implements SapphireObject {
+public class SO extends StatusReporter {
+    boolean status = true;
     public Integer i = 0;
 
     public Integer getI() {
@@ -35,5 +36,14 @@ public class SO implements SapphireObject {
 
         }
         return i;
+    }
+
+    @Override
+    public boolean getStatus() {
+        return status;
+    }
+
+    public void setStatus(boolean status) {
+        this.status = status;
     }
 }


### PR DESCRIPTION
**This PR includes:**
- New class StatusReporter is added. It has default implementation of getStatus(). Application class can extend it and can override the default behavior. So, Application can either extend StatusReporter or implement SapphireObject to make its classes sapphire objects.
NOTE: when SapphireObject interface(existing) is used to make app classes as sapphire objects, health monitoring is not done.
- SendHeartbeat() in kernelserverimpl is modified to send status in batch.
- StubGeneration is modified to add the annotation `AddEvent` in GroupPolicy stubs.
- UT for healthcheck
- Minnietwitter APP is modified as below:
TagManager, Timeline, User extends StatusReporter and make use of default implementation of getStatus(). TwitterManager extends StatusReporter and overrides getStatus() to have customize implementation. UserManager uses the conventional `SapphireObject' interface and do not use health status check.

**Design doc link:**
https://docs.google.com/document/d/12-eK7-QzC9GKpFjXbm5qZQpaEdEQO2L5gTcxmTjF9A8/edit?usp=sharing