### PR TITLE
Remove arbitrary sleep from multiDM integrationTest.

### DIFF
--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -16,6 +16,7 @@ import java.net.InetSocketAddress;
 import java.rmi.registry.LocateRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -45,7 +46,7 @@ public class MultiDMTestCases {
 
     // Unless AtLeastOnceRPC policy is used, we need to explicitly retry.
     final String AT_LEAST_ONCE_RPC = "AtLeastOnceRPC";
-    final long retryTimeoutMs = 5000L;
+    final long retryTimeoutMs = 10000L;
     final long retryPeriodMs = 100L;
 
     final int DHT_SHARDS = 2;
@@ -84,9 +85,7 @@ public class MultiDMTestCases {
                         store.set(key, value);
                         returnValue = (String) store.get(key);
                         logger.info("Got value " + returnValue + " for key " + key);
-                        if (value.equals(returnValue)) {
-                            break; // Success, no more retries necessary
-                        }
+                        break; // Success, no more retries necessary
                     } catch (RuntimeException r) {
                         logger.info(
                                 "Runtime exception after "
@@ -120,7 +119,7 @@ public class MultiDMTestCases {
                     }
                 }
                 if (System.currentTimeMillis() - startTime >= retryTimeoutMs) {
-                    logger.info("Timed out retrying key " + key + ", value " + value);
+                    throw new TimeoutException("Timed out retrying key " + key + ", value " + value);
                 }
                 Assert.assertEquals(value, returnValue);
             }

--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -220,8 +220,8 @@ public class MultiDMTestCases {
     }
 
     @Test
-    public void testDHTConsensusRSMCacheLeaseAtLeastOnceRPC() throws Exception {
-        runTest("DHT", "ConsensusRSM", "CacheLease", "AtLeastOnceRPC");
+    public void testDHTAtLeastOnceRPCConsensusRSMCacheLease() throws Exception {
+        runTest("DHT", "AtLeastOnceRPC", "ConsensusRSM", "CacheLease");
     }
 
     @Test

--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -16,6 +16,7 @@ import java.net.InetSocketAddress;
 import java.rmi.registry.LocateRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,6 +51,7 @@ public class MultiDMTestCases {
     final int DHT_SHARDS = 2;
     Registry registry;
     private static String regionName = "";
+    private static final Logger logger = Logger.getLogger(MultiDMTestCases.class.getName());
 
     @BeforeClass
     public static void bootstrap() throws Exception {
@@ -81,12 +83,12 @@ public class MultiDMTestCases {
                     try {
                         store.set(key, value);
                         returnValue = (String) store.get(key);
-                        System.out.println("Got value " + returnValue + " for key " + key);
+                        logger.info("Got value " + returnValue + " for key " + key);
                         if (value.equals(returnValue)) {
                             break; // Success, no more retries necessary
                         }
                     } catch (RuntimeException r) {
-                        System.out.println(
+                        logger.info(
                                 "Runtime exception after "
                                         + (System.currentTimeMillis() - startTime)
                                         + "ms for key "
@@ -99,26 +101,26 @@ public class MultiDMTestCases {
                                 && r.getCause()
                                         .getClass()
                                         .isAssignableFrom(LeaderException.class)) {
-                            System.out.println("Cause of runtime exception is LeaderException");
+                            logger.info("Cause of runtime exception is LeaderException");
                             if (!Arrays.asList(dmNames).contains(AT_LEAST_ONCE_RPC)) {
                                 // Swallow the exception and retry, after sleeping
-                                System.out.println(
+                                logger.info(
                                         "Swallowing runtime exception because AtLeastOnceRPC is not used.");
                                 Thread.sleep(retryPeriodMs);
                             } else {
-                                System.out.println(
+                                logger.info(
                                         "Not swallowing runtime exception because AtLeastOnceRPC is used.");
                                 throw r;
                             }
                         } else {
-                            System.out.println(
+                            logger.info(
                                     "Not swallowing runtime exception because cause is not LeaderException");
                             throw r;
                         }
                     }
                 }
                 if (System.currentTimeMillis() - startTime >= retryTimeoutMs) {
-                    System.out.println("Timed out retrying key " + key + ", value " + value);
+                    logger.info("Timed out retrying key " + key + ", value " + value);
                 }
                 Assert.assertEquals(value, returnValue);
             }

--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -108,10 +108,12 @@ public class MultiDMTestCases {
                             } else {
                                 System.out.println(
                                         "Not swallowing runtime exception because AtLeastOnceRPC is used.");
+                                throw r;
                             }
                         } else {
                             System.out.println(
                                     "Not swallowing runtime exception because cause is not LeaderException");
+                            throw r;
                         }
                     }
                 }

--- a/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
+++ b/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
@@ -36,6 +36,8 @@ public class AtLeastOnceRPCPolicy extends DefaultPolicy {
                 } catch (AppExceptionWrapper e) {
                     throw e; // Don't retry on application exceptions
                 } catch (Exception e) {
+                    System.out.println(
+                            "AtLeastOnceRPCPolicy retrying due to " + e.getClass().getName());
                     lastException = e; // So we can throw this after the timeout.
                     Thread.sleep(delay);
                     delay *= exponentialMultiplier;

--- a/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
+++ b/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
@@ -15,7 +15,7 @@ public class AtLeastOnceRPCPolicy extends DefaultPolicy {
     public static class ClientPolicy extends DefaultClientPolicy {
         private static final Logger logger = Logger.getLogger(AtLeastOnceRPCPolicy.class.getName());
         // a reasonable default timeout for production
-        private long timeoutMilliSeconds = 10000L;
+        private long timeoutMilliSeconds = 20000L;
         private long initialExponentialDelayMilliSeconds =
                 20L; // Wait this long before the first retry.
         private long exponentialMultiplier = 2L; // Double the wait before every subsequent retry.

--- a/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
+++ b/core/src/main/java/amino/run/policy/atleastoncerpc/AtLeastOnceRPCPolicy.java
@@ -4,6 +4,7 @@ import amino.run.common.AppExceptionWrapper;
 import amino.run.policy.DefaultPolicy;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Logger;
 
 /**
  * Deployment Manager policy to automatically retry RPCs for bounded amount of time, with
@@ -12,6 +13,7 @@ import java.util.concurrent.TimeoutException;
 public class AtLeastOnceRPCPolicy extends DefaultPolicy {
 
     public static class ClientPolicy extends DefaultClientPolicy {
+        private static final Logger logger = Logger.getLogger(AtLeastOnceRPCPolicy.class.getName());
         // a reasonable default timeout for production
         private long timeoutMilliSeconds = 10000L;
         private long initialExponentialDelayMilliSeconds =
@@ -34,10 +36,10 @@ public class AtLeastOnceRPCPolicy extends DefaultPolicy {
                 try {
                     return super.onRPC(method, params);
                 } catch (AppExceptionWrapper e) {
+                    logger.info("Not retrying because exception is from application: " + e);
                     throw e; // Don't retry on application exceptions
                 } catch (Exception e) {
-                    System.out.println(
-                            "AtLeastOnceRPCPolicy retrying due to " + e.getClass().getName());
+                    logger.info("Retrying method " + method + " after " + delay + "ms due to " + e);
                     lastException = e; // So we can throw this after the timeout.
                     Thread.sleep(delay);
                     delay *= exponentialMultiplier;
@@ -45,7 +47,10 @@ public class AtLeastOnceRPCPolicy extends DefaultPolicy {
                 }
             } while (System.currentTimeMillis() - startTime < timeoutMilliSeconds);
             TimeoutException e =
-                    new TimeoutException("Retry timeout exceeded in AtLeastOnceRPCPolicy");
+                    new TimeoutException(
+                            "Retry timeout of "
+                                    + timeoutMilliSeconds
+                                    + "ms exceeded in AtLeastOnceRPCPolicy");
             e.initCause(lastException); // Legacy constructor lacks cause argument;
             throw e;
         }


### PR DESCRIPTION
In summary:

Rather than wait an arbitrary 5 seconds for ConsensusRSM leader to be elected, explicitly catch LeaderException, and retry until timeout, but only if AtLeastOnceRPC is not in the DM chain.
