### PR TITLE
Added configuration option for gradle task "run", fixes #627

### DIFF
--- a/sapphire/examples/build.gradle
+++ b/sapphire/examples/build.gradle
@@ -65,7 +65,7 @@ class ExecWait extends DefaultTask {
         if (!command.isEmpty()) {
             def rootDir = project.rootDir
             def taskName = command.split(':').last()
-            def readyExpr = "ready!"
+            def readyExpr = "ready at port"
             def line
 
             Process process = new ProcessBuilder(command.split(' '))

--- a/sapphire/sapphire-core/src/main/java/amino/run/kernel/server/KernelServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/kernel/server/KernelServerImpl.java
@@ -438,6 +438,8 @@ public class KernelServerImpl implements KernelServer {
 
             // Start a thread that print memory stats
             server.getMemoryStatThread().start();
+
+            // Log being used in examples gradle task "run", hence modify accordingly.
             logger.info(String.format("Kernel server ready at port(%s)!", servicePort));
         } catch (Exception e) {
             System.err.println("Failed to start kernel server: " + e.getMessage());

--- a/sapphire/sapphire-core/src/main/java/amino/run/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/oms/OMSServerImpl.java
@@ -287,8 +287,10 @@ public class OMSServerImpl implements OMSServer, Registry {
                     (KernelServer) UnicastRemoteObject.exportObject(localKernelServer, servicePort);
             registry.rebind("io.amino.run.kernelserver", localKernelServerStub);
 
-            logger.info(String.format("OMS ready at port (%s)!", port));
-            // to get all the kernel server's addresses passing null in oms.getServers
+            // Log being used in examples gradle task "run", hence modify accordingly.
+            logger.info(String.format("OMS ready at port(%s)!", port));
+
+            // To get all the kernel server's addresses passing null in oms.getServers
             for (Iterator<InetSocketAddress> it = oms.getServers(null).iterator(); it.hasNext(); ) {
                 InetSocketAddress address = it.next();
                 logger.fine("   " + address.getHostName() + ":" + address.getPort());


### PR DESCRIPTION
This issue has been raised for tracking the comment provided in PR #612
The same is being tracked through issue #627 

Currently the gradle task "run" launches 4 Kernel Servers by default for all the example applications.
As four Kernel Servers are not needed for all the examples and for all the scenarios, the comment in PR #612 was to make the same user configurable.

With this PR, the no of Kernel Servers being launched has being made configurable through command line parameter "KS".
