### PR TITLE
Fix #692 - Gradlew warning fix for bootstrap and comment for JDK compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,9 +98,15 @@ subprojects {
     }
 
     // Added for enforcing Java 1.6 version compatibility.
-    def javaVersion = JavaVersion.VERSION_1_6
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
+    // Note that this will not result in compilation failure unless JDK 1.6 or less is used.
+    // GraalVM supports from JDK 1.8; therefore, it doesn't have an effect except IDE inspector
+    // may show incompatible APIs for higher version than JDK 1.6.
+    tasks.withType(JavaCompile) {
+        def javaVersion = JavaVersion.VERSION_1_6
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+        options.bootstrapClasspath = files("$System.env.JAVA_HOME/jre/lib/rt.jar")
+    }
     
     // SourceSet for generated stubs
     sourceSets {


### PR DESCRIPTION
This PR fixes issue #692 and added comments regarding issue #676.

1. The following warning is fixed in each task of Gradle build:
"warning: [options] bootstrap class path not set in conjunction with -source 1.6"

2. Comments were added in regards to issue #676.

<img width="962" alt="Screen Shot 2019-04-10 at 7 01 46 PM" src="https://user-images.githubusercontent.com/12723038/55925663-1f191a80-5bc3-11e9-9209-3d2ffc8d0508.png">

![Screen Shot 2019-04-10 at 7 02 42 PM](https://user-images.githubusercontent.com/12723038/55925711-4ec82280-5bc3-11e9-9f83-0ac5fb492fd6.png)
![Screen Shot 2019-04-10 at 7 03 04 PM](https://user-images.githubusercontent.com/12723038/55925716-5091e600-5bc3-11e9-9611-13d9ec0f6277.png)
