### PR TITLE
add check for ignoring upRPCCall

### DIFF
--- a/core/src/main/java/amino/run/compiler/Stub.java
+++ b/core/src/main/java/amino/run/compiler/Stub.java
@@ -119,6 +119,8 @@ public abstract class Stub implements RmicConstants {
             MethodStub m = i.next();
             if (m.name.equals("onRPC")) {
                 buffer.append(EOLN + m.getStubImpl(false));
+            } else if (m.name.equals("upRPCCall")) {
+                continue;
             } else {
                 buffer.append(EOLN + m.getStubImpl(true));
             }


### PR DESCRIPTION
Added check to avoid ```upRPCCall`` method for stub generation

![image](https://user-images.githubusercontent.com/9818606/56671708-b9ed1b00-66d2-11e9-98ca-014c59d115e8.png)

Fixes: #729