### PR TITLE
Upgrade bintray plugin from 1.8.0 to 1.8.4 to resolve https://github.…

### DIFF
--- a/sapphire/build.gradle
+++ b/sapphire/build.gradle
@@ -8,7 +8,7 @@ buildscript {
          * Dependencies to support bintray upload
          */
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 
         /**
          * Be careful at upgrading to higher version of gradle (e.g., > 3.0):


### PR DESCRIPTION
I ran into https://github.com/bintray/gradle-bintray-plugin/issues/242
So this resolves it.

All tests pass:

```
> Task :sapphire-core:bintrayUpload
Task ':sapphire-core:bintrayUpload' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Gradle Bintray Plugin version: 1.8.4
Uploading to https://api.bintray.com/content/terryzhuo/DCAP/sapphire-core/1.0.0/com/huawei/paas/sapphire-core/1.0.0/sapphire-core-1.0.0.pom...
Uploaded to 'https://api.bintray.com/content/terryzhuo/DCAP/sapphire-core/1.0.0/com/huawei/paas/sapphire-core/1.0.0/sapphire-core-1.0.0.pom'.
Uploading to https://api.bintray.com/content/terryzhuo/DCAP/sapphire-core/1.0.0/com/huawei/paas/sapphire-core/1.0.0/sapphire-core-1.0.0.jar...
Uploaded to 'https://api.bintray.com/content/terryzhuo/DCAP/sapphire-core/1.0.0/com/huawei/paas/sapphire-core/1.0.0/sapphire-core-1.0.0.jar'.
Uploading to https://api.bintray.com/content/terryzhuo/DCAP/sapphire-core/1.0.0/com/huawei/paas/sapphire-core/1.0.0/sapphire-core-1.0.0.pom...
Uploaded to 'https://api.bintray.com/content/terryzhuo/DCAP/sapphire-core/1.0.0/com/huawei/paas/sapphire-core/1.0.0/sapphire-core-1.0.0.pom'.
:sapphire-core:bintrayUpload (Thread[Task worker for ':',5,main]) completed. Took 5.694 secs.

> Task :bintrayPublish
Task ':bintrayPublish' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
Published 'terryzhuo/DCAP/sapphire-core/1.0.0'.
:bintrayPublish (Thread[Task worker for ':',5,main]) completed. Took 0.225 secs.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 10s
```
