### PR TITLE
Fix election timeout logic to prevent candidate loops.

### DIFF
--- a/core/src/main/java/amino/run/policy/util/consensus/raft/Server.java
+++ b/core/src/main/java/amino/run/policy/util/consensus/raft/Server.java
@@ -808,9 +808,12 @@ public class Server
         /**
          * How long we wait after starting election, before giving up and starting again if no
          * leader has been elected yet. Note that a random variation between servers is introduced
-         * to reduce split votes.
+         * to reduce split votes. And a minimum to prevent randomly chosen timeouts being too short.
+         * The end result is intended to be an election timeout slightly more or less than the
+         * heartbeat timeout.
          */
-        public final int LEADER_ELECTION_TIMEOUT = (int) (LEADER_HEARTBEAT_TIMEOUT * Math.random());
+        public final int LEADER_ELECTION_TIMEOUT =
+                (int) (LEADER_HEARTBEAT_TIMEOUT * Math.random()) + LEADER_HEARTBEAT_TIMEOUT / 2;
 
         /** If no leader is elected within the timeout, start another election. */
         ResettableTimer leaderElectionTimer;


### PR DESCRIPTION
Potentially simpler fix than #719 ?

All tests pass

Logs seem to indicate that loop is avoided

Leader election seems to succeed

```
INFO: 87267e66-c8e1-4d5f-8c0f-5835bf4e17d8: Start being a follower.
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Candidate$3 run
INFO: 87267e66-c8e1-4d5f-8c0f-5835bf4e17d8Interrupted while waiting to receive a majority of votes in leader election.
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Candidate$3 run
INFO: 87267e66-c8e1-4d5f-8c0f-5835bf4e17d8 While waiting in blocking call, state transitioned from CANDIDATE to FOLLOWER, old term : 1 and current term : 2
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Leader sendAppendEntries
WARNING: amino.run.policy.util.consensus.raft.InvalidTermException: Server: Attempt to append entries from prior leader term 1, current term 2
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Candidate sendVoteRequest
INFO: Vote received from server bfad70b3-9276-4e79-b6a9-551b1aeb2d1b
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Candidate$2 run
INFO: Sent vote request to server bfad70b3-9276-4e79-b6a9-551b1aeb2d1b
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Candidate sendVoteRequest
INFO: Vote received from server 87267e66-c8e1-4d5f-8c0f-5835bf4e17d8
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Candidate stop
INFO: 234b75e5-7d16-4e34-a83c-9b13564b381c: Stop being a candidate.
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Leader start
INFO: 234b75e5-7d16-4e34-a83c-9b13564b381c: Start being a leader.
Apr 22, 2019 3:16:23 PM amino.run.policy.util.consensus.raft.Server$Candidate$2 run
INFO: Sent vote request to server 87267e66-c8e1-4d5f-8c0f-5835bf4e17d8
Apr 22, 2019 3:16:25 PM amino.run.policy.util.consensus.raft.Server$Candidate stop
INFO: 7e1076d9-b562-4b44-8bf7-ff34df2f4f43: Stop being a candidate.
Apr 22, 2019 3:16:25 PM amino.run.policy.util.consensus.raft.Server$Candidate start
INFO: 7e1076d9-b562-4b44-8bf7-ff34df2f4f43: Start being a candidate.
Apr 22, 2019 3:16:25 PM amino.run.policy.util.consensus.raft.Server$Candidate sendVoteRequest
INFO: Sending vote request to server 8be4b420-1091-4ed9-97f9-87f77adcfd2a
Apr 22, 2019 3:16:25 PM amino.run.policy.util.consensus.raft.Server$Candidate sendVoteRequest
INFO: Sending vote request to server d4b9ff65-74dc-4c77-bc79-72fa66a11170
Apr 22, 2019 3:16:25 PM amino.run.policy.util.consensus.raft.Server$Candidate stop
INFO: 8be4b420-1091-4ed9-97f9-87f77adcfd2a: Stop being a candidate.
Apr 22, 2019 3:16:25 PM amino.run.policy.util.consensus.raft.Server$Candidate stop
INFO: d4b9ff65-74dc-4c77-bc79-72fa66a11170: Stop being a candidate.
Apr 22, 2019 3:16:25 PM amino.run.policy.util.consensus.raft.Server$Follower start
INFO: 8be4b420-1091-4ed9-97f9-87f77adcfd2a: Start being a follower.
```

