### PR TITLE
Minor naming corrections (remove sapphire)

### DIFF
--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
@@ -25,7 +25,7 @@ public abstract class Library implements Upcalls {
     public abstract static class ClientPolicyLibrary implements ClientUpcalls {
 
         /*
-         * INTERNAL FUNCTIONS (Used by sapphire runtime system)
+         * INTERNAL FUNCTIONS (Used by Amino Microservice DMs)
          */
     }
 
@@ -275,7 +275,6 @@ public abstract class Library implements Upcalls {
                             + server);
         }
 
-        // TODO (2018-9-26, Sungwook) Remove after verification.
         public void terminate() throws RemoteException {
             try {
                 GlobalKernelReferences.nodeServer.oms.unRegisterReplica(getReplicaId());
@@ -439,8 +438,8 @@ public abstract class Library implements Upcalls {
             return this.oid;
         }
 
-        public void setSapphireObjId(MicroServiceID sapphireId) {
-            microServiceId = sapphireId;
+        public void setMicroServiceId(MicroServiceID microServiceId) {
+            this.microServiceId = microServiceId;
         }
 
         public MicroServiceID getSapphireObjId() {
@@ -452,9 +451,9 @@ public abstract class Library implements Upcalls {
          * itself from {@code KernelObjectManager} on local kernel server, 2) remove itself of OMS's
          * {@code KernelObjectManager}, and 3) remove replica ID from OMS.
          *
-         * <p><strong>Warning:</strong> Do not try to call OMS to unregister the sapphire object.
-         * {@link OMSServer#delete(MicroServiceID)} is the public entry point to delete a sapphire
-         * object. OMS will take care of deleting sapphire object at {@link
+         * <p><strong>Warning:</strong> Do not try to call OMS to unregister the microservice.
+         * {@link OMSServer#delete(MicroServiceID)} is the public entry point to delete a
+         * microservice. OMS will take care of deleting microservice at {@link
          * amino.run.oms.OMSServerImpl#delete(MicroServiceID)}.
          *
          * @throws RemoteException

--- a/sapphire/sapphire-core/src/main/java/amino/run/runtime/MicroService.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/runtime/MicroService.java
@@ -49,17 +49,17 @@ public class MicroService {
     static Logger logger = Logger.getLogger(MicroService.class.getName());
 
     /**
-     * Creates a sapphire object.
+     * Creates a Amino microservice.
      *
      * @param spec MicroService object specification
-     * @param args parameters to sapphire object constructor
-     * @return sapphire object stub
+     * @param args parameters to microservice constructor
+     * @return Microservice stub for application
      */
     public static Object new_(MicroServiceSpec spec, Object... args)
             throws MicroServiceCreationException {
         AppObjectStub appStub = null;
         try {
-            logger.info("Creating object for spec:" + spec);
+            logger.info("Creating microservice for spec:" + spec);
             if (spec.getLang() == Language.java && spec.getDmList().isEmpty()) {
                 Class<?> appObjectClass = Class.forName(spec.getJavaClassName());
                 return new_(appObjectClass, args);
@@ -69,16 +69,16 @@ public class MicroService {
             String region = GlobalKernelReferences.nodeServer.getRegion();
             return createPolicyChain(spec, region, args);
         } catch (Exception e) {
-            String msg = String.format("Failed to create sapphire object '%s'", spec);
+            String msg = String.format("Failed to create a microservice'%s'", spec);
             logger.log(Level.SEVERE, msg, e);
             throw new MicroServiceCreationException(msg, e);
         }
     }
 
     /**
-     * WARN: This method only works for Java sapphire object. This method has been deprecated.
-     * Please use {@link #new_(MicroServiceSpec, Object...)}. We keep this method because we have
-     * Java demo apps that call this method directly.
+     * WARN: This method only works for Java microservice. This method has been deprecated. Please
+     * use {@link #new_(MicroServiceSpec, Object...)}. We keep this method because we have Java demo
+     * apps that call this method directly.
      *
      * @param appObjectClass the class of the app object
      * @param args the arguments to app object constructor
@@ -99,7 +99,7 @@ public class MicroService {
             logger.info("MicroService Object created: " + appObjectClass.getName());
             return appStub;
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Failed to create sapphire object:", e);
+            logger.log(Level.SEVERE, "Failed to create MicroService object:", e);
             return null;
         }
     }
@@ -128,7 +128,7 @@ public class MicroService {
             spec = setDefaultDMSpec(spec);
         }
 
-        /* Register for a sapphire object Id from OMS */
+        /* Register for a Microservice Id from OMS */
         MicroServiceID microServiceID =
                 GlobalKernelReferences.nodeServer.oms.registerMicroService();
 
@@ -178,7 +178,7 @@ public class MicroService {
      * @param processedPolicies Policies processed so far (created and linked)
      * @param microServiceID Object ID registred to OMS which is one per AminoMicroservice chain
      *     (all replicas of the chain will have the same object ID.
-     * @param spec Amino object spec
+     * @param spec Microservice spec
      * @return list of processed policies so far
      * @throws MicroServiceCreationException thrown when policy object creation fails
      */
@@ -244,7 +244,7 @@ public class MicroService {
      * @param groupPolicyStub Group Policy stub
      * @param policyNamesToCreate name of polices that need to be created (this and inner policies)
      * @param processedPolicies Policies processed so far (created and linked)
-     * @param spec Amino object spec
+     * @param spec Microservice spec
      * @return list of policies that had been created so far including the one just created here
      * @throws MicroServiceCreationException thrown when policy object creation fails
      */
@@ -278,7 +278,6 @@ public class MicroService {
             // TODO: client is unncessary for outer policies of a replica.
             client.onCreate(groupPolicyStub, spec);
 
-            // TODO: Separate out the following code block.
             // Note that subList is non serializable; hence, the new list creation.
             List<String> nextPolicyNames = new ArrayList<>(policyNamesToCreate);
 
@@ -322,23 +321,23 @@ public class MicroService {
     }
 
     /**
-     * Deletes the given sapphire object
+     * Deletes the given microservice object
      *
      * @param stub
      */
     public static void delete_(Object stub) {
         if (!(stub instanceof AppObjectStub)) {
-            throw new RuntimeException("Tried to delete invalid sapphire object");
+            throw new RuntimeException("Tried to delete invalid microservice object");
         }
 
         MicroServiceID microServiceId = ((AppObjectStub) stub).$__getMicroServiceId();
         try {
             GlobalKernelReferences.nodeServer.oms.delete(microServiceId);
         } catch (MicroServiceNotFoundException e) {
-            /* Ignore it. It might have happened that sapphire object is already deleted and still hold reference */
+            /* Ignore it. It might have happened that microservice object is already deleted and still hold reference */
             logger.warning(String.format("%s is not found. Probably deleted.", microServiceId));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to delete sapphire object.", e);
+            throw new RuntimeException("Failed to delete microservice object.", e);
         }
     }
 
@@ -360,8 +359,8 @@ public class MicroService {
         Policy.GroupPolicy groupPolicyStub = (GroupPolicy) getPolicyStub(policyClass);
         try {
             GroupPolicy groupPolicy = initializeGroupPolicy(groupPolicyStub);
-            groupPolicyStub.setSapphireObjId(microServiceId);
-            groupPolicy.setSapphireObjId(microServiceId);
+            groupPolicyStub.setMicroServiceId(microServiceId);
+            groupPolicy.setMicroServiceId(microServiceId);
         } catch (KernelObjectNotFoundException e) {
             logger.severe(
                     "Failed to find the group kernel object created just before it. Exception info: "
@@ -483,7 +482,7 @@ public class MicroService {
     /**
      * Initializes server policy and stub with app object.
      *
-     * @param spec sapphire object spec
+     * @param spec microservice spec
      * @param serverPolicy server policy
      * @param appArgs app arguments
      * @throws ClassNotFoundException

--- a/sapphire/sapphire-core/src/main/java/amino/run/runtime/util/PolicyCreationHelper.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/runtime/util/PolicyCreationHelper.java
@@ -24,19 +24,20 @@ public class PolicyCreationHelper {
      * should be called as a part of creating policy chain from kernel or library.
      *
      * @param policyName
-     * @param sapphireObjId
+     * @param microServiceIDId
      * @return
      * @throws amino.run.common.MicroServiceCreationException
      */
     public static Policy.GroupPolicy createGroupPolicy(
-            String policyName, MicroServiceID sapphireObjId) throws MicroServiceCreationException {
+            String policyName, MicroServiceID microServiceIDId)
+            throws MicroServiceCreationException {
         try {
             /* Create the Kernel Object for the Group Policy and get the Group Policy Stub from OMS */
-            Class<?> sapphireGroupPolicyClass = getPolicyMap(policyName).get(GroupPolicyClass);
+            Class<?> groupPolicyClass = getPolicyMap(policyName).get(GroupPolicyClass);
 
             Policy.GroupPolicy groupPolicyStub =
                     GlobalKernelReferences.nodeServer.oms.createGroupPolicy(
-                            sapphireGroupPolicyClass, sapphireObjId);
+                            groupPolicyClass, microServiceIDId);
 
             return groupPolicyStub;
         } catch (ClassNotFoundException


### PR DESCRIPTION
Replace sapphire with microservice at Microservice and Library. Removed TODOs that are not valid any longer. Related to issue #343

Gradle build and test
<img width="962" alt="screen shot 2019-02-27 at 2 29 20 pm" src="https://user-images.githubusercontent.com/12723038/53527532-17cb0100-3a9c-11e9-9397-433955695007.png">

KVstore
![screen shot 2019-02-27 at 2 35 14 pm](https://user-images.githubusercontent.com/12723038/53528148-94aaaa80-3a9d-11e9-8344-a66afa83c110.png)

HanksTodo
![screen shot 2019-02-27 at 2 37 51 pm](https://user-images.githubusercontent.com/12723038/53528155-983e3180-3a9d-11e9-9640-14cf41975d3d.png)
