### PR TITLE
Make MultiDMTestCases be data driven by using JUnit Parameterized Tests.

### DIFF
--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -10,10 +10,9 @@ import amino.run.common.MicroServiceID;
 import amino.run.common.Utils;
 import amino.run.demo.KVStore;
 import amino.run.kernel.server.KernelServerImpl;
-import amino.run.policy.cache.CacheLeasePolicy;
-import amino.run.policy.cache.WriteThroughCachePolicy;
 import amino.run.policy.Upcalls;
 import amino.run.policy.atleastoncerpc.AtLeastOnceRPCPolicy;
+import amino.run.policy.cache.CacheLeasePolicy;
 import amino.run.policy.cache.WriteThroughCachePolicy;
 import amino.run.policy.checkpoint.durableserializable.DurableSerializableRPCPolicy;
 import amino.run.policy.checkpoint.periodiccheckpoint.PeriodicCheckpointPolicy;
@@ -31,7 +30,6 @@ import java.rmi.registry.LocateRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
@@ -45,8 +43,8 @@ import org.junit.runners.Parameterized;
 
 /**
  * Test multiple deployment managers (<strong>"multi-dm"</strong>) with multiple kernel servers.
- * 
- * TODO: Current integration tests only check the results returned back to the client. Ideally, 
+ *
+ * <p>TODO: Current integration tests only check the results returned back to the client. Ideally,
  * they should check each kernel server to verify whether RPCs were made to intended kernel servers.
  */
 @RunWith(Parameterized.class)
@@ -54,7 +52,7 @@ public class MultiDMTestCases {
     final String JAVA_CLASS_NAME = "amino.run.demo.KVStore";
     final Language DEFAULT_LANG = Language.java;
 
-    // Unless AtLeastOnceRPC policy is used, we need to explicitly retry.
+    // Unless AtLeastOnceRPC policy is used as outer DM, we need to explicitly retry.
     final long RETRY_TIMEOUT_MS = 10000L;
     final long RETRY_PERIOD_MS = 1000L;
 
@@ -64,118 +62,161 @@ public class MultiDMTestCases {
     private static final Logger logger = Logger.getLogger(MultiDMTestCases.class.getName());
 
     /**
-     * Array of all DM classes to be tested.  Every binary combination (i.e. 2) of these DM's
-     * will be tested unless explicitly ignored below.
+     * Array of all DM classes to be tested. Every binary combination (i.e. 2) of these DM's will be
+     * tested unless explicitly ignored below.
      */
     private static Class[] allDmClasses = {
         AtLeastOnceRPCPolicy.class,
         CacheLeasePolicy.class,
         ConsensusRSMPolicy.class,
-            DurableSerializableRPCPolicy.class,
-            DHTPolicy.class,
-            LoadBalancedMasterSlaveSyncPolicy.class,
-            LockingTransactionPolicy.class,
-            OptConcurrentTransactPolicy.class,
-            PeriodicCheckpointPolicy.class,
-            SerializableRPCPolicy.class,
-            TwoPCCoordinatorPolicy.class,
-            WriteThroughCachePolicy.class
+        DurableSerializableRPCPolicy.class,
+        DHTPolicy.class,
+        LoadBalancedMasterSlaveSyncPolicy.class,
+        LockingTransactionPolicy.class,
+        OptConcurrentTransactPolicy.class,
+        PeriodicCheckpointPolicy.class,
+        SerializableRPCPolicy.class,
+        TwoPCCoordinatorPolicy.class,
+        WriteThroughCachePolicy.class
     };
 
     /**
-     * Array of additional combinations of DM's to be tested.
-     * Because the number of combinations of 3 or more DM's is so large,
-     * we do not automatically test all possible combinations of 3 or more,
-     * only those combinations listed here.
+     * Array of additional combinations of DM's to be tested. Because the number of combinations of
+     * 3 or more DM's is so large, we do not automatically test all possible combinations of 3 or
+     * more, only those combinations listed here.
      */
     private static Class[][] additionalCombinations = {
-            { AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class, ConsensusRSMPolicy.class },
-            { AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class },
-            { AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class, LoadBalancedMasterSlaveSyncPolicy.class },
-            { AtLeastOnceRPCPolicy.class, ConsensusRSMPolicy.class, DHTPolicy.class },
-            { AtLeastOnceRPCPolicy.class, DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class },
-            { AtLeastOnceRPCPolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class },
-            { CacheLeasePolicy.class, AtLeastOnceRPCPolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class },
-            { CacheLeasePolicy.class, DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class },
-            { CacheLeasePolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class },
-            { ConsensusRSMPolicy.class, DHTPolicy.class, AtLeastOnceRPCPolicy.class },
-            { DHTPolicy.class, AtLeastOnceRPCPolicy.class, ConsensusRSMPolicy.class, CacheLeasePolicy.class },
-            { DHTPolicy.class, ConsensusRSMPolicy.class, CacheLeasePolicy.class },
-            { DHTPolicy.class, ConsensusRSMPolicy.class, AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class },
-            { DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class, AtLeastOnceRPCPolicy.class },
-            { DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class, AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class }
+        {AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class, ConsensusRSMPolicy.class},
+        {
+            AtLeastOnceRPCPolicy.class,
+            CacheLeasePolicy.class,
+            DHTPolicy.class,
+            ConsensusRSMPolicy.class
+        },
+        {
+            AtLeastOnceRPCPolicy.class,
+            CacheLeasePolicy.class,
+            LoadBalancedMasterSlaveSyncPolicy.class
+        },
+        {AtLeastOnceRPCPolicy.class, ConsensusRSMPolicy.class, DHTPolicy.class},
+        {AtLeastOnceRPCPolicy.class, DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class},
+        {AtLeastOnceRPCPolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class},
+        {
+            CacheLeasePolicy.class,
+            AtLeastOnceRPCPolicy.class,
+            DHTPolicy.class,
+            ConsensusRSMPolicy.class
+        },
+        {CacheLeasePolicy.class, DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class},
+        {CacheLeasePolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class},
+        {ConsensusRSMPolicy.class, DHTPolicy.class, AtLeastOnceRPCPolicy.class},
+        {
+            DHTPolicy.class,
+            AtLeastOnceRPCPolicy.class,
+            ConsensusRSMPolicy.class,
+            CacheLeasePolicy.class
+        },
+        {DHTPolicy.class, ConsensusRSMPolicy.class, CacheLeasePolicy.class},
+        {
+            DHTPolicy.class,
+            ConsensusRSMPolicy.class,
+            AtLeastOnceRPCPolicy.class,
+            CacheLeasePolicy.class
+        },
+        {DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class, AtLeastOnceRPCPolicy.class},
+        {
+            DHTPolicy.class,
+            LoadBalancedMasterSlaveSyncPolicy.class,
+            AtLeastOnceRPCPolicy.class,
+            CacheLeasePolicy.class
+        }
     };
 
     /**
-     * Array of all combinations of DM that should not be tested.
-     * Typically these are known not to work.  When adding to this list, please
-     * include the reason why the combination is known not to work, and an issue number
-     * to track fixing the problem.
+     * Array of all combinations of DM that should not be tested. Typically these are known not to
+     * work. When adding to this list, please include the reason why the combination is known not to
+     * work, and an issue number to track fixing the problem.
      */
     private static Class[][] ignoredCombinations = {
-            /* See DM issue #618. Enable this test once resolved. */
-            { AtLeastOnceRPCPolicy.class, ConsensusRSMPolicy.class, DHTPolicy.class },
-            /* See DM issue #642. Enable this test once resolved. */
-            { AtLeastOnceRPCPolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class },
-            /* See DM issue #642. Enable this test once resolved. */
-            { AtLeastOnceRPCPolicy.class, LoadBalancedFrontendPolicy.class },
-            /* See DM issue #618. Enable this test once resolved. */
-            { ConsensusRSMPolicy.class, DHTPolicy.class },
-            /* See DM issue #618. Enable this test once resolved. */
-            { ConsensusRSMPolicy.class, DHTPolicy.class, AtLeastOnceRPCPolicy.class },
-            /* TimeoutException: Timed out retrying key k1_0, value v1_0 at runTest(MultiDMTestCases.java:278) */
-            { ConsensusRSMPolicy.class, DurableSerializableRPCPolicy.class },
-            /* LeaderException: Current Leader is 00000000-0000-0000-0000-000000000000 */
-            { ConsensusRSMPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class },
-            /* TimeoutException: Timed out retrying key k1_0, value v1_0 at runTest(MultiDMTestCases.java:278) */
-            { ConsensusRSMPolicy.class,  PeriodicCheckpointPolicy.class },
-            /* TransactionAbortException: Distributed transaction has been rolled back. execution had error. */
-            { ConsensusRSMPolicy.class, TwoPCCoordinatorPolicy.class },
-            /* TimeoutException: Timed out retrying key k1_0, value v1_0 at MultiDMTestCases.runTest(MultiDMTestCases.java:278) */
-            { DHTPolicy.class, AtLeastOnceRPCPolicy.class, ConsensusRSMPolicy.class, CacheLeasePolicy.class },
-            /* See DM issue #618. Enable this test once resolved */
-            { DHTPolicy.class, ConsensusRSMPolicy.class, AtLeastOnceRPCPolicy.class },
-            /* See DM issue #642. Enable this test once resolved. */
-            { DHTPolicy.class, ConsensusRSMPolicy.class, AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class },
-            /* See DM issue #642. Enable this test once resolved. */
-            { DHTPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class, AtLeastOnceRPCPolicy.class, CacheLeasePolicy.class },
-            /* LeaseNotAvailableException: Could not get lease */
-            { LoadBalancedMasterSlaveSyncPolicy.class, CacheLeasePolicy.class },
-            /* java.lang.NullPointerException */
-            { LoadBalancedMasterSlaveSyncPolicy.class, ConsensusRSMPolicy.class },
-            /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
-            { LoadBalancedMasterSlaveSyncPolicy.class, DHTPolicy.class },
-            /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
-            { LoadBalancedMasterSlaveSyncPolicy.class, LockingTransactionPolicy.class },
-            /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
-            { LoadBalancedMasterSlaveSyncPolicy.class, OptConcurrentTransactPolicy.class },
-            /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
-            { LoadBalancedMasterSlaveSyncPolicy.class, WriteThroughCachePolicy.class },
-            /* MicroServiceCreationException casused by KernelObjectMigratingException */
-            { OptConcurrentTransactPolicy.class, ConsensusRSMPolicy.class },
-            /* MicroServiceCreationException casused by KernelObjectMigratingException */
-            { OptConcurrentTransactPolicy.class, DHTPolicy.class },
-            /* MicroServiceCreationException casused by KernelObjectMigratingException */
-            { OptConcurrentTransactPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class },
-            /* java.lang.NullPointerException */
-            { TwoPCCoordinatorPolicy.class, ConsensusRSMPolicy.class },
-            /* java.lang.NullPointerException */
-            { TwoPCCoordinatorPolicy.class, DHTPolicy.class },
-            /* TransactionAlreadyStartedException: nested transaction is unsupported. */
-            { TwoPCCoordinatorPolicy.class, DurableSerializableRPCPolicy.class },
-            /* TransactionAlreadyStartedException: nested transaction is unsupported. */
-            { TwoPCCoordinatorPolicy.class, PeriodicCheckpointPolicy.class },
-            /* TransactionAlreadyStartedException: nested transaction is unsupported. */
-            { TwoPCCoordinatorPolicy.class, LockingTransactionPolicy.class },
-            /* TransactionAlreadyStartedException: nested transaction is unsupported. */
-            { TwoPCCoordinatorPolicy.class, WriteThroughCachePolicy.class },
-            /* java.lang.NullPointerException */
-            { TwoPCCoordinatorPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class }
-
+        /* See DM issue #618. Enable this test once resolved. */
+        {AtLeastOnceRPCPolicy.class, ConsensusRSMPolicy.class, DHTPolicy.class},
+        /* See DM issue #642. Enable this test once resolved. */
+        {AtLeastOnceRPCPolicy.class, DHTPolicy.class, ConsensusRSMPolicy.class},
+        /* See DM issue #642. Enable this test once resolved. */
+        {AtLeastOnceRPCPolicy.class, LoadBalancedFrontendPolicy.class},
+        /* TimeoutException at MultiDMTestCases.java:283 Caused by: consensus.raft.LeaderException */
+        {ConsensusRSMPolicy.class, AtLeastOnceRPCPolicy.class},
+        /* See DM issue #618. Enable this test once resolved. */
+        {ConsensusRSMPolicy.class, DHTPolicy.class},
+        /* See DM issue #618. Enable this test once resolved. */
+        {ConsensusRSMPolicy.class, DHTPolicy.class, AtLeastOnceRPCPolicy.class},
+        /* TimeoutException: Timed out retrying key k1_0, value v1_0 at runTest(MultiDMTestCases.java:278) */
+        {ConsensusRSMPolicy.class, DurableSerializableRPCPolicy.class},
+        /* LeaderException: Current Leader is 00000000-0000-0000-0000-000000000000 */
+        {ConsensusRSMPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class},
+        /* TimeoutException: Timed out retrying key k1_0, value v1_0 at runTest(MultiDMTestCases.java:278) */
+        {ConsensusRSMPolicy.class, PeriodicCheckpointPolicy.class},
+        /* TransactionAbortException: Distributed transaction has been rolled back. execution had error. */
+        {ConsensusRSMPolicy.class, TwoPCCoordinatorPolicy.class},
+        /* TimeoutException: Timed out retrying key k1_0, value v1_0 at MultiDMTestCases.runTest(MultiDMTestCases.java:278) */
+        {
+            DHTPolicy.class,
+            AtLeastOnceRPCPolicy.class,
+            ConsensusRSMPolicy.class,
+            CacheLeasePolicy.class
+        },
+        /* See DM issue #618. Enable this test once resolved */
+        {DHTPolicy.class, ConsensusRSMPolicy.class, AtLeastOnceRPCPolicy.class},
+        /* See DM issue #642. Enable this test once resolved. */
+        {
+            DHTPolicy.class,
+            ConsensusRSMPolicy.class,
+            AtLeastOnceRPCPolicy.class,
+            CacheLeasePolicy.class
+        },
+        /* See DM issue #642. Enable this test once resolved. */
+        {
+            DHTPolicy.class,
+            LoadBalancedMasterSlaveSyncPolicy.class,
+            AtLeastOnceRPCPolicy.class,
+            CacheLeasePolicy.class
+        },
+        /* LeaseNotAvailableException: Could not get lease */
+        {LoadBalancedMasterSlaveSyncPolicy.class, CacheLeasePolicy.class},
+        /* java.lang.NullPointerException */
+        {LoadBalancedMasterSlaveSyncPolicy.class, ConsensusRSMPolicy.class},
+        /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
+        {LoadBalancedMasterSlaveSyncPolicy.class, DHTPolicy.class},
+        /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
+        {LoadBalancedMasterSlaveSyncPolicy.class, LockingTransactionPolicy.class},
+        /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
+        {LoadBalancedMasterSlaveSyncPolicy.class, OptConcurrentTransactPolicy.class},
+        /* AssertionError at amino.run.policy.Library$ClientPolicyLibrary.extractAppContext(Library.java:87) */
+        {LoadBalancedMasterSlaveSyncPolicy.class, WriteThroughCachePolicy.class},
+        /* MicroServiceCreationException casused by KernelObjectMigratingException */
+        {OptConcurrentTransactPolicy.class, ConsensusRSMPolicy.class},
+        /* MicroServiceCreationException casused by KernelObjectMigratingException */
+        {OptConcurrentTransactPolicy.class, DHTPolicy.class},
+        /* MicroServiceCreationException casused by KernelObjectMigratingException */
+        {OptConcurrentTransactPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class},
+        /* java.lang.NullPointerException */
+        {TwoPCCoordinatorPolicy.class, ConsensusRSMPolicy.class},
+        /* java.lang.NullPointerException */
+        {TwoPCCoordinatorPolicy.class, DHTPolicy.class},
+        /* TransactionAlreadyStartedException: nested transaction is unsupported. */
+        {TwoPCCoordinatorPolicy.class, DurableSerializableRPCPolicy.class},
+        /* TransactionAlreadyStartedException: nested transaction is unsupported. */
+        {TwoPCCoordinatorPolicy.class, PeriodicCheckpointPolicy.class},
+        /* TransactionAlreadyStartedException: nested transaction is unsupported. */
+        {TwoPCCoordinatorPolicy.class, LockingTransactionPolicy.class},
+        /* TransactionAlreadyStartedException: nested transaction is unsupported. */
+        {TwoPCCoordinatorPolicy.class, WriteThroughCachePolicy.class},
+        /* java.lang.NullPointerException */
+        {TwoPCCoordinatorPolicy.class, LoadBalancedMasterSlaveSyncPolicy.class}
     };
 
     @Parameterized.Parameter(0)
-    public Collection<Class> dmClasses;
+    public List<Class> dmClasses;
 
     @BeforeClass
     public static void bootstrap() throws Exception {
@@ -204,19 +245,25 @@ public class MultiDMTestCases {
                 if (!first.equals(second)) { // Don't test DMs in combination with themselves
                     Class[] combo = new Class[] {first, second};
                     int foundIndex = Arrays.binarySearch(ignoredCombinations, combo, comparator);
-                    logger.info("Found Index: " + foundIndex + " for " + first.getName() + ", " + second.getName());
-                    if (Arrays.binarySearch(ignoredCombinations, combo, comparator) < 0) {
-                        data.add( Arrays.asList(combo));
+                    logger.info(
+                            "Found Index: "
+                                    + foundIndex
+                                    + " for "
+                                    + first.getName()
+                                    + ", "
+                                    + second.getName());
+                    if (foundIndex < 0) {
+                        data.add(Arrays.asList(combo));
                     }
                 }
             }
         }
         // Explicitly add some extra combinations of more than 2 DMs
-        for(Class[] combo: additionalCombinations) {
+        for (Class[] combo : additionalCombinations) {
             data.add(Arrays.asList(combo));
         }
         // Explicitly remove all ignored combinations.
-        for(Class[] combo: ignoredCombinations) {
+        for (Class[] combo : ignoredCombinations) {
             data.remove(Arrays.asList(combo));
         }
         logger.info(
@@ -238,7 +285,7 @@ public class MultiDMTestCases {
                 String value = "v1_" + i;
                 long startTime = System.currentTimeMillis();
                 String returnValue = "";
-                while (System.currentTimeMillis() - startTime < retryTimeoutMs) {
+                while (System.currentTimeMillis() - startTime < RETRY_TIMEOUT_MS) {
                     try {
                         store.set(key, value);
                         returnValue = (String) store.get(key);
@@ -259,8 +306,10 @@ public class MultiDMTestCases {
                                         .getClass()
                                         .isAssignableFrom(LeaderException.class)) {
                             logger.info("Cause of runtime exception is LeaderException");
-                            if (!Arrays.asList(dmClasses).contains(AtLeastOnceRPCPolicy.class)) {
-                                // Swallow the exception and retry, after sleeping
+                            if (!(dmClasses.indexOf(AtLeastOnceRPCPolicy.class) == 0)) {
+                                /* If AtLeastOnceRPC is not the outermost DM, then we might need to
+                                  retry, so swallow the exception and retry, after sleeping.
+                                */
                                 logger.info(
                                         "Swallowing runtime exception because AtLeastOnceRPC is not used.");
                                 Thread.sleep(RETRY_PERIOD_MS);
@@ -276,7 +325,7 @@ public class MultiDMTestCases {
                         }
                     }
                 }
-                if (System.currentTimeMillis() - startTime >= retryTimeoutMs) {
+                if (System.currentTimeMillis() - startTime >= RETRY_TIMEOUT_MS) {
                     throw new TimeoutException(
                             "Timed out retrying key " + key + ", value " + value);
                 }
@@ -306,7 +355,6 @@ public class MultiDMTestCases {
         for (Class dmClass : dmClasses) {
             Upcalls.PolicyConfig config;
             DMSpec dmSpec = DMSpec.newBuilder().setName(dmClass.getCanonicalName()).create();
-
             if (dmClass.equals(DHTPolicy.class)) {
                 config = new DHTPolicy.Config();
                 ((DHTPolicy.Config) config).setNumOfShards(DHT_SHARDS);
@@ -314,7 +362,6 @@ public class MultiDMTestCases {
             }
             spec.addDMSpec(dmSpec);
         }
-
         return spec;
     }
 

--- a/core/src/main/java/amino/run/common/Utils.java
+++ b/core/src/main/java/amino/run/common/Utils.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,11 +34,60 @@ public class Utils {
 
     private Utils() {} // // so that nobody can accidentally create a Utils object
 
+    /**
+     * Safe, efficient Comparator for arrays of Objects, by Quinton.
+     * Where necessary, toString() is involked on array elements to determine ordering.
+     * Unfortunately there's no easier way to do this using the Java standard library, as far
+     * as I can determine.  Crazy! See https://www.geeksforgeeks.org/comparator-interface-java/
+     */
+    public static class ArrayToStringComparator implements Comparator<Object[]> {
+        public int compare(Object[] a, Object[] b) {
+            if (a == null && b == null) {
+                return 0; // If both arrays are null, consider them equal.
+            }
+            else if (a != null) { // We can index into a
+                if (b == null) {
+                    return +1; // a is not null, and b is null, consider a > b
+                }
+                else { // Compare a and b element-wise, until a difference is found.
+                    for(int i = 0; i < a.length && i < b.length ; i++) {
+                        if (a[i] == null) {
+                            if (b[i] != null) {
+                                return -1;
+                            }
+                            else {
+                                continue; // a[i] == b[i] == null, so keep looking
+                            }
+                        }
+                        else {
+                            if (b[i] == null) {
+                                return +1;
+                            }
+                            int comparison = a[i].toString().compareTo(b[i].toString());
+                            if (comparison == 0){
+                                continue;
+                            }
+                            else {
+                                return comparison;
+                            }
+                        }
+                    }
+                    /* We dropped out of the loop because we got to the end of a and/or b
+                       without finding a difference, so the longer of a or b is greater.
+                     */
+                    return Integer.compare(a.length, b.length);
+                }
+            }
+            else {  // a is null, and b is not null
+                return -1;
+            }
+        }
+    }
+
     public static class ObjectCloner { // see
         // https://www.javaworld.com/article/2077578/learn-java/java-tip-76--an-alternative-to-the-deep-copy-technique.html
         // returns a deep copy of an object
-        private
-        ObjectCloner() {} // // so that nobody can accidentally creates an ObjectCloner object
+        private ObjectCloner() {} // // so that nobody can accidentally creates an ObjectCloner object
 
         public static Serializable deepCopy(Serializable oldObj)
                 throws IOException, ClassNotFoundException {

--- a/core/src/main/java/amino/run/common/Utils.java
+++ b/core/src/main/java/amino/run/common/Utils.java
@@ -35,50 +35,44 @@ public class Utils {
     private Utils() {} // // so that nobody can accidentally create a Utils object
 
     /**
-     * Safe, efficient Comparator for arrays of Objects, by Quinton.
-     * Where necessary, toString() is involked on array elements to determine ordering.
-     * Unfortunately there's no easier way to do this using the Java standard library, as far
-     * as I can determine.  Crazy! See https://www.geeksforgeeks.org/comparator-interface-java/
+     * Safe, efficient Comparator for arrays of Objects, by Quinton. Where necessary, toString() is
+     * involked on array elements to determine ordering. Unfortunately there's no easier way to do
+     * this using the Java standard library, as far as I can determine. Crazy! See
+     * https://www.geeksforgeeks.org/comparator-interface-java/
      */
     public static class ArrayToStringComparator implements Comparator<Object[]> {
         public int compare(Object[] a, Object[] b) {
             if (a == null && b == null) {
                 return 0; // If both arrays are null, consider them equal.
-            }
-            else if (a != null) { // We can index into a
+            } else if (a != null) { // We can index into a
                 if (b == null) {
                     return +1; // a is not null, and b is null, consider a > b
-                }
-                else { // Compare a and b element-wise, until a difference is found.
-                    for(int i = 0; i < a.length && i < b.length ; i++) {
+                } else { // Compare a and b element-wise, until a difference is found.
+                    for (int i = 0; i < a.length && i < b.length; i++) {
                         if (a[i] == null) {
                             if (b[i] != null) {
                                 return -1;
-                            }
-                            else {
+                            } else {
                                 continue; // a[i] == b[i] == null, so keep looking
                             }
-                        }
-                        else {
+                        } else {
                             if (b[i] == null) {
                                 return +1;
                             }
                             int comparison = a[i].toString().compareTo(b[i].toString());
-                            if (comparison == 0){
+                            if (comparison == 0) {
                                 continue;
-                            }
-                            else {
+                            } else {
                                 return comparison;
                             }
                         }
                     }
                     /* We dropped out of the loop because we got to the end of a and/or b
-                       without finding a difference, so the longer of a or b is greater.
-                     */
+                      without finding a difference, so the longer of a or b is greater.
+                    */
                     return Integer.compare(a.length, b.length);
                 }
-            }
-            else {  // a is null, and b is not null
+            } else { // a is null, and b is not null
                 return -1;
             }
         }
@@ -87,7 +81,8 @@ public class Utils {
     public static class ObjectCloner { // see
         // https://www.javaworld.com/article/2077578/learn-java/java-tip-76--an-alternative-to-the-deep-copy-technique.html
         // returns a deep copy of an object
-        private ObjectCloner() {} // // so that nobody can accidentally creates an ObjectCloner object
+        private
+        ObjectCloner() {} // // so that nobody can accidentally creates an ObjectCloner object
 
         public static Serializable deepCopy(Serializable oldObj)
                 throws IOException, ClassNotFoundException {


### PR DESCRIPTION
Rather than write an explicit test for every possible combination of DM's, here I generate the combinations to programatically create the tests.

Details of Parameterized Tests are here:

https://dzone.com/articles/junit-parameterized-test

140 such autogenerated tests now pass.  
An additional 30 are explicitly disabled, mostly due to two broken DMs. 