### PR TITLE
We must have a link to the documentation website on the main page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,7 +79,7 @@ transactional storage system (Amino.Sync) and a privacy and security framework
 (Amino.Safe). Initial focus is on making Amino.Run production-ready.
 
 ## Important Links
-* [Getting started](GettingStarted.md)
+* [Amino.Run Documentation](https://amino.readthedocs.io/en/latest/index.html)
 
 ## References
 <sup>1</sup> [Customizable and Extensible Deployment for Mobile/Cloud Applications


### PR DESCRIPTION
The current link to Getting Started is resulting into a 404 on GitHub, I believe we must have a link to the Amino.Run documentation web page so that it is easily accessible to anyone visiting the repo

This PR fixes this issue 

![image](https://user-images.githubusercontent.com/9480316/56494014-8f526500-650e-11e9-859e-c57a8716b5e2.png)
