### PR TITLE
Switch distributionUrl from gradle-4.1-bin.zip to gradle-4.1-all.zip …

### DIFF
--- a/sapphire/gradle/wrapper/gradle-wrapper.properties
+++ b/sapphire/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 24 12:36:51 PST 2018
+#Fri Mar 22 14:19:01 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
…for improved documentation and source debugging.

Android Studio suggests doing this.

