### PR TITLE
Consensus issue - Upon vote request rcv in new term, server was just updating its current term without becoming follower

### DIFF
--- a/sapphire/sapphire-core/src/integrationTest/java/amino/run/kernel/IntegrationTestBase.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/amino/run/kernel/IntegrationTestBase.java
@@ -3,14 +3,12 @@ package amino.run.kernel;
 import static java.lang.Thread.sleep;
 
 import amino.run.app.MicroServiceSpec;
-import amino.run.demo.KVStore;
 import amino.run.kernel.server.KernelServerImpl;
 import amino.run.oms.OMSServerImpl;
 import java.io.*;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.util.List;
-import org.junit.Assert;
 
 public class IntegrationTestBase {
     public static String omsIp = "127.0.0.1";
@@ -63,31 +61,6 @@ public class IntegrationTestBase {
         }
     }
 
-    /**
-     * Wait the specified time for a key in the store to have a desired value
-     *
-     * @param store
-     * @param key
-     * @param desiredValue
-     * @param timeoutMs How long to try for, in ms. If <= 0, use the default.
-     * @throws InterruptedException
-     */
-    public static void waitForValue(KVStore store, String key, Object desiredValue, long timeoutMs)
-            throws InterruptedException {
-        long DEFAULT_TIMEOUT_MS = 1000;
-        long DEFAULT_SLEEP_BETWEEN_TRIES_MS = 100;
-        if (timeoutMs <= 0) {
-            timeoutMs = DEFAULT_TIMEOUT_MS;
-        }
-        long startTime = System.currentTimeMillis();
-        Object value;
-        do {
-            sleep(DEFAULT_SLEEP_BETWEEN_TRIES_MS);
-            value = store.get(key);
-        } while (!desiredValue.equals(value)
-                && (System.currentTimeMillis() - startTime) < timeoutMs);
-        Assert.assertEquals(desiredValue, value);
-    }
     /**
      * start the OMS process
      *

--- a/sapphire/sapphire-core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -70,8 +70,9 @@ public class MultiDMTestCases {
             String key = "k1_" + i;
             String value = "v1_" + i;
             store.set(key, value);
-            waitForValue(store, key, value, -1);
-            Assert.assertEquals(value, store.get(key));
+            String returnValue = (String) store.get(key);
+            Assert.assertEquals(
+                    "Expected: " + value + "Actual: " + returnValue, value, returnValue);
         }
     }
 
@@ -99,7 +100,7 @@ public class MultiDMTestCases {
             String completeDMName =
                     getPackageName(shortDMName) + "." + shortDMName + POLICY_POSTFIX;
             DMSpec dmSpec = DMSpec.newBuilder().setName(completeDMName).create();
-            
+
             if (shortDMName.equals("DHT")) {
                 config = new DHTPolicy.Config();
                 ((DHTPolicy.Config) config).setNumOfShards(DHT_SHARDS);

--- a/sapphire/sapphire-core/src/integrationTest/java/amino/run/policy/ConsensusDMIntegrationTest.java
+++ b/sapphire/sapphire-core/src/integrationTest/java/amino/run/policy/ConsensusDMIntegrationTest.java
@@ -45,8 +45,9 @@ public class ConsensusDMIntegrationTest {
             String key = "k1_" + i;
             String value = "v1_" + i;
             store.set(key, value);
-            sleep(500);
-            Assert.assertEquals(value, store.get(key));
+            String returnValue = (String) store.get(key);
+            Assert.assertEquals(
+                    "Expected: " + value + "Actual: " + returnValue, value, returnValue);
         }
     }
 


### PR DESCRIPTION
Following consensus issues are fixed:
1. ![Selection_023](https://user-images.githubusercontent.com/35334869/55810864-dbaca680-5b05-11e9-8997-249daa4a2afc.png)

`leaderHeartbeatReceiveTimer` used from multiple threads without synchronization and lead to exception.
2. When a vote request with new term is seen, we were just updating current term to latest but not resetting setVotedFor to NO_LEADER and restarting leaderHeartbeatReceiveTimer. In the below picture with 3 servers in group, server[4eb5bf71-e938-4529-bc29-4ff1678b6525] had requested votes for term=2, server[42fc1a2e-f23f-42cf-9c13-69c345429a81] had voted and becomes follower himself. And soon after that, server[208c8fa0-31f3-4332-9f83-bbf50d4f7022 has initiated vote request for term=3. server[4eb5bf71-e938-4529-bc29-4ff1678b6525 had voted it. But server[42fc1a2e-f23f-42cf-9c13-69c345429a81 rejected vote request with reason- "already voted for 4eb5bf71-e938-4529-bc29-4ff1678b6525 (current term = 3)". Actually server[42fc1a2e-f23f-42cf-9c13-69c345429a81] had never given positive vote for term 3.
![Selection_024](https://user-images.githubusercontent.com/35334869/55813043-bb7ee680-5b09-11e9-9a92-6052fa6a086f.png)
Full log of test case:
[issue.log](https://github.com/Huawei-PaaS/DCAP-Sapphire/files/3059804/issue.log)

3. Removed unwanted delay in integration test.
