### PR TITLE
Added check for static methods in App stub, Group policy and Server policy stub

### DIFF
--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -119,7 +119,8 @@ public class MultiDMTestCases {
                     }
                 }
                 if (System.currentTimeMillis() - startTime >= retryTimeoutMs) {
-                    throw new TimeoutException("Timed out retrying key " + key + ", value " + value);
+                    throw new TimeoutException(
+                            "Timed out retrying key " + key + ", value " + value);
                 }
                 Assert.assertEquals(value, returnValue);
             }
@@ -270,7 +271,6 @@ public class MultiDMTestCases {
     public void testAtLeastOnceRPCDHTLoadBalancedMasterSlaveSync() throws Exception {
         runTest("AtLeastOnceRPC", "DHT", "LoadBalancedMasterSlaveSync");
     }
-
 
     @Test
     public void testAtLeastOnceRPCLockingTransaction() throws Exception {

--- a/core/src/main/java/amino/run/compiler/AppStub.java
+++ b/core/src/main/java/amino/run/compiler/AppStub.java
@@ -24,8 +24,8 @@ public final class AppStub extends Stub {
         TreeSet<MethodStub> ms = new TreeSet<MethodStub>();
 
         for (Method m : stubClass.getDeclaredMethods()) {
-            // Add public methods to methods vector
-            if (Modifier.isPublic(m.getModifiers())) {
+            // Add public non static methods to methods vector
+            if (Modifier.isPublic(m.getModifiers()) && !Modifier.isStatic(m.getModifiers())) {
                 ms.add(new MethodStub((Method) m));
             }
         }

--- a/core/src/main/java/amino/run/compiler/PolicyStub.java
+++ b/core/src/main/java/amino/run/compiler/PolicyStub.java
@@ -22,8 +22,8 @@ public class PolicyStub extends Stub {
                 && (!ancestorClass.getSimpleName().equals("GroupPolicyLibrary"))) {
 
             for (Method m : ancestorClass.getDeclaredMethods()) {
-                // Add public methods to methods vector
-                if (Modifier.isPublic(m.getModifiers())) {
+                // Add public non static methods to methods vector
+                if (Modifier.isPublic(m.getModifiers()) && !Modifier.isStatic(m.getModifiers())) {
                     ms.add(new MethodStub(m));
                 }
             }

--- a/core/src/test/java/amino/run/compiler/AppStubTest.java
+++ b/core/src/test/java/amino/run/compiler/AppStubTest.java
@@ -13,7 +13,8 @@ public class AppStubTest {
 
         TreeSet<Stub.MethodStub> stubMethods = appStub.getMethods();
         for (Stub.MethodStub methodStub : stubMethods) {
-            Assert.assertNotEquals(methodStub.getName(), "getPolicies");
+            // Assert to check for static method generation in App stub methods set.
+            Assert.assertNotEquals(methodStub.getName(), "staticMethod");
         }
     }
 }

--- a/core/src/test/java/amino/run/compiler/AppStubTest.java
+++ b/core/src/test/java/amino/run/compiler/AppStubTest.java
@@ -1,0 +1,19 @@
+package amino.run.compiler;
+
+import amino.run.sampleSO.SO;
+import java.util.TreeSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AppStubTest {
+
+    @Test
+    public void testAppStubNonStaticPublicMethod() throws Exception {
+        AppStub appStub = new AppStub(SO.class);
+
+        TreeSet<Stub.MethodStub> stubMethods = appStub.getMethods();
+        for (Stub.MethodStub methodStub : stubMethods) {
+            Assert.assertNotEquals(methodStub.getName(), "getPolicies");
+        }
+    }
+}

--- a/core/src/test/java/amino/run/compiler/PolicyStubTest.java
+++ b/core/src/test/java/amino/run/compiler/PolicyStubTest.java
@@ -1,0 +1,29 @@
+package amino.run.compiler;
+
+import amino.run.samplepolicy.TestPolicy;
+import java.util.TreeSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PolicyStubTest {
+
+    @Test
+    public void testServerPolicyNonStaticPublicMethod() {
+        PolicyStub appStub = new PolicyStub(TestPolicy.ServerPolicy.class);
+
+        TreeSet<Stub.MethodStub> stubMethods = appStub.getMethods();
+        for (Stub.MethodStub methodStub : stubMethods) {
+            Assert.assertNotEquals(methodStub.getName(), "getPolicyName");
+        }
+    }
+
+    @Test
+    public void testGroupPolicyNonStaticPublicMethod() {
+        PolicyStub appStub = new PolicyStub(TestPolicy.GroupPolicy.class);
+
+        TreeSet<Stub.MethodStub> stubMethods = appStub.getMethods();
+        for (Stub.MethodStub methodStub : stubMethods) {
+            Assert.assertNotEquals(methodStub.getName(), "getPolicyName");
+        }
+    }
+}

--- a/core/src/test/java/amino/run/compiler/PolicyStubTest.java
+++ b/core/src/test/java/amino/run/compiler/PolicyStubTest.java
@@ -13,6 +13,7 @@ public class PolicyStubTest {
 
         TreeSet<Stub.MethodStub> stubMethods = appStub.getMethods();
         for (Stub.MethodStub methodStub : stubMethods) {
+            // Assert to check for static method generation in Server policy stub methods set.
             Assert.assertNotEquals(methodStub.getName(), "getPolicyName");
         }
     }
@@ -23,6 +24,7 @@ public class PolicyStubTest {
 
         TreeSet<Stub.MethodStub> stubMethods = appStub.getMethods();
         for (Stub.MethodStub methodStub : stubMethods) {
+            // Assert to check for static method generation in Group policy stub methods set.
             Assert.assertNotEquals(methodStub.getName(), "getPolicyName");
         }
     }

--- a/core/src/test/java/amino/run/sampleSO/SO.java
+++ b/core/src/test/java/amino/run/sampleSO/SO.java
@@ -42,4 +42,8 @@ public class SO implements MicroService, ExplicitMigrator {
 
     @Override
     public void migrateTo(InetSocketAddress destinationAddr) throws MigrationException {}
+
+    public static String[] getPolicies() {
+        return SO.class.getAnnotation(MicroServiceConfiguration.class).Policies();
+    }
 }

--- a/core/src/test/java/amino/run/sampleSO/SO.java
+++ b/core/src/test/java/amino/run/sampleSO/SO.java
@@ -43,7 +43,12 @@ public class SO implements MicroService, ExplicitMigrator {
     @Override
     public void migrateTo(InetSocketAddress destinationAddr) throws MigrationException {}
 
-    public static String[] getPolicies() {
-        return SO.class.getAnnotation(MicroServiceConfiguration.class).Policies();
+    /**
+     * Method declared to check static method generation in App stub methods.
+     *
+     * @return true
+     */
+    public static Boolean staticMethod() {
+        return true;
     }
 }

--- a/core/src/test/java/amino/run/samplepolicy/TestPolicy.java
+++ b/core/src/test/java/amino/run/samplepolicy/TestPolicy.java
@@ -1,0 +1,17 @@
+package amino.run.samplepolicy;
+
+import amino.run.policy.DefaultPolicy;
+
+public class TestPolicy extends DefaultPolicy {
+    public static class ServerPolicy extends DefaultServerPolicy {
+        public static String getPolicyName() {
+            return "amino.run.samplepolicy.TestPolicy.ServerPolicy";
+        }
+    }
+
+    public static class GroupPolicy extends DefaultGroupPolicy {
+        public static String getPolicyName() {
+            return "amino.run.samplepolicy.TestPolicy.GroupPolicy";
+        }
+    }
+}

--- a/core/src/test/java/amino/run/samplepolicy/TestPolicy.java
+++ b/core/src/test/java/amino/run/samplepolicy/TestPolicy.java
@@ -4,14 +4,24 @@ import amino.run.policy.DefaultPolicy;
 
 public class TestPolicy extends DefaultPolicy {
     public static class ServerPolicy extends DefaultServerPolicy {
-        public static String getPolicyName() {
-            return "amino.run.samplepolicy.TestPolicy.ServerPolicy";
+        /**
+         * Method declared to check static method generation in Server policy stub.
+         *
+         * @return true
+         */
+        public static Boolean staticMethod() {
+            return true;
         }
     }
 
     public static class GroupPolicy extends DefaultGroupPolicy {
-        public static String getPolicyName() {
-            return "amino.run.samplepolicy.TestPolicy.GroupPolicy";
+        /**
+         * Method declared to check static method generation in Group policy stub methods.
+         *
+         * @return true
+         */
+        public static Boolean staticMethod() {
+            return true;
         }
     }
 }

--- a/examples/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/HanksTodoMain.java
+++ b/examples/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/HanksTodoMain.java
@@ -1,7 +1,5 @@
 package amino.run.appexamples.hankstodo;
 
-import static java.lang.Thread.sleep;
-
 import amino.run.app.Language;
 import amino.run.app.MicroServiceSpec;
 import amino.run.app.Registry;

--- a/examples/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/TodoListManager.java
+++ b/examples/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/TodoListManager.java
@@ -36,7 +36,9 @@ public class TodoListManager implements MicroService {
                             .addDMSpec(
                                     DMSpec.newBuilder().setName(DHTPolicy.class.getName()).create())
                             .addDMSpec(
-                                    DMSpec.newBuilder().setName(AtLeastOnceRPCPolicy.class.getName()).create())
+                                    DMSpec.newBuilder()
+                                            .setName(AtLeastOnceRPCPolicy.class.getName())
+                                            .create())
                             .addDMSpec(
                                     DMSpec.newBuilder()
                                             .setName(ConsensusRSMPolicy.class.getName())


### PR DESCRIPTION
This PR handles issue raised in #57. 
Currently if Application, Group policy or Server policy code includes any static method, gradle build fails because generated stub contains method signature of static methods as instance method. This is not allowed in Java.

This PR added checks in stub generation for static methods for App stub, Group policy and Server policy stub.

Build Report :
![image](https://user-images.githubusercontent.com/9818606/60168805-22678e00-9823-11e9-9d42-7a14a73aeb05.png)

***Note***
Some code modifications are related to Java formatting. 