### PR TITLE
DHT chord removal added

### DIFF
--- a/core/src/main/java/amino/run/policy/dht/DHTPolicy.java
+++ b/core/src/main/java/amino/run/policy/dht/DHTPolicy.java
@@ -131,7 +131,7 @@ public class DHTPolicy extends DefaultPolicy {
         @Override
         protected void removeServer(Policy.ServerPolicy server) {
             super.removeServer(server);
-            // TODO: Need to remove from chord too
+            dhtChord.remove((ServerPolicy) server);
         }
 
         public DHTChord getChord() {


### PR DESCRIPTION
Added DHT remove chord support:
1. Added `remove()` in DHTChord.java
2. Added `readObject` and `writeObject` to control serialization of `DHTChord`. Since `TreeSet` implementation is not thread safe, concurrent add/remove/access `TreeSet` for sake of serialization can lead to exception. So added synchronized access to `nodes`