### PR TITLE
Avoid swallowing exceptions, to make error reporting and debugging easier

### DIFF
--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -69,7 +69,7 @@ public class MultiDMTestCases {
 
             // consensus DM needs some time to elect the leader other wise function call will fail
             if (spec.getName().contains(CONSENSUS)) {
-                Thread.sleep(5000);
+                Thread.sleep(20000);
             }
 
             for (int i = 0; i < 10; i++) {

--- a/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/UserInfo.java
+++ b/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/UserInfo.java
@@ -1,7 +1,9 @@
 package amino.run.appexamples.minnietwitter;
 
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 public class UserInfo implements Serializable {
     /* Unique username */
@@ -9,16 +11,12 @@ public class UserInfo implements Serializable {
     /* MDH5 of password*/
     byte[] password;
 
-    public UserInfo(String username, String passwd) {
+    public UserInfo(String username, String passwd)
+            throws NoSuchAlgorithmException, UnsupportedEncodingException {
         this.username = username;
         MessageDigest md;
-        try {
-            md = MessageDigest.getInstance("MD5");
-            this.password = md.digest(passwd.getBytes("UTF-8"));
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+        md = MessageDigest.getInstance("MD5");
+        this.password = md.digest(passwd.getBytes("UTF-8"));
     }
 
     public String getUsername() {

--- a/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/UserManager.java
+++ b/examples/minnietwitter/src/main/java/amino/run/appexamples/minnietwitter/UserManager.java
@@ -5,7 +5,9 @@ import static amino.run.runtime.MicroService.*;
 import amino.run.app.MicroService;
 import amino.run.policy.dht.DHTKey;
 import amino.run.runtime.MicroServiceConfiguration;
+import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -19,7 +21,8 @@ public class UserManager implements MicroService {
         this.users = new Hashtable<DHTKey, User>();
     }
 
-    public User addUser(String username, String passwd) {
+    public User addUser(String username, String passwd)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException {
 
         User user = (User) new_(User.class, new UserInfo(username, passwd), tm);
         user.initialize(user);
@@ -41,21 +44,17 @@ public class UserManager implements MicroService {
     }
 
     // TODO: throws exception; test
-    public User login(String username, String passwd) {
+    public User login(String username, String passwd)
+            throws NoSuchAlgorithmException, UnsupportedEncodingException {
         User u = users.get(new DHTKey(username));
 
         if (u == null) return null;
 
         // check password
         MessageDigest md;
-        try {
-            md = MessageDigest.getInstance("MD5");
-            byte[] pass = md.digest(passwd.getBytes("UTF-8"));
-            if (!checkPasswords(pass, u.getUserInfo().getPassword())) return null;
-        } catch (Exception e) {
-            e.printStackTrace();
-            // TODO: throw exception
-        }
+        md = MessageDigest.getInstance("MD5");
+        byte[] pass = md.digest(passwd.getBytes("UTF-8"));
+        if (!checkPasswords(pass, u.getUserInfo().getPassword())) return null;
         return u;
     }
 


### PR DESCRIPTION
This PR looks biggish, but all it does is remove try catch blocks that just print out stack traces, and instead lets the exceptions propagate back to callers.  Removing the associated indentation makes the PR look bigger than it really is.