### PR TITLE
[Object Monitoring]Replication of server policies to other kernel server when kernel server on which they are running goes down

### DIFF
--- a/core/src/main/java/amino/run/kernel/common/ServerUnreachable.java
+++ b/core/src/main/java/amino/run/kernel/common/ServerUnreachable.java
@@ -1,0 +1,12 @@
+package amino.run.kernel.common;
+
+import amino.run.common.Notification;
+
+/** ServerUnreachable notification to notify kernel server health to group policy(on OMS) */
+public class ServerUnreachable implements Notification {
+    public ServerInfo serverInfo;
+
+    public ServerUnreachable(ServerInfo serverInfo) {
+        this.serverInfo = serverInfo;
+    }
+}

--- a/core/src/main/java/amino/run/oms/KernelServerManager.java
+++ b/core/src/main/java/amino/run/oms/KernelServerManager.java
@@ -72,7 +72,8 @@ public class KernelServerManager {
         }
     }
 
-    public void registerKernelServer(ServerInfo info) throws RemoteException, NotBoundException {
+    public void registerKernelServer(ServerInfo info, final Runnable onRemove)
+            throws RemoteException, NotBoundException {
         logger.info(
                 "New kernel server: "
                         + info.getHost().toString()
@@ -96,6 +97,7 @@ public class KernelServerManager {
                                 // If we don't receive a heartbeat from this kernel server, remove
                                 // that from the list
                                 stopHeartBeat(srvInfo);
+                                onRemove.run();
                             }
                         },
                         OMSServer.KS_HEARTBEAT_TIMEOUT);

--- a/core/src/main/java/amino/run/oms/MicroServiceManager.java
+++ b/core/src/main/java/amino/run/oms/MicroServiceManager.java
@@ -145,9 +145,9 @@ public class MicroServiceManager {
     /**
      * Get all the microservices
      *
-     * @throws java.rmi.RemoteException
+     * @return List of Microservice Ids
      */
-    public ArrayList<MicroServiceID> getAllMicroServices() throws RemoteException {
+    public ArrayList<MicroServiceID> getAllMicroServices() {
         ArrayList<MicroServiceID> arr = new ArrayList<MicroServiceID>(microServices.keySet());
         return arr;
     }

--- a/core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
+++ b/core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
@@ -1,7 +1,7 @@
 package amino.run.policy;
 
 import amino.run.common.MicroServiceNotFoundException;
-import amino.run.common.MicroServiceReplicaNotFoundException;
+import amino.run.kernel.common.KernelServerNotFoundException;
 import amino.run.policy.transaction.IllegalComponentException;
 import amino.run.policy.transaction.TransactionContext;
 import amino.run.policy.transaction.TwoPCClient;
@@ -79,8 +79,7 @@ public abstract class DefaultUpcallImpl extends Library {
         /* This function is here just to generate the stub for this function in all server policies */
         @Override
         public void pin_to_server(InetSocketAddress server)
-                throws RemoteException, MicroServiceNotFoundException,
-                        MicroServiceReplicaNotFoundException {
+                throws RemoteException, MicroServiceNotFoundException {
             super.pin_to_server(server);
         }
 
@@ -91,6 +90,19 @@ public abstract class DefaultUpcallImpl extends Library {
     }
 
     public abstract static class GroupPolicy extends GroupPolicyLibrary {
+
+        /**
+         * Following abstract methods need to be implemented in the DM group policy to override the
+         * default behavior. Stub methods are not generated for them. These methods are called
+         * within group policy(not exposed outside)
+         */
+        abstract void addServer(Policy.ServerPolicy server);
+
+        abstract void removeServer(Policy.ServerPolicy server);
+
+        abstract void replicate()
+                throws RemoteException, MicroServiceNotFoundException,
+                        KernelServerNotFoundException;
 
         /*
          * INTERNAL FUNCTIONS (Used by MicroService runtime)

--- a/core/src/main/java/amino/run/policy/Library.java
+++ b/core/src/main/java/amino/run/policy/Library.java
@@ -18,10 +18,7 @@ import amino.run.common.MultiDMConstructionHelper;
 import amino.run.common.ReplicaID;
 import amino.run.common.Utils;
 import amino.run.compiler.GlobalStubConstants;
-import amino.run.kernel.common.GlobalKernelReferences;
-import amino.run.kernel.common.KernelOID;
-import amino.run.kernel.common.KernelObjectFactory;
-import amino.run.kernel.common.KernelObjectNotFoundException;
+import amino.run.kernel.common.*;
 import amino.run.kernel.server.KernelServerImpl;
 import amino.run.oms.OMSServer;
 import amino.run.policy.Policy.ServerPolicy;
@@ -320,11 +317,9 @@ public abstract class Library implements Upcalls {
          * @param server
          * @throws RemoteException
          * @throws MicroServiceNotFoundException
-         * @throws MicroServiceReplicaNotFoundException
          */
         public void pin_to_server(InetSocketAddress server)
-                throws RemoteException, MicroServiceNotFoundException,
-                        MicroServiceReplicaNotFoundException {
+                throws RemoteException, MicroServiceNotFoundException {
             ServerPolicy serverPolicy = (ServerPolicy) this;
 
             logger.info(
@@ -555,6 +550,15 @@ public abstract class Library implements Upcalls {
                 }
             }
             return serversInRegion;
+        }
+
+        public void terminateLocal(ServerPolicy server)
+                throws RemoteException, MicroServiceNotFoundException,
+                        KernelObjectNotFoundException {
+            oms().unRegisterKernelObject(
+                            ((KernelObjectStub) server).$__getKernelOID(),
+                            ((KernelObjectStub) server).$__getHostname());
+            oms().unRegisterReplica(server.getReplicaId());
         }
 
         public void $__setKernelOID(KernelOID oid) {

--- a/core/src/main/java/amino/run/policy/mobility/explicitmigration/ExplicitMigrationPolicy.java
+++ b/core/src/main/java/amino/run/policy/mobility/explicitmigration/ExplicitMigrationPolicy.java
@@ -1,7 +1,6 @@
 package amino.run.policy.mobility.explicitmigration;
 
 import amino.run.common.MicroServiceNotFoundException;
-import amino.run.common.MicroServiceReplicaNotFoundException;
 import amino.run.kernel.common.KernelObjectStub;
 import amino.run.policy.DefaultPolicy;
 import amino.run.policy.Policy;
@@ -78,8 +77,6 @@ public class ExplicitMigrationPolicy extends DefaultPolicy {
             try {
                 /* Pin the source server policy object to given destination address */
                 pin(sourceServer, destinationAddress);
-            } catch (MicroServiceReplicaNotFoundException e) {
-                throw new MigrationException("Not found the server policy object to migrate", e);
             } catch (MicroServiceNotFoundException e) {
                 throw new MigrationException("MicroService not found", e);
             }

--- a/core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
+++ b/core/src/main/java/amino/run/policy/scalability/ScaleUpFrontendPolicy.java
@@ -1,7 +1,6 @@
 package amino.run.policy.scalability;
 
 import amino.run.common.MicroServiceNotFoundException;
-import amino.run.common.MicroServiceReplicaNotFoundException;
 import amino.run.kernel.common.KernelObjectStub;
 import amino.run.policy.Policy;
 import amino.run.policy.util.ResettableTimer;
@@ -223,9 +222,6 @@ public class ScaleUpFrontendPolicy extends LoadBalancedFrontendPolicy {
                     replicate(servers.get(0), addressList.get(0), region);
                 } catch (MicroServiceNotFoundException e) {
                     throw new ScaleUpException("Failed to find microservice. Probably deleted.", e);
-                } catch (MicroServiceReplicaNotFoundException e) {
-                    throw new ScaleUpException(
-                            "Failed to find replicate microservice. Probably deleted.", e);
                 }
             } else {
                 throw new ScaleUpException(

--- a/core/src/test/java/amino/run/oms/KernelServerManagerTest.java
+++ b/core/src/test/java/amino/run/oms/KernelServerManagerTest.java
@@ -235,7 +235,12 @@ public class KernelServerManagerTest {
             labels.put(LABEL2_PREFIX + i, LABEL2_PREFIX + i);
             labels.put(REGION_KEY, "region_" + i);
             s.addLabels(labels);
-            manager.registerKernelServer(s);
+            manager.registerKernelServer(
+                    s,
+                    new Runnable() {
+                        @Override
+                        public void run() {}
+                    });
             timer =
                     new ResettableTimer(
                             new TimerTask() {

--- a/examples/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/HanksTodoMain.java
+++ b/examples/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/HanksTodoMain.java
@@ -1,6 +1,7 @@
 package amino.run.appexamples.hankstodo;
 
 import java.net.InetSocketAddress;
+import java.rmi.ConnectException;
 import java.rmi.registry.LocateRegistry;
 import java.util.Collections;
 
@@ -78,7 +79,16 @@ public class HanksTodoMain {
                     System.out.println(
                             String.format(
                                     "Adding %s. Content: %s at iteration %d", subject, content, i));
-                    td1.addToDo(subject, content);
+                    try {
+                        td1.addToDo(subject, content);
+                    } catch (Exception e) {
+                        /* Retry adding if connection exception had occurred */
+                        if (e instanceof RuntimeException) {
+                            if (e.getCause() instanceof ConnectException) {
+                                j--;
+                            }
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Replication of server policies to other kernel server when kernel server on which they are running goes down

Note: 
**1. In case of single instance DM, replication is not handled. Because, there is no reference copy to replicate. And the microservice state is not presisted. Need to consider it further.
2. MultiDM case need to be handled in separate PR.
3. Consensus Membership change will be handled in separate PR.**