### PR TITLE
Upgrade gradle version as recommended by Android Studio.

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -18,12 +18,12 @@ buildscript {
          * https://issuetracker.google.com/issues/38454212
          * https://github.com/requery/requery/issues/467
          */
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.1'
+    gradleVersion = '4.10.1'
 }
 
 subprojects {

--- a/sapphire/gradle/wrapper/gradle-wrapper.properties
+++ b/sapphire/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
This is just what Android Studio recommended. 
Build, test and examples seem to run fine. 
@sungwook-moon tells me that the AAPT bug comments probably no longer apply, but I left them in just in case we run into problems and need to debug.