### PR TITLE
[Gradle Script Issue #799] Gradle script correction for example repo

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -132,18 +132,16 @@ subprojects {
             println "Launched Kernel Server 4. !!!"
         }
     }
-    task runenvapp(dependsOn: ksTask) {
-        // If any failures in 'runapp' task then 'runenvapp' task also should fail.
+
+    task run (dependsOn: ksTask) {
+        //If any failures in 'runapp' task then 'runenvapp' task also should fail.
         finalizedBy 'runapp'
-        // 'cleanup' task should run after runapp task always. Currently it is running after 'runapp' task.
+        // 'cleanup' task should run after runapp task always. Currently it is running after runapp task.
         // Dont move this task before 'runapp' task.
         finalizedBy 'cleanup'
     }
 
-    task run (dependsOn: runenvapp) {
-    }
-
-    task cleanup (dependsOn: runenvapp) {
+    task cleanup () {
         // Need to cleanup all the background processes which were launched, before exiting.
         doLast {
             def ports = ["$omsPort", "$kernelServerPort", "$kernelServerPort2", "$kernelServerPort3", "$kernelServerPort4"]

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -132,11 +132,18 @@ subprojects {
             println "Launched Kernel Server 4. !!!"
         }
     }
-    task runenvapp(type: ExecWait, dependsOn: ksTask) {
-        command './gradlew ' + project + ':runapp'
+    task runenvapp(dependsOn: ksTask) {
+        // If any failures in 'runapp' task then 'runenvapp' task also should fail.
+        finalizedBy 'runapp'
+        // 'cleanup' task should run after runapp task always. Currently it is running after 'runapp' task.
+        // Dont move this task before 'runapp' task.
+        finalizedBy 'cleanup'
     }
 
     task run (dependsOn: runenvapp) {
+    }
+
+    task cleanup (dependsOn: runenvapp) {
         // Need to cleanup all the background processes which were launched, before exiting.
         doLast {
             def ports = ["$omsPort", "$kernelServerPort", "$kernelServerPort2", "$kernelServerPort3", "$kernelServerPort4"]


### PR DESCRIPTION
1. PR raised for the issue  #799
2. 'runapp' task no relation with 'runenvapp' task. runenvapp task will be SUCCESSFUL always even 'runapp' task fails/success.
I fixed this by using the "runenvapp.finalizedBy runapp".
In this case, 'runenvapp' task status will be decided by 'runapp' task.

Build Report:
![BuildReport](https://user-images.githubusercontent.com/17046058/60177956-dc68f500-9837-11e9-98e3-9958ecb36e1f.png)

Success Case:
![successCase](https://user-images.githubusercontent.com/17046058/60177967-e3900300-9837-11e9-9ca4-84f05ce0bf71.png)

Failure Case
![FailureCase](https://user-images.githubusercontent.com/17046058/60177977-eab71100-9837-11e9-807a-3e00a51a83b2.png)

ports close after task:
![portsClean](https://user-images.githubusercontent.com/17046058/60178041-14703800-9838-11e9-933a-8d6c67706f5f.png)

