### PR TITLE
ClientPolicy.onRPC() of DefaultUpcallImpl.java swallows RemoteException and do not propagate this exception

### DIFF
--- a/core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
+++ b/core/src/main/java/amino/run/policy/DefaultUpcallImpl.java
@@ -27,9 +27,8 @@ public abstract class DefaultUpcallImpl extends Library {
             try {
                 ret = getServer().onRPC(method, params);
             } catch (RemoteException e) {
-                // TODO: Quinton: This looks like a bug.  RemoteExceptions are silently swallowed
-                // and null is returned.
                 setServer(getGroup().onRefRequest());
+                throw e;
             }
             return ret;
         }

--- a/core/src/main/java/amino/run/policy/replication/ConsensusRSMPolicy.java
+++ b/core/src/main/java/amino/run/policy/replication/ConsensusRSMPolicy.java
@@ -56,9 +56,8 @@ public class ConsensusRSMPolicy extends DefaultPolicy {
             try {
                 ret = getServer().onRPC(method, params);
             } catch (LeaderException e) {
-
                 if (null == e.getLeader()) {
-                    throw new RemoteException("Raft leader is not elected");
+                    throw e;
                 }
 
                 setServer((ServerPolicy) e.getLeader());
@@ -72,7 +71,7 @@ public class ConsensusRSMPolicy extends DefaultPolicy {
                 if (e.getTargetException() instanceof LeaderException) {
                     LeaderException le = (LeaderException) e.getTargetException();
                     if (null == le.getLeader()) {
-                        throw new RemoteException("Raft leader is not elected");
+                        throw le;
                     }
                     setServer((ServerPolicy) le.getLeader());
                     ret = ((ServerPolicy) le.getLeader()).onRPC(method, params);
@@ -97,7 +96,7 @@ public class ConsensusRSMPolicy extends DefaultPolicy {
                         /* Store this server as reachable and use it for the rpcs to follow */
                         if (null == le.getLeader()) {
                             setServer(server);
-                            throw new RemoteException("Raft leader is not elected");
+                            throw le;
                         }
 
                         setServer(((ServerPolicy) le.getLeader()));

--- a/core/src/test/java/amino/run/policy/replication/ConsensusRSMPolicyTest.java
+++ b/core/src/test/java/amino/run/policy/replication/ConsensusRSMPolicyTest.java
@@ -204,7 +204,7 @@ public class ConsensusRSMPolicyTest extends BaseTest {
         Policy.ServerPolicy server = spy(ConsensusRSMPolicy.ServerPolicy.class);
         client.setServer(server);
         doThrow(new LeaderException("leaderException", null)).when(server).onRPC(method, params);
-        thrown.expect(RemoteException.class);
+        thrown.expect(LeaderException.class);
         client.onRPC(method, params);
     }
 
@@ -348,7 +348,7 @@ public class ConsensusRSMPolicyTest extends BaseTest {
         doThrow(new LeaderException("leaderException", null)).when(server2).onRPC(method, params);
         doReturn(new KernelOID(1)).when(server1).$__getKernelOID();
         doReturn(new KernelOID(2)).when(server2).$__getKernelOID();
-        thrown.expect(RemoteException.class);
+        thrown.expect(LeaderException.class);
         localClient.onRPC(method, params);
     }
 


### PR DESCRIPTION
Fixes #792
1. ClientPolicy.onRPC() of DefaultUpcallImpl.java swallowed RemoteException. So AtLeastOnceRPCPolicy retry doesn't work in case of RemoteException.
2. Consensus DM client is throwing RemoteException upon LeaderException when leader is not elected. So when AtleastOnceRPC is chained with Consensus DM, and if Consensus DM client throws RemoteException, it is swallowed at DefaultUpcallImpl.ClientPolicy.onRPC() and AtLeastOnceRPCPolicy retry do not happen.