### PR TITLE
WIP: Upgrade gradle from 4.10 to 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
          * https://issuetracker.google.com/issues/38454212
          * https://github.com/requery/requery/issues/467
          */
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 
@@ -28,11 +28,11 @@ plugins {
     // 2. Run `gradlew verGJF` to verify code farmat
     // 3. More usage information can be found at
     // https://github.com/sherter/google-java-format-gradle-plugin
-    id 'com.github.sherter.google-java-format' version '0.7.1'
+    id 'com.github.sherter.google-java-format' version '0.8'
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.10.1'
+wrapper {
+    gradleVersion = '5.1.1'
 }
 
 subprojects {
@@ -134,7 +134,7 @@ subprojects {
     compileStubsJava {
         classpath = sourceSets.main.runtimeClasspath
         options.incremental = true
-        inputs.dir genStubs.outputs
+        inputs.files genStubs.outputs
     }
 
     clean {
@@ -146,12 +146,12 @@ subprojects {
 
     // Include stubs sourceSet classes in the jar file.
     jar {
-        from sourceSets.stubs.output.classesDir
+        from sourceSets.stubs.output.classesDirs
         // Java jar file depends on compile tasks of all sourceSets.
         // Currently there are two sourceSets - "main" and "stubs".
         // Java modules will have "main" and "stubs" sourceSets and
         // non-Java examples will have only "main" sourceSet.
-        inputs.dir tasks.withType(AbstractCompile)   // jar needs to be rebuilt if any compileTask gets executed.
+        dependsOn tasks.withType(AbstractCompile)   // jar needs to be rebuilt if any compileTask gets executed.
     }
 
     googleJavaFormat {
@@ -160,7 +160,7 @@ subprojects {
         // date and get regenerated and reformatted again and again.
     }
 
-    tasks.googleJavaFormat.dependsOn tasks.withType(AbstractCompile)
+    // quinton: This looks like rubbish: tasks.googleJavaFormat.dependsOn tasks.withType(AbstractCompile)
     check.dependsOn tasks.googleJavaFormat
 
     check.dependsOn tasks.withType(AbstractCompile)  // Ensure that all compileTasks are executed, as part of check.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,7 +81,7 @@ def getGraalVmVersion = { ->
 
 // Check that the installed GraalVM version matches the the standard version we use for this project.
 task checkGraalVmVersion {
-    inputs.property('graalVmVersion', null)
+    inputs.property('graalVmVersion', 'null')
     inputs.property('actualVersion', { getGraalVmVersion() })
     doLast {
         def requiredVersion = project.property('graalVmVersion')
@@ -111,18 +111,20 @@ task compileSampleSO(type: JavaCompile) {
     source = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO')
     exclude('**/*_Stub*')  // Added for excluding older Stub files, while compiling Sample SO package.
     classpath = sourceSets.main.runtimeClasspath
-    destinationDir = sourceSets.test.output.classesDir
+    destinationDir sourceSets.test.output.classesDirs[0]
     options.incremental = true
 }
 
 task genUnitTestStubs(type :JavaExec){
     dependsOn compileSampleSO
     main = "amino.run.compiler.StubGenerator"
-    classpath += files(sourceSets.test.output.classesDir)
+    classpath += files(sourceSets.test.output.classesDirs)
 
     def pkg = 'amino.run.sampleSO'
-    def src = file(project.buildDir.toString() + '/classes/java/test/amino/run/sampleSO/')
-    def dst = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO/stubs/')
+    // def src = file(project.buildDir.toString() + '/classes/java/test/amino/run/sampleSO/')
+    // def dst = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO/stubs/')
+    def src = sourceSets.test.output.classesDirs[0].toString() + '/amino/run/sampleSO'
+    def dst = sourceSets.stubs.java.srcDirs[0].toString() + '/amino/run/sampleSO'
     args src.toString(), pkg, dst.toString()
     inputs.dir src
     outputs.dir dst
@@ -138,17 +140,17 @@ task genGraalTestStubs(type: JavaExec) {
     def packageName = "amino.run.stubs"
     def microServiceClasses = "Student"
     args microServicePath, outPath, packageName, microServiceClasses
-    inputs.dir microServicePath   // Declare inputs, so gradle will run if they have been changed
+    inputs.files microServicePath   // Declare inputs, so gradle will run if they have been changed
     outputs.dir outPath + "/amino/run/stubs" // Declare outputs, so gradle will run if they have been changed
 }
 // Task for Graal Test stubs compilation
 task compileGraalTestStubs(type: JavaCompile) {
     dependsOn genGraalTestStubs
-    source = "$projectDir/src/test/java/amino/run/stubs"
+    source "$projectDir/src/test/java/amino/run/stubs"
     classpath = sourceSets.main.runtimeClasspath
-    destinationDir = sourceSets.test.output.classesDir
+    destinationDir sourceSets.test.output.classesDirs[0]
     options.incremental = true
-    inputs.dir genGraalTestStubs.outputs
+    inputs.files genGraalTestStubs.outputs.files
     outputs.dir destinationDir
 }
 
@@ -156,14 +158,14 @@ task compileIntegTestDemoPkg(type: JavaCompile) {
     source = file(project.projectDir.toString() + '/src/integrationTest/java/amino/run/demo/')
     exclude('**/*_Stub*')  // Added for excluding older Stub files, while compiling Integration Test Demo package.
     classpath = sourceSets.integrationTest.compileClasspath
-    destinationDir = sourceSets.integrationTest.output.classesDir
+    destinationDir = sourceSets.integrationTest.output.classesDirs[0]
     options.incremental = true
 }
 
 task genIntegTestStubs(type :JavaExec) {
     dependsOn compileIntegTestDemoPkg
     main = "amino.run.compiler.StubGenerator"
-    classpath += files(sourceSets.integrationTest.output.classesDir)
+    classpath += files(sourceSets.integrationTest.output.classesDirs)
 
     def pkg = 'amino.run.demo'
     def src = file(project.buildDir.toString() + '/classes/java/integrationTest/amino/run/demo')
@@ -188,13 +190,19 @@ jar {
 }
 
 compileJava.dependsOn checkGraalVmVersion
+
+compileStubsJava {
+    classpath += sourceSets.test.output.classesDirs
+}
+
 compileTestJava {
     dependsOn compileStubsJava
     dependsOn compileGraalTestStubs
-    dependsOn genUnitTestStubs
-    classpath += sourceSets.stubs.output
+    // dependsOn genUnitTestStubs
+    // inputs.files genUnitTestStubs.outputs.files
+    classpath += sourceSets.stubs.output.classesDirs
 }
-compileIntegrationTestJava.dependsOn genIntegTestStubs
+// compileIntegrationTestJava.dependsOn genIntegTestStubs
 
 integTest.mustRunAfter test
 check.dependsOn integTest

--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -119,7 +119,8 @@ public class MultiDMTestCases {
                     }
                 }
                 if (System.currentTimeMillis() - startTime >= retryTimeoutMs) {
-                    throw new TimeoutException("Timed out retrying key " + key + ", value " + value);
+                    throw new TimeoutException(
+                            "Timed out retrying key " + key + ", value " + value);
                 }
                 Assert.assertEquals(value, returnValue);
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 22 14:19:01 PDT 2019
+#Fri Jun 21 12:01:23 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
We're on a very old version of Gradle and the Android gradle plugin.
Upgrade to the latest stable version, and make required changes to the build scripts to deal with deprecated fields etc.

I'm still trying to resolve a circular dependency problem that's crept in after which I'll remove the WIP and merge once reviewed.  If I manually generate stubs, then all tests and examples succeed.  But when I add a dependency to make that happen automatically, gradle fails with a circular dependency. That's what still needs to be resolved. 
