### PR TITLE
Added node selection for DM

### DIFF
--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNConsensus.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNConsensus.yaml
@@ -10,9 +10,7 @@ dmList:
   name: amino.run.policy.dht.DHTPolicy
 - configs: []
   name: amino.run.policy.replication.ConsensusRSMPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNMasterSlave.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/AtleastRPCDHTNMasterSlave.yaml
@@ -10,9 +10,7 @@ dmList:
   name: amino.run.policy.dht.DHTPolicy
 - configs: []
   name: amino.run.policy.scalability.LoadBalancedMasterSlaveSyncPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNConsensus.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNConsensus.yaml
@@ -8,9 +8,7 @@ dmList:
   name: amino.run.policy.dht.DHTPolicy
 - configs: []
   name: amino.run.policy.replication.ConsensusRSMPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNMasterSlave.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/multi-dm/DHTNMasterSlave.yaml
@@ -8,9 +8,7 @@ dmList:
   name: amino.run.policy.dht.DHTPolicy
 - configs: []
   name: amino.run.policy.scalability.LoadBalancedMasterSlaveSyncPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/AtLeastOnceDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/AtLeastOnceDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.atleastoncerpc.AtLeastOnceRPCPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/CacheLease.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/CacheLease.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.cache.CacheLeasePolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DHTDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DHTDM.yaml
@@ -5,9 +5,7 @@ dmList:
 - configs:
   - !!amino.run.policy.dht.DHTPolicy$Config {numOfShards: 3}
   name: amino.run.policy.dht.DHTPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DurableSerializableRPCDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/DurableSerializableRPCDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.checkpoint.durableserializable.DurableSerializableRPCPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCachingDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCachingDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.cache.explicitcaching.ExplicitCachingPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCheckpointDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitCheckpointDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.checkpoint.explicitcheckpoint.ExplicitCheckpointPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitMigrationDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/ExplicitMigrationDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.mobility.explicitmigration.ExplicitMigrationPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/Immutable.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/Immutable.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.primitive.ImmutablePolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/LockingTransaction.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/LockingTransaction.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.serializability.LockingTransactionPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/NoDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/NoDM.yaml
@@ -2,9 +2,7 @@
 !!amino.run.app.MicroServiceSpec
 constructorName: null
 javaClassName: amino.run.demo.KVStore
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 lang: java
 name: null
 sourceFileLocation: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/OptConcurrentTransactionDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/OptConcurrentTransactionDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.serializability.OptConcurrentTransactPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/PeriodicCheckpointDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/PeriodicCheckpointDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.checkpoint.periodiccheckpoint.PeriodicCheckpointPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/SerializableRPCDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/SerializableRPCDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.serializability.SerializableRPCPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/TwoPCCohortDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/TwoPCCohortDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.transaction.TwoPCCohortPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/TwoPCCoordinatorDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/TwoPCCoordinatorDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.transaction.TwoPCCoordinatorPolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.Coordinator
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/WriteThroughCacheDM.yaml
+++ b/sapphire/sapphire-core/src/integrationTest/resources/specs/simple-dm/WriteThroughCacheDM.yaml
@@ -5,9 +5,7 @@ constructorName: null
 dmList:
 - configs: []
   name: amino.run.policy.cache.WriteThroughCachePolicy
-nodeSelectorSpec:
-  andLabels: !!set {}
-  orLabels: !!set {}
+nodeSelectorSpec: null
 javaClassName: amino.run.demo.KVStore
 lang: java
 name: null

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/DMSpec.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/DMSpec.java
@@ -15,6 +15,7 @@ import org.yaml.snakeyaml.Yaml;
 public final class DMSpec implements Serializable {
     private String name;
     private List<PolicyConfig> configs = new ArrayList<PolicyConfig>();
+    private NodeSelectorSpec nodeSelectorSpec;
 
     /**
      * Returns a builder class for DMSpec.
@@ -49,6 +50,10 @@ public final class DMSpec implements Serializable {
         return configs;
     }
 
+    public NodeSelectorSpec getNodeSelectorSpec() {
+        return nodeSelectorSpec;
+    }
+
     /**
      * Returns a policy configuration map where the key is the name of the configuration and the
      * value is a {@link PolicyConfig} instance.
@@ -69,6 +74,10 @@ public final class DMSpec implements Serializable {
 
     public void setConfigs(List<PolicyConfig> configs) {
         this.configs = configs;
+    }
+
+    public void setNodeSelectorSpec(NodeSelectorSpec nodeSelectorSpec) {
+        this.nodeSelectorSpec = nodeSelectorSpec;
     }
 
     public static DMSpec fromYaml(String yamlStr) {
@@ -97,6 +106,7 @@ public final class DMSpec implements Serializable {
     public static class Builder {
         private String name;
         private List<PolicyConfig> configs = new ArrayList<PolicyConfig>();
+        private NodeSelectorSpec nodeSelectorSpec;
 
         public Builder setName(String name) {
             this.name = name;
@@ -108,10 +118,16 @@ public final class DMSpec implements Serializable {
             return this;
         }
 
+        public Builder addNodeSelectionSpec(NodeSelectorSpec spec) {
+            this.nodeSelectorSpec = spec;
+            return this;
+        }
+
         public DMSpec create() {
             DMSpec spec = new DMSpec();
             spec.setName(name);
             spec.setConfigs(configs);
+            spec.setNodeSelectorSpec(nodeSelectorSpec);
             return spec;
         }
     }

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/MicroServiceSpec.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/MicroServiceSpec.java
@@ -139,7 +139,8 @@ public class MicroServiceSpec implements Serializable {
                 && Objects.equals(javaClassName, that.javaClassName)
                 && Objects.equals(sourceFileLocation, that.sourceFileLocation)
                 && Objects.equals(constructorName, that.constructorName)
-                && Objects.equals(dmList, that.dmList);
+                && Objects.equals(dmList, that.dmList)
+                && Objects.equals(nodeSelectorSpec, that.nodeSelectorSpec);
     }
 
     @Override

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/NodeSelectorSpec.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/NodeSelectorSpec.java
@@ -1,10 +1,7 @@
 package amino.run.app;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -13,80 +10,24 @@ import org.yaml.snakeyaml.Yaml;
  *
  * <p>At present we only support specifying {@code NodeSelectorSpec} at microservice level. We will
  * consider support specifying {@code NodeSelectorSpec} at DM level in the future if necessary.
- *
- * <p>{@code NodeSelectorSpec} contains two label sets, a {@code orLabels} set and a {@code
- * andLabels} set. {@code orLabels} set and {@code andLabels} set are considered as selector used to
- * select nodes.
- *
- * <p>If {@code orLabels} set is not empty, then a node will be selected only if it contains any
- * label specified in {@code orLabels} set. If {@code andLabels} set is not empty, then a node will
- * be selected only if it contains all labels specified in {@code andLabels} set. If both {@code
- * orLabels} and {@code andLabels} are specified, then a node will be selected only if it contains
- * all labels in {@code andLabels} set <strong>and</strong> some label in {@code orLabels} set.
- *
- * <p>By default, both {@code orLabels} set and {@code andLabels} set are empty which means no
- * selector will be applied in which case all nodes will be returned.
  */
 public class NodeSelectorSpec implements Serializable {
-    public Set<String> orLabels = new HashSet<String>();
-    public Set<String> andLabels = new HashSet<String>();
+    // If the affinity requirements specified by this field are not met at
+    // scheduling time, the SO will not be scheduled onto the node.
+    // +optional
+    private List<NodeSelectorTerm> requireExpressions = new ArrayList<NodeSelectorTerm>();
 
-    public Set<String> getOrLabels() {
-        return Collections.unmodifiableSet(orLabels);
+    public void setRequireExpressions(List<NodeSelectorTerm> requireExpressions) {
+        this.requireExpressions = requireExpressions;
     }
 
-    public Set<String> getAndLabels() {
-        return Collections.unmodifiableSet(andLabels);
+    public List<NodeSelectorTerm> getRequireExpressions() {
+        return requireExpressions;
     }
 
-    /**
-     * Adds the label into {@code andLabels} set Null label or empty label is ignored.
-     *
-     * @param label a label
-     */
-    public void addAndLabel(String label) {
-        if (label == null || label.isEmpty()) {
-            return;
-        }
-        this.andLabels.add(label);
-    }
-
-    /**
-     * Adds the given label set into the {@code andLabels} set Null label set is ignored.
-     *
-     * @param andLabels a label set
-     */
-    public void addAndLabels(Set<String> andLabels) {
-        if (andLabels == null) {
-            return;
-        }
-        this.andLabels.addAll(andLabels);
-    }
-
-    /**
-     * Adds the label into {@code orLabels} set. Null label or empty label is ignored.
-     *
-     * @param label a label
-     */
-    public void addOrLabel(String label) {
-        if (label == null || label.isEmpty()) {
-            return;
-        }
-
-        this.orLabels.add(label);
-    }
-
-    /**
-     * Adds the given label set into the {@code orLabels} set Null label set is ignored.
-     *
-     * @param orLabels a label set
-     */
-    public void addOrLabels(Set<String> orLabels) {
-        if (orLabels == null) {
-            return;
-        }
-
-        this.orLabels.addAll(orLabels);
+    public NodeSelectorSpec addRequireExpressions(NodeSelectorTerm term) {
+        requireExpressions.add(term);
+        return this;
     }
 
     @Override
@@ -100,11 +41,11 @@ public class NodeSelectorSpec implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         NodeSelectorSpec that = (NodeSelectorSpec) o;
-        return Objects.equals(orLabels, that.orLabels) && Objects.equals(andLabels, that.andLabels);
+        return Objects.equals(requireExpressions, that.requireExpressions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(orLabels, andLabels);
+        return Objects.hash(requireExpressions);
     }
 }

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/NodeSelectorTerm.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/NodeSelectorTerm.java
@@ -1,0 +1,28 @@
+package amino.run.app;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by AmitRoushan on 03/19/19. which is kernel server selector term follows similar logic as
+ * k8s
+ */
+public class NodeSelectorTerm implements Serializable {
+
+    // A list of node selector requirements by node's labels.
+    public List<Requirement> matchExpressions = new ArrayList<Requirement>();
+
+    public void setMatchExpressions(List<Requirement> MatchExpressions) {
+        this.matchExpressions = MatchExpressions;
+    }
+
+    public List<Requirement> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public NodeSelectorTerm add(Requirement requirement) {
+        matchExpressions.add(requirement);
+        return this;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/Operator.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/Operator.java
@@ -1,0 +1,19 @@
+package amino.run.app;
+
+public enum Operator {
+    Equal("="),
+    In("in"),
+    NotIn("notin"),
+    Exists("exists");
+
+    private String operator;
+
+    Operator(String operator) {
+        this.operator = operator;
+    }
+
+    @Override
+    public String toString() {
+        return operator;
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/app/Requirement.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/app/Requirement.java
@@ -1,0 +1,114 @@
+package amino.run.app;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * Requirement is condition used in selector.
+ *
+ * <p>Each requirement can represent one of different condition such as equal/in/notin.
+ *
+ * <p>Application can create multiple requirements and add them in selectors. <code>
+ *    Requirement req = new Requirement(
+ *                         "key1", Requirement.Equal, new ArrayList<>(Arrays.asList("value1")));
+ *    </code>
+ */
+public class Requirement implements Serializable {
+    private String key;
+    private Operator operator;
+    private List<String> values;
+
+    public Requirement(String key, Operator operator, List<String> values)
+            throws IllegalArgumentException {
+        validateRequirement(key, operator, values);
+        this.key = key;
+        this.operator = operator;
+        this.values = values;
+    }
+
+    // constructor defined for JavaBeans in yaml parsing
+    private Requirement() {}
+
+    // setter and getter method defined for JavaBeans yaml parsing
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setOperator(Operator operator) {
+        this.operator = operator;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Operator getOperator() {
+        return operator;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    private void validateRequirement(String key, Operator operator, List<String> values)
+            throws IllegalArgumentException {
+        switch (operator) {
+            case Equal:
+                if (values == null || values.isEmpty() || values.size() > 1) {
+                    throw new IllegalArgumentException("invalid value for <Equal> operation");
+                }
+                break;
+            case Exists:
+                if (values != null && !values.isEmpty()) {
+                    throw new IllegalArgumentException("values provided for <Exists> operation");
+                }
+                break;
+        }
+    }
+
+    private boolean hasValue(String value) {
+        return values != null && values.contains(value);
+    }
+
+    /**
+     * Test label against condition in Requirement
+     *
+     * @param labels label getting tested
+     * @return return true if label satisfy condition
+     */
+    public boolean matches(Map<String, String> labels) {
+        switch (operator) {
+            case Equal:
+            case In:
+                if (!labels.containsKey(key)) {
+                    return false;
+                }
+                return hasValue(labels.get(key));
+            case NotIn:
+                if (!labels.containsKey(key)) {
+                    return true;
+                }
+                return !hasValue(labels.get(key));
+            case Exists:
+                return labels.containsKey(key);
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        String req =
+                key
+                        + " " // insert key
+                        + operator; // insert operator
+        if (operator.equals(Operator.Exists)) {
+            return req;
+        }
+        return req + " " + Arrays.toString(values.toArray()); // insert values
+    }
+}

--- a/sapphire/sapphire-core/src/main/java/amino/run/oms/KernelServerManager.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/oms/KernelServerManager.java
@@ -145,14 +145,8 @@ public class KernelServerManager {
      */
     public List<InetSocketAddress> getServers(NodeSelectorSpec spec) {
         List<InetSocketAddress> nodes = new ArrayList<InetSocketAddress>();
-        Set<String> orLabels = null;
-        Set<String> andLabels = null;
-        if (null != spec) {
-            orLabels = spec.getOrLabels();
-            andLabels = spec.getAndLabels();
-        }
         for (ServerInfo s : serverInfos) {
-            if (s.containsAll(andLabels) && s.containsAny(orLabels)) {
+            if (s.matchNodeSelectorSpec(spec)) {
                 nodes.add(s.getHost());
             }
         }

--- a/sapphire/sapphire-core/src/main/java/amino/run/oms/OMSServer.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/oms/OMSServer.java
@@ -35,7 +35,7 @@ public interface OMSServer extends Remote {
 
     ArrayList<String> getRegions() throws RemoteException;
 
-    List<InetSocketAddress> getServers(NodeSelectorSpec spec) throws RemoteException;
+    List<InetSocketAddress> getServers(List<NodeSelectorSpec> specs) throws RemoteException;
 
     void registerKernelServer(ServerInfo info) throws RemoteException, NotBoundException;
 

--- a/sapphire/sapphire-core/src/main/java/amino/run/oms/OMSServerImpl.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/oms/OMSServerImpl.java
@@ -129,12 +129,12 @@ public class OMSServerImpl implements OMSServer, Registry {
     /**
      * Gets all servers matching the specified node selector
      *
-     * @param spec
+     * @param specs
      * @return
      * @throws RemoteException
      */
-    public List<InetSocketAddress> getServers(NodeSelectorSpec spec) throws RemoteException {
-        return serverManager.getServers(spec);
+    public List<InetSocketAddress> getServers(List<NodeSelectorSpec> specs) throws RemoteException {
+        return serverManager.getServers(specs);
     }
 
     @Override

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/Library.java
@@ -1,8 +1,8 @@
 package amino.run.policy;
 
-import amino.run.app.Language;
-import amino.run.app.MicroServiceSpec;
-import amino.run.app.NodeSelectorSpec;
+import static amino.run.kernel.server.KernelServerImpl.REGION_KEY;
+
+import amino.run.app.*;
 import amino.run.common.*;
 import amino.run.compiler.GlobalStubConstants;
 import amino.run.kernel.common.GlobalKernelReferences;
@@ -422,7 +422,14 @@ public abstract class Library implements Upcalls {
             } else {
                 if (region != null && !region.isEmpty()) {
                     nodeSelector = new NodeSelectorSpec();
-                    nodeSelector.addAndLabel(region);
+                    NodeSelectorTerm term = new NodeSelectorTerm();
+                    term.setMatchExpressions(
+                            Collections.singletonList(
+                                    new Requirement(
+                                            REGION_KEY,
+                                            Operator.Equal,
+                                            Collections.singletonList(region))));
+                    nodeSelector.setRequireExpressions(Collections.singletonList(term));
                     serversInRegion = oms().getServers(nodeSelector);
                 } else {
                     serversInRegion = oms().getServers(null);

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/dht/DHTPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/dht/DHTPolicy.java
@@ -172,7 +172,7 @@ public class DHTPolicy extends DefaultPolicy {
         private InetSocketAddress getAddress(String region)
                 throws NoKernelServerFoundException, RemoteException {
             List<InetSocketAddress> addressList =
-                    getAddressList(spec.getNodeSelectorSpec(), region);
+                    getAddressList(getNodeSelectionSpecs(spec), region);
             if (addressList == null || addressList.isEmpty()) {
                 String msg =
                         String.format(

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/replication/ConsensusRSMPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/replication/ConsensusRSMPolicy.java
@@ -222,7 +222,7 @@ public class ConsensusRSMPolicy extends DefaultPolicy {
                 if (server.isLastPolicy()) {
                     // TODO: Make deployment kernel pin primary replica once node selection
                     // constraint is implemented.
-                    addressList = getAddressList(spec.getNodeSelectorSpec(), region);
+                    addressList = getAddressList(getNodeSelectionSpecs(spec), region);
                     // The first in the addressList is for primary policy chain.
                     // TODO: Improve node allocation so that other servers can be used instead of
                     // the first one in the region.

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedFrontendPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedFrontendPolicy.java
@@ -197,7 +197,7 @@ public class LoadBalancedFrontendPolicy extends DefaultPolicy {
                 microservices in the same region(excluding this kernel server) */
                 InetSocketAddress addr = ((KernelObjectStub) server).$__getHostname();
                 List<InetSocketAddress> addressList =
-                        getAddressList(spec.getNodeSelectorSpec(), region);
+                        getAddressList(getNodeSelectionSpecs(spec), region);
 
                 /* Create the replicas on different kernelServers belongs to same region*/
                 if (addressList != null) {

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveBase.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/LoadBalancedMasterSlaveBase.java
@@ -180,7 +180,7 @@ public abstract class LoadBalancedMasterSlaveBase extends DefaultPolicy {
 
             try {
                 List<InetSocketAddress> addressList =
-                        getAddressList(spec.getNodeSelectorSpec(), region);
+                        getAddressList(getNodeSelectionSpecs(spec), region);
                 if (addressList.size() < NUM_OF_REPLICAS) {
                     logger.warning(
                             String.format(

--- a/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
+++ b/sapphire/sapphire-core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
@@ -213,7 +213,7 @@ public class ScaleUpFrontendPolicy extends LoadBalancedFrontendPolicy {
 
             /* Get the list of available servers in region */
             List<InetSocketAddress> addressList =
-                    getAddressList(spec.getNodeSelectorSpec(), region);
+                    getAddressList(getNodeSelectionSpecs(spec), region);
 
             if (null == addressList) {
                 throw new ScaleUpException("Scaleup failed. Couldn't fetch kernel server list.");

--- a/sapphire/sapphire-core/src/test/java/amino/run/app/MicroServiceSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/app/MicroServiceSpecTest.java
@@ -29,10 +29,6 @@ public class MicroServiceSpecTest {
     }
 
     private MicroServiceSpec createSpec() {
-        NodeSelectorSpec nodeSelectorSpec = new NodeSelectorSpec();
-        nodeSelectorSpec.addAndLabel("and_label");
-        nodeSelectorSpec.addOrLabel("or_label");
-
         ScaleUpFrontendPolicy.Config scaleUpConfig = new ScaleUpFrontendPolicy.Config();
         scaleUpConfig.setReplicationRateInMs(100);
 
@@ -53,7 +49,7 @@ public class MicroServiceSpecTest {
                 .setSourceFileLocation("src/main/js/college.js")
                 .setConstructorName("college")
                 .addDMSpec(dmSpec)
-                .setNodeSelectorSpec(nodeSelectorSpec)
+                .setNodeSelectorSpec(new NodeSelectorSpec())
                 .create();
     }
 }

--- a/sapphire/sapphire-core/src/test/java/amino/run/app/NodeSelectorSpecTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/app/NodeSelectorSpecTest.java
@@ -1,30 +1,3 @@
 package amino.run.app;
 
-import org.junit.Test;
-
-public class NodeSelectorSpecTest {
-
-    @Test
-    public void testAddNullOrLabels() {
-        NodeSelectorSpec spec = new NodeSelectorSpec();
-        spec.addOrLabels(null);
-    }
-
-    @Test
-    public void testAddNullOrLabel() {
-        NodeSelectorSpec spec = new NodeSelectorSpec();
-        spec.addOrLabel(null);
-    }
-
-    @Test
-    public void testAddNullAndLabels() {
-        NodeSelectorSpec spec = new NodeSelectorSpec();
-        spec.addAndLabels(null);
-    }
-
-    @Test
-    public void testAddNullAndLabel() {
-        NodeSelectorSpec spec = new NodeSelectorSpec();
-        spec.addAndLabel(null);
-    }
-}
+public class NodeSelectorSpecTest {}

--- a/sapphire/sapphire-core/src/test/java/amino/run/app/RequirementTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/app/RequirementTest.java
@@ -1,0 +1,105 @@
+package amino.run.app;
+
+import java.util.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RequirementTest {
+    HashMap<String, String> labels;
+
+    @Before
+    public void setup() {
+        labels = new HashMap<String, String>();
+        labels.put("key1", "value1");
+        labels.put("key2", "value2");
+        labels.put("key3", "value3");
+    }
+
+    // scenario for EQUAL Operator
+    @Test
+    public void testEQUAL() throws Exception {
+        // when label matches
+        Requirement req =
+                new Requirement(
+                        "key1", Operator.Equal, new ArrayList<String>(Arrays.asList("value1")));
+        Assert.assertTrue(req.matches(labels));
+
+        // when label do not matches
+        req =
+                new Requirement(
+                        "key1", Operator.Equal, new ArrayList<String>(Arrays.asList("value2")));
+        Assert.assertFalse(req.matches(labels));
+    }
+
+    // scenario for IN Operator
+    @Test
+    public void testIN() throws Exception {
+        // when label matches
+        Requirement req =
+                new Requirement(
+                        "key1", Operator.Equal, new ArrayList<String>(Arrays.asList("value1")));
+        Assert.assertTrue(req.matches(labels));
+
+        // when label do not matches
+        req =
+                new Requirement(
+                        "key1", Operator.Equal, new ArrayList<String>(Arrays.asList("value2")));
+        Assert.assertFalse(req.matches(labels));
+    }
+
+    // scenario for NOTIN Operator
+    @Test
+    public void testNOTIN() throws Exception {
+        // when label matches
+        Requirement req =
+                new Requirement(
+                        "key1", Operator.Equal, new ArrayList<String>(Arrays.asList("value1")));
+        Assert.assertTrue(req.matches(labels));
+
+        // when label do not matches
+        req =
+                new Requirement(
+                        "key1", Operator.Equal, new ArrayList<String>(Arrays.asList("value2")));
+        Assert.assertFalse(req.matches(labels));
+    }
+
+    // Positive scenario for EXISTS Operator
+    @Test
+    public void testEXISTS() throws Exception {
+        // when label matches
+        Requirement req = new Requirement("key1", Operator.Exists, new ArrayList<String>());
+        Assert.assertTrue(req.matches(labels));
+
+        // when label do not matches
+        req = new Requirement("key6", Operator.Exists, new ArrayList<String>());
+        Assert.assertFalse(req.matches(labels));
+    }
+
+    // tests for tostring() function with EQUAL,IN,NOTIN,EXISTS operator
+    @Test
+    public void testToString() throws Exception {
+        // check
+        Requirement req =
+                new Requirement(
+                        "key1", Operator.Equal, new ArrayList<String>(Arrays.asList("value1")));
+        Assert.assertEquals(req.toString(), "key1 = [value1]");
+
+        req =
+                new Requirement(
+                        "key1",
+                        Operator.In,
+                        new ArrayList<String>(Arrays.asList("value1", "value2")));
+        Assert.assertEquals(req.toString(), "key1 in [value1, value2]");
+
+        req =
+                new Requirement(
+                        "key1",
+                        Operator.NotIn,
+                        new ArrayList<String>(Arrays.asList("value1", "value2")));
+        Assert.assertEquals(req.toString(), "key1 notin [value1, value2]");
+
+        req = new Requirement("key1", Operator.Exists, new ArrayList<String>());
+        Assert.assertEquals(req.toString(), "key1 exists");
+    }
+}

--- a/sapphire/sapphire-core/src/test/java/amino/run/kernel/common/ServerInfoTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/kernel/common/ServerInfoTest.java
@@ -18,51 +18,52 @@ public class ServerInfoTest {
     @Test
     public void testHasAnyLabel() {
         ServerInfo server = createServer(numOfLabels);
-        Set<String> labels = new HashSet<String>();
-        labels.add(LABEL_PREFIX + "0");
+        Map<String, String> labels = new HashMap<String, String>();
+        labels.put(LABEL_PREFIX + "0", LABEL_PREFIX + "0");
         Assert.assertTrue(server.containsAny(labels));
     }
 
     @Test
     public void testHasAnyLabelWithNonExistentLabel() {
         ServerInfo server = createServer(numOfLabels);
-        Set<String> labels = createLabels(numOfLabels);
-        labels.add("non_existent_label");
+        Map<String, String> labels = createLabels(numOfLabels);
+        labels.put("non_existent_label", "non_existent_label");
         Assert.assertTrue(server.containsAny(labels));
     }
 
     @Test
     public void testHasAnyLabelWithEmptyLabels() {
         ServerInfo server = createServer(numOfLabels);
-        Assert.assertTrue(server.containsAny(Collections.<String>emptySet()));
+        Assert.assertTrue(server.containsAny(Collections.EMPTY_MAP));
     }
 
     @Test
     public void testHasAnyLabelFailure() {
         ServerInfo server = createServer(numOfLabels);
-        Set<String> labels = new HashSet<String>(Arrays.asList(NON_EXISTENT_LABEL));
+        Map<String, String> labels = new HashMap<String, String>();
+        labels.put(NON_EXISTENT_LABEL, NON_EXISTENT_LABEL);
         Assert.assertFalse(server.containsAny(labels));
     }
 
     @Test
     public void testHasAllLabel() {
         ServerInfo server = createServer(numOfLabels);
-        Set<String> labels = createLabels(numOfLabels);
+        Map<String, String> labels = createLabels(numOfLabels);
         Assert.assertTrue(server.containsAll(labels));
     }
 
     @Test
     public void testHasAllLabelFailure() {
         ServerInfo server = createServer(numOfLabels);
-        Set<String> labels = createLabels(numOfLabels);
-        labels.add(NON_EXISTENT_LABEL);
+        Map<String, String> labels = createLabels(numOfLabels);
+        labels.put(NON_EXISTENT_LABEL, NON_EXISTENT_LABEL);
         Assert.assertFalse(server.containsAll(labels));
     }
 
     @Test
     public void testHasAllLabelsWithEmptyLabels() {
         ServerInfo server = createServer(numOfLabels);
-        Assert.assertTrue(server.containsAll(Collections.<String>emptySet()));
+        Assert.assertTrue(server.containsAll(Collections.EMPTY_MAP));
     }
 
     private ServerInfo createServer(int numOfLabels) {
@@ -71,10 +72,10 @@ public class ServerInfoTest {
         return server;
     }
 
-    private Set<String> createLabels(int numOfLabels) {
-        Set<String> labels = new HashSet<String>();
+    private HashMap createLabels(int numOfLabels) {
+        HashMap labels = new HashMap();
         for (int i = 0; i < numOfLabels; i++) {
-            labels.add(LABEL_PREFIX + i);
+            labels.put(LABEL_PREFIX + i, LABEL_PREFIX + i);
         }
         return labels;
     }

--- a/sapphire/sapphire-core/src/test/java/amino/run/oms/KernelServerManagerTest.java
+++ b/sapphire/sapphire-core/src/test/java/amino/run/oms/KernelServerManagerTest.java
@@ -38,7 +38,7 @@ public class KernelServerManagerTest {
                                                         Operator.Equal,
                                                         Collections.singletonList(
                                                                 LABEL1_PREFIX + "1"))));
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result.get(0).getPort());
     }
@@ -61,7 +61,7 @@ public class KernelServerManagerTest {
                                                         Operator.Equal,
                                                         Collections.singletonList(
                                                                 LABEL1_PREFIX + "1"))));
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result.get(0).getPort());
     }
@@ -78,7 +78,7 @@ public class KernelServerManagerTest {
                                                         Operator.Equal,
                                                         Collections.singletonList(
                                                                 NON_EXISTENT_LABEL))));
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(0, result.size());
     }
 
@@ -104,7 +104,7 @@ public class KernelServerManagerTest {
                                                         Collections.singletonList(
                                                                 NON_EXISTENT_LABEL))));
 
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result.get(0).getPort());
     }
@@ -112,7 +112,7 @@ public class KernelServerManagerTest {
     @Test
     public void testEmptyLabelSet() throws Exception {
         NodeSelectorSpec spec = new NodeSelectorSpec();
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(10, result.size());
     }
 
@@ -135,7 +135,7 @@ public class KernelServerManagerTest {
                                                         Collections.singletonList(
                                                                 NON_EXISTENT_LABEL))));
 
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(0, result.size());
     }
 
@@ -159,7 +159,7 @@ public class KernelServerManagerTest {
                                                         Operator.Equal,
                                                         Collections.singletonList(
                                                                 NON_EXISTENT_LABEL))));
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(0, result.size());
     }
 
@@ -196,7 +196,7 @@ public class KernelServerManagerTest {
                                                         Collections.singletonList(
                                                                 NON_EXISTENT_LABEL))));
 
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result.get(0).getPort());
     }
@@ -226,7 +226,7 @@ public class KernelServerManagerTest {
                                                         Operator.Equal,
                                                         Collections.singletonList(
                                                                 LABEL1_PREFIX + "1"))));
-        List<InetSocketAddress> result = manager.getServers(spec);
+        List<InetSocketAddress> result = manager.getServers(Collections.singletonList(spec));
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result.get(0).getPort());
     }


### PR DESCRIPTION
Enabled DMSpec for maintaining node selection specifications.

PR is follow up PR of #649 

Note:
   1. DM contract related implementations are not handled