### PR TITLE
Extract app method name and params from input arguments of onRPC call at DM clients

### DIFF
--- a/core/src/main/java/amino/run/policy/cache/WriteThroughCachePolicy.java
+++ b/core/src/main/java/amino/run/policy/cache/WriteThroughCachePolicy.java
@@ -25,7 +25,10 @@ public class WriteThroughCachePolicy extends DefaultPolicy {
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
             Object ret = null;
 
-            if (isMethodMutable(method, params)) {
+            // Extract app method name and params from input parameters
+            AppContext context = extractAppContext(method, params);
+
+            if (isMethodMutable(context.getAppMethod(), context.getAppParams())) {
                 ret = getServer().onRPC(method, params);
                 cachedObject = ((ServerPolicy) getServer()).getObject();
             } else {

--- a/core/src/main/java/amino/run/policy/cache/explicitcaching/ExplicitCachingPolicy.java
+++ b/core/src/main/java/amino/run/policy/cache/explicitcaching/ExplicitCachingPolicy.java
@@ -46,11 +46,14 @@ public class ExplicitCachingPolicy extends DefaultPolicy {
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
+            // Extract app method name and params from input parameters
+            AppContext context = extractAppContext(method, params);
+
             // All the operations between pull/push calls goes against local cache
-            if (this.isPull(method)) {
+            if (this.isPull(context.getAppMethod())) {
                 this.pull();
                 return null;
-            } else if (this.isPush(method)) {
+            } else if (this.isPush(context.getAppMethod())) {
                 this.push();
                 return null;
             } else if (this.cachedCopy != null) {

--- a/core/src/main/java/amino/run/policy/dht/DHTPolicy.java
+++ b/core/src/main/java/amino/run/policy/dht/DHTPolicy.java
@@ -48,7 +48,10 @@ public class DHTPolicy extends DefaultPolicy {
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
-            DHTKey key = new DHTKey(params.get(0).toString());
+            // Get app method name and params
+            AppContext context = extractAppContext(method, params);
+
+            DHTKey key = new DHTKey(context.getAppParams().get(0).toString());
             if (dhtChord == null) {
                 dhtChord = ((GroupPolicy) getGroup()).getChord();
             }

--- a/core/src/main/java/amino/run/policy/mobility/explicitmigration/ExplicitMigrationPolicy.java
+++ b/core/src/main/java/amino/run/policy/mobility/explicitmigration/ExplicitMigrationPolicy.java
@@ -22,9 +22,13 @@ public class ExplicitMigrationPolicy extends DefaultPolicy {
     public static class ClientPolicy extends DefaultClientPolicy {
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
-            if (isMigrateTo(method)) {
+            // Get app method name and params
+            AppContext context = extractAppContext(method, params);
+
+            if (isMigrateTo(context.getAppMethod())) {
                 /* If the method name is migrateTo, request group policy to migrate remote server policy object */
-                ((GroupPolicy) getGroup()).migrate(getServer(), (InetSocketAddress) params.get(0));
+                ((GroupPolicy) getGroup())
+                        .migrate(getServer(), (InetSocketAddress) context.getAppParams().get(0));
                 return null;
             } else {
                 return super.onRPC(method, params);

--- a/core/src/main/java/amino/run/policy/serializability/LockingTransactionPolicy.java
+++ b/core/src/main/java/amino/run/policy/serializability/LockingTransactionPolicy.java
@@ -19,13 +19,16 @@ public class LockingTransactionPolicy extends CacheLeasePolicy {
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
-            if (isStartTransaction(method)) {
-                this.startTransaction(params);
+            // Get app method name and params
+            AppContext context = extractAppContext(method, params);
+
+            if (isStartTransaction(context.getAppMethod())) {
+                this.startTransaction(context.getAppParams());
                 return null;
-            } else if (isCommitTransaction(method)) {
+            } else if (isCommitTransaction(context.getAppMethod())) {
                 this.commitTransaction();
                 return null;
-            } else if (isRollbackTransaction(method)) {
+            } else if (isRollbackTransaction(context.getAppMethod())) {
                 this.rollbackTransaction();
                 return null;
             } else { // Normal method invocation

--- a/core/src/main/java/amino/run/policy/serializability/OptConcurrentTransactPolicy.java
+++ b/core/src/main/java/amino/run/policy/serializability/OptConcurrentTransactPolicy.java
@@ -57,13 +57,16 @@ public class OptConcurrentTransactPolicy extends DefaultPolicy {
 
         @Override
         public Object onRPC(String method, ArrayList<Object> params) throws Exception {
-            if (isStartTransaction(method)) {
-                this.startTransaction(params);
+            // Get app method name and params
+            AppContext context = extractAppContext(method, params);
+
+            if (isStartTransaction(context.getAppMethod())) {
+                this.startTransaction(context.getAppParams());
                 return null;
-            } else if (isCommitTransaction(method)) {
+            } else if (isCommitTransaction(context.getAppMethod())) {
                 this.commitTransaction();
                 return null;
-            } else if (isRollbackTransaction(method)) {
+            } else if (isRollbackTransaction(context.getAppMethod())) {
                 this.rollbackTransaction();
                 return null;
             } else { // Normal method invocation

--- a/core/src/main/java/amino/run/runtime/MicroService.java
+++ b/core/src/main/java/amino/run/runtime/MicroService.java
@@ -291,6 +291,7 @@ public class MicroService {
             /* Link everything together */
             // TODO: client is unncessary for outer policies of a replica.
             client.onCreate(groupPolicyStub);
+            client.setClientDepth(processedPolicies.size());
 
             // Note that subList is non serializable; hence, the new list creation.
             List<String> nextPolicyNames = new ArrayList<String>(policyNamesToCreate);


### PR DESCRIPTION
Some DMs use parameters for processing inside DM. The intention is usually to use parameter passed from the application. These DMs need to be updated to correctly find the parameter it wants to process for as DMs were written pre-multi-DM. Currently, it processes the first parameter which is not necessarily an application parameter (i.e., onRpc method name of the upstream DM). 
                                      With multi-DM, these DM clients need to extract the app method name and app params from the params stack argument of `public Object onRPC(String method, ArrayList<Object> params)` and use.

Fixes #534