### PR TITLE
Move bintray artifacts to Amino repo.

### DIFF
--- a/sapphire/dependencies/apache.harmony/gradle.properties
+++ b/sapphire/dependencies/apache.harmony/gradle.properties
@@ -2,13 +2,13 @@
 version=1.0.0
 
 # bintray properties
-bintrayRepo=DCAP
+bintrayRepo=Amino
 bintrayPkgName=apache-harmony
 bintrayLicense=MIT
-bintrayVersion=1.0.0
-bintrayVcsUrl=https://github.com/Huawei-PaaS/DCAP-Sapphire.git
+bintrayVersion=1.0.0.RC6
+bintrayVcsUrl=https://github.com/amino-distributed-os/AminoRun
 
 # maven properties
-mavenGroupId=com.huawei.paas
+mavenGroupId=com.amino-os.run
 mavenArtifactId=apache.harmony
-mavenVersion=1.0.0
+mavenVersion=1.0.0.RC6

--- a/sapphire/dependencies/java.rmi/gradle.properties
+++ b/sapphire/dependencies/java.rmi/gradle.properties
@@ -2,13 +2,13 @@
 version=1.0.0
 
 # bintray properties
-bintryRepo=DCAP
+bintryRepo=Amino
 bintrayPkgName=java-rmi
 bintrayLicense=MIT
-bintrayVersion=1.0.0
-bintrayVcsUrl=https://github.com/Huawei-PaaS/DCAP-Sapphire.git
+bintrayVersion=1.0.0.RC6
+bintrayVcsUrl=https://github.com/amino-distributed-os/AminoRun
 
 # maven properties
-mavenGroupId=com.huawei.paas
+mavenGroupId=com.amino-os.run
 mavenArtifactId=java.rmi
-mavenVersion=1.0.0
+mavenVersion=1.0.0.RC6

--- a/sapphire/gradle.properties
+++ b/sapphire/gradle.properties
@@ -1,7 +1,7 @@
 # Bintray properties
 # Subprojects which plan to upload to bintray should
 # override these properties in its own gradle.properties
-bintrayRepo=DCAP
+bintrayRepo=Amino
 bintrayPkgName=unspecified
 bintrayLicense=MIT
 bintrayVersion=unspecified
@@ -10,7 +10,7 @@ bintrayVcsUrl=unspecified
 # Maven Publish Plugin Properties
 # Subprojects which plan to publish maven packages should
 # override these properties in its own gradle.properties
-mavenGroupId=com.huawei.paas
+mavenGroupId=com.amino-os.run
 mavenArtifactId=unspecified
 mavenVersion=unspecified
 

--- a/sapphire/sapphire-core/gradle.properties
+++ b/sapphire/sapphire-core/gradle.properties
@@ -6,14 +6,14 @@ version=1.0.0
 graalVmVersion=1.0.0-rc14
 
 # bintray properties
-bintrayRepo=DCAP
-bintrayPkgName=sapphire-core
+bintrayRepo=Amino
+bintrayPkgName=amino-run-core
 bintrayLicense=MIT
-bintrayVersion=1.0.0
-bintrayVcsUrl=https://github.com/Huawei-PaaS/DCAP-Sapphire.git
+bintrayVersion=1.0.0.RC6
+bintrayVcsUrl=https://github.com/amino-distributed-os/AminoRun.git
 
 # maven properties
-mavenGroupId=com.huawei.paas
-mavenArtifactId=sapphire-core
-mavenVersion=1.0.0
+mavenGroupId=com.amino-os.run
+mavenArtifactId=amino-run-core
+mavenVersion=1.0.0.RC6
 


### PR DESCRIPTION
In summary this does:

1. Change bintray repo from 'DCAP' to 'Amino' (this is just a name change)
2. Change bintray and maven versions from 1.0.0. to 1.0.0.RC6 (so that we can actually start to change the version number when we publish a new version). 
3. Change bintray vcs url to the location of the new repo (in anticipation of the move): https://github.com/amino-distributed-os/AminoRun

What's still to do is remove all the cut 'n pasted duplicate configuration, but I'll do that in a followup PR.

Also, the dependencies in http://github.com/Huawei-Paas/DCAP-Sapphire-Examples on the artifacts published from this repo need to be updated.  But that will also be done in a separate PR.  In the mean time the Examples should still build and run correctly, as the original artifacts on which they rely have not been moved.

All tests pass:
```
./gradlew check
...
BUILD SUCCESSFUL in 2m 10s
46 actionable tasks: 3 executed, 43 up-to-date

$ ./gradlew :sapphire-core:bintrayUpload

> Task :sapphire-core:bintrayUpload
Uploading to https://api.bintray.com/content/terryzhuo/Amino/amino-run-core/1.0.0.RC6/com/amino-os/run/sapphire-core/1.0.0.RC6/sapphire-core-1.0.0.RC6.pom...
Uploaded to 'https://api.bintray.com/content/terryzhuo/Amino/amino-run-core/1.0.0.RC6/com/amino-os/run/sapphire-core/1.0.0.RC6/sapphire-core-1.0.0.RC6.pom'.
Uploading to https://api.bintray.com/content/terryzhuo/Amino/amino-run-core/1.0.0.RC6/com/amino-os/run/sapphire-core/1.0.0.RC6/sapphire-core-1.0.0.RC6.jar...
Uploaded to 'https://api.bintray.com/content/terryzhuo/Amino/amino-run-core/1.0.0.RC6/com/amino-os/run/sapphire-core/1.0.0.RC6/sapphire-core-1.0.0.RC6.jar'.
Uploading to https://api.bintray.com/content/terryzhuo/Amino/amino-run-core/1.0.0.RC6/com/amino-os/run/amino-run-core/1.0.0.RC6/amino-run-core-1.0.0.RC6.pom...
Uploaded to 'https://api.bintray.com/content/terryzhuo/Amino/amino-run-core/1.0.0.RC6/com/amino-os/run/amino-run-core/1.0.0.RC6/amino-run-core-1.0.0.RC6.pom'.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 5s
24 actionable tasks: 6 executed, 18 up-to-date

```
