### PR TITLE
 Add ConsensusRSMPolicy to minnietwitter example

### DIFF
--- a/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
+++ b/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
@@ -6,15 +6,16 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Deployment Manager policy to automatically retry RPCs for bounded amount of time,
- * with exponential backoff.
+ * Deployment Manager policy to automatically retry RPCs for bounded amount of time, with
+ * exponential backoff.
  */
 public class AtLeastOnceRPCPolicy extends DefaultPolicy {
 
     public static class ClientPolicy extends DefaultClientPolicy {
-        // 5s looks like a reasonable default timeout for production
-        private long timeoutMilliSeconds = 5000L;
-        private long initialExponentialDelayMilliSeconds = 20L;  // Wait this long before the first retry.
+        // a reasonable default timeout for production
+        private long timeoutMilliSeconds = 10000L;
+        private long initialExponentialDelayMilliSeconds =
+                20L; // Wait this long before the first retry.
         private long exponentialMultiplier = 2L; // Double the wait before every subsequent retry.
 
         public ClientPolicy() {}

--- a/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/MinnieTwitterMain.java
+++ b/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/MinnieTwitterMain.java
@@ -12,6 +12,8 @@ import amino.run.common.MicroServiceNotFoundException;
 import amino.run.kernel.server.KernelServer;
 import amino.run.kernel.server.KernelServerImpl;
 import amino.run.policy.atleastoncerpc.AtLeastOnceRPCPolicy;
+import amino.run.policy.replication.ConsensusRSMPolicy;
+
 import com.google.devtools.common.options.OptionsParser;
 import java.net.InetSocketAddress;
 import java.rmi.RemoteException;
@@ -163,6 +165,10 @@ public class MinnieTwitterMain {
                                 DMSpec.newBuilder()
                                         .setName(AtLeastOnceRPCPolicy.class.getName())
                                         .create())
+                        .addDMSpec(
+                                DMSpec.newBuilder()
+                                        .setName(ConsensusRSMPolicy.class.getName())
+                                        .create())
                         .create();
 
         MicroServiceID microServiceId = oms.create(spec.toString());
@@ -247,6 +253,25 @@ public class MinnieTwitterMain {
         TwitterManager clients[] = new TwitterManager[3];
         // Start the microservice
         clients[0] = createTwitterManager(oms, microServiceName);
+
+        /* TODO: quinton: Fix this hack.
+         *
+         * For some reason, when adding a ConsensusRSMPolicy after the AtLeastOnceRPCPolicy
+         * it seems that the TwitterManager stub is returned before the TwitterManager microservice
+         * has been properly initialized.
+         * Specifically, for a few seconds, getUserManager() and getTagManager() both return null.
+         * Now looking at the implementation of TwitterManager, those fields are initialized
+         * in the one and only constructor, so could never, in theory, by null.
+         * So I assume what's happening is that the stub is being returned before the replicas
+         * created by ConsensusRSMPolicy.GroupPolicy have been properly initlialized.
+         * Until we get to the bottom of that bug, here is a simple hack to get around it for now.
+         */
+        long waitMillis = 20L;
+        long waitMaxMillis = 5000L;
+        while (waitMillis < waitMaxMillis && (clients[0].getUserManager() == null || clients[0].getTagManager() == null)) {
+            Thread.sleep(waitMillis);
+            waitMillis *= 2; // Exponential backoff
+        }
 
         // Client 0 populates a bunch of users, tweets, retweets etc
         populate(clients[0]);
@@ -378,7 +403,7 @@ public class MinnieTwitterMain {
         }
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         OptionsParser parser = OptionsParser.newOptionsParser(AppArgumentParser.class);
         if (args.length < 8) {
             System.out.println("Incorrect arguments to the program");
@@ -397,11 +422,7 @@ public class MinnieTwitterMain {
         InetSocketAddress
                 hostAddr = new InetSocketAddress(appArgs.kernelServerIP, appArgs.kernelServerPort),
                 omsAddr = new InetSocketAddress(appArgs.omsIP, appArgs.omsPort);
-        try {
-            runFullDemo(hostAddr, omsAddr);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        runFullDemo(hostAddr, omsAddr);
     }
 
     private static void printUsage(OptionsParser parser) {

--- a/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/MinnieTwitterMain.java
+++ b/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/MinnieTwitterMain.java
@@ -13,7 +13,6 @@ import amino.run.kernel.server.KernelServer;
 import amino.run.kernel.server.KernelServerImpl;
 import amino.run.policy.atleastoncerpc.AtLeastOnceRPCPolicy;
 import amino.run.policy.replication.ConsensusRSMPolicy;
-
 import com.google.devtools.common.options.OptionsParser;
 import java.net.InetSocketAddress;
 import java.rmi.RemoteException;
@@ -253,26 +252,6 @@ public class MinnieTwitterMain {
         TwitterManager clients[] = new TwitterManager[3];
         // Start the microservice
         clients[0] = createTwitterManager(oms, microServiceName);
-
-        /* TODO: quinton: Fix this hack.
-         *
-         * For some reason, when adding a ConsensusRSMPolicy after the AtLeastOnceRPCPolicy
-         * it seems that the TwitterManager stub is returned before the TwitterManager microservice
-         * has been properly initialized.
-         * Specifically, for a few seconds, getUserManager() and getTagManager() both return null.
-         * Now looking at the implementation of TwitterManager, those fields are initialized
-         * in the one and only constructor, so could never, in theory, by null.
-         * So I assume what's happening is that the stub is being returned before the replicas
-         * created by ConsensusRSMPolicy.GroupPolicy have been properly initlialized.
-         * Until we get to the bottom of that bug, here is a simple hack to get around it for now.
-         */
-        long waitMillis = 20L;
-        long waitMaxMillis = 5000L;
-        while (waitMillis < waitMaxMillis && (clients[0].getUserManager() == null || clients[0].getTagManager() == null)) {
-            Thread.sleep(waitMillis);
-            waitMillis *= 2; // Exponential backoff
-        }
-
         // Client 0 populates a bunch of users, tweets, retweets etc
         populate(clients[0]);
 


### PR DESCRIPTION
1. Add AtLeastOnceRPCPolicy
2. Prevent main() from swallowing exceptions, so that gradle can actually report errors.
3. Adjust AtLeastOnceRPCPolicy default retry timeout from 5s to 10s

