### PR TITLE
Gradle changes to fix app failing  Fixes #650

### DIFF
--- a/sapphire/examples/build.gradle
+++ b/sapphire/examples/build.gradle
@@ -48,7 +48,7 @@ subprojects {
 
     // Run application
     task runapp(type: JavaExec) {
-        args project.property('kernelServerIpFlag'), project.property('kernelServerIp'), project.property('kernelServerPortFlag'), project.property('kernelServerPort')
+        args project.property('kernelServerIpFlag'), project.property('embeddedKernelServerIp'), project.property('kernelServerPortFlag'), project.property('kernelServerPort')
     }
 }
 

--- a/sapphire/examples/gradle.properties
+++ b/sapphire/examples/gradle.properties
@@ -5,7 +5,7 @@ omsPort=22222
 # IP being used for kernelServer's.
 # Has used different IP compared to OMS for applying rules if needed,
 # even though both map to localhost.
-kernelServerIp=127.0.0.2
+kernelServerIp=127.0.0.1
 
 kernelServerPort=22345
 kernelServerPort2=22346
@@ -16,6 +16,9 @@ kernelServerLabel=region=r0
 kernelServerLabel2=region=r0
 kernelServerLabel3=region=r1
 kernelServerLabel4=region=r1
+
+# IP for kernel server embedded in sapphire application
+embeddedKernelServerIp=127.0.0.2
 
 omsIpFlag=--oms-ip
 omsPortFlag=--oms-port

--- a/sapphire/examples/hanksTodoRuby/build.gradle
+++ b/sapphire/examples/hanksTodoRuby/build.gradle
@@ -16,7 +16,7 @@ task runrubyapp(type: Exec) {
     environment  RUBY_HOME: "${project.projectDir}/src/main/ruby/amino/run/appexamples/hankstodo"
     environment  OMS_IP: "${project.property('omsIp')}"
     environment  OMS_PORT: "${project.property('omsPort')}"
-    environment  KERNEL_SERVER_IP: "${project.property('kernelServerIp')}"
+    environment  KERNEL_SERVER_IP: "${project.property('embeddedKernelServerIp')}"
     environment  KERNEL_SERVER_PORT: "${project.property('kernelServerPort')}"
     def classpath = sourceSets.main.runtimeClasspath.asPath
     executable "$System.env.JAVA_HOME/bin/ruby"
@@ -29,7 +29,7 @@ task runjsapp(type: Exec) {
     environment  JS_HOME: "${project.projectDir}/src/main/js/amino/run/appexamples/hankstodo"
     environment  OMS_IP: "${project.property('omsIp')}"
     environment  OMS_PORT: "${project.property('omsPort')}"
-    environment  HOST_IP: "${project.property('kernelServerIp')}"
+    environment  HOST_IP: "${project.property('embeddedKernelServerIp')}"
     environment  HOST_PORT: "${project.property('kernelServerPort')}"
     def classpath = sourceSets.main.runtimeClasspath.asPath
     executable "$System.env.JAVA_HOME/bin/js"
@@ -43,7 +43,7 @@ runapp {
     systemProperty "JS_HOME",  "${project.projectDir}/src/main/js/amino/run/appexamples/hankstodo/"
     main = 'amino.run.appexamples.hankstodo.Client'
     // Default runapp arguments are overridden to follow the format accepted by hanksTodoRuby client.
-    args = [project.property('kernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')]
+    args = [project.property('embeddedKernelServerIp'), project.property('kernelServerPort'), project.property('omsIp'), project.property('omsPort')]
 }
 
 compileJava.dependsOn genStubs

--- a/sapphire/examples/kvstorejs/build.gradle
+++ b/sapphire/examples/kvstorejs/build.gradle
@@ -15,7 +15,7 @@ genStubs {
 task runjsapp(type: Exec) {
     environment  OMS_IP: "${project.property('omsIp')}"
     environment  OMS_PORT: "${project.property('omsPort')}"
-    environment  HOST_IP: "${project.property('kernelServerIp')}"
+    environment  HOST_IP: "${project.property('embeddedKernelServerIp')}"
     environment  HOST_PORT: "${project.property('kernelServerPort')}"
     def classpath = sourceSets.main.runtimeClasspath.asPath
 
@@ -29,7 +29,7 @@ task runjsapp(type: Exec) {
 runapp {
     environment  OMS_IP: "${project.property('omsIp')}"
     environment  OMS_PORT: "${project.property('omsPort')}"
-    environment  HOST_IP: "${project.property('kernelServerIp')}"
+    environment  HOST_IP: "${project.property('embeddedKernelServerIp')}"
     environment  HOST_PORT: "${project.property('kernelServerPort')}"
     environment  YAML_FILE:  "KeyValueStore.yaml"
     main = 'amino.run.appdemo.KeyValueStoreClient'


### PR DESCRIPTION
In pr #640  embeddedKernelServerIp was removed from gradle properties  and in app arguments kernelServerIp was passed , due to these  all apps except kvstore was failing as mentioned in issue #650 
To fix the same changes made in pr #640 has been  reverted ,all the app run against the latest changes 
please find the screen shot of some apps  hankstodo ,hankstodo ruby,and hankstodo  js 
![hankstodo](https://user-images.githubusercontent.com/39764768/54704882-9f6ad380-4b61-11e9-88e3-c88c3df73c34.png)
![hanksruby](https://user-images.githubusercontent.com/39764768/54704895-a5f94b00-4b61-11e9-97ac-dd9c66422611.png)
![hanksjs](https://user-images.githubusercontent.com/39764768/54704909-b01b4980-4b61-11e9-8267-0d4017fb5de7.png)


