### PR TITLE
Remove MakeKernelRPC from GroupPolicyStub

### DIFF
--- a/core/src/main/java/amino/run/compiler/PolicyStub.java
+++ b/core/src/main/java/amino/run/compiler/PolicyStub.java
@@ -1,5 +1,6 @@
 package amino.run.compiler;
 
+import amino.run.policy.Upcalls;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Iterator;
@@ -116,8 +117,7 @@ public class PolicyStub extends Stub {
 
     @Override
     public String getStubAdditionalMethods() {
-        Class<?> ancestorClass = stubClass;
-        boolean isGroupPolicy = ancestorClass.getSimpleName().equals("GroupPolicy");
+        boolean isGroupPolicy = Upcalls.GroupUpcalls.class.isAssignableFrom(stubClass);
         StringBuilder buffer = new StringBuilder();
 
         /* Implementation for getKernelOID */


### PR DESCRIPTION
Fixes #545 

MakeKernelRPC is not used in GroupPolicy as all calls to GroupStub should be direct calls.
Added a comment about setNextPolicy which is another method that is not used by Group Policy.

<img width="962" alt="Screen Shot 2019-04-16 at 5 13 46 PM" src="https://user-images.githubusercontent.com/12723038/56383185-239a9000-61ce-11e9-9794-fc2a46c9b5fc.png">
