### PR TITLE
Removed unused return from void method in stubs

### DIFF
--- a/core/src/main/java/amino/run/compiler/PolicyStub.java
+++ b/core/src/main/java/amino/run/compiler/PolicyStub.java
@@ -297,15 +297,21 @@ public class PolicyStub extends Stub {
      * Returns the KernelRPC stub implementation code based on whether the method is a DM method or
      * Application method.
      *
+     * @param m
      * @param isDMMethod
      * @return Stub code for RPC call based on method type.
      */
     public String getMethodRPCContent(MethodStub m, boolean isDMMethod) {
         if (m.retType.equals(Void.TYPE)) {
-            if (isDMMethod) return "$__makeKernelDMRPC($__method, $__params);";
+            if (isDMMethod) {
+                return "$__makeKernelDMRPC($__method, $__params);";
+            }
             return "$__makeKernelRPC($__method, $__params);";
         }
-        if (isDMMethod) return "$__result = $__makeKernelDMRPC($__method, $__params);";
+
+        if (isDMMethod) {
+            return "$__result = $__makeKernelDMRPC($__method, $__params);";
+        }
         return "$__result = $__makeKernelRPC($__method, $__params);";
     }
 

--- a/core/src/main/java/amino/run/compiler/PolicyStub.java
+++ b/core/src/main/java/amino/run/compiler/PolicyStub.java
@@ -235,7 +235,8 @@ public class PolicyStub extends Stub {
         }
 
         // Write return statement.
-        buffer.append(indenter.indent() + "java.lang.Object $__result = null;" + EOLN);
+        if (!m.retType.equals(Void.TYPE))
+            buffer.append(indenter.indent() + "java.lang.Object $__result = null;" + EOLN);
 
         /* If method do not throw generic exception. Catch all the exceptions in the stub and rethrow
         them based on exceptions method is allowed to throw. Runtime exceptions are thrown to app
@@ -245,13 +246,13 @@ public class PolicyStub extends Stub {
             buffer.append(indenter.indent() + "try {" + EOLN);
             buffer.append(
                     indenter.tIncrease()
-                            + getMethodRPCContent(isDMMethod)
+                            + getMethodRPCContent(m, isDMMethod)
                             + EOLN); //$NON-NLS-1$ //$NON-NLS-2$
 
         } else {
             buffer.append(
                     indenter.indent()
-                            + getMethodRPCContent(isDMMethod)
+                            + getMethodRPCContent(m, isDMMethod)
                             + EOLN); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
@@ -299,12 +300,13 @@ public class PolicyStub extends Stub {
      * @param isDMMethod
      * @return Stub code for RPC call based on method type.
      */
-    public String getMethodRPCContent(boolean isDMMethod) {
-        if (isDMMethod == true) {
-            return "$__result = $__makeKernelDMRPC($__method, $__params);";
-        } else {
-            return "$__result = $__makeKernelRPC($__method, $__params);";
+    public String getMethodRPCContent(MethodStub m, boolean isDMMethod) {
+        if (m.retType.equals(Void.TYPE)) {
+            if (isDMMethod) return "$__makeKernelDMRPC($__method, $__params);";
+            return "$__makeKernelRPC($__method, $__params);";
         }
+        if (isDMMethod) return "$__result = $__makeKernelDMRPC($__method, $__params);";
+        return "$__result = $__makeKernelRPC($__method, $__params);";
     }
 
     private void addServerPolicyContent(StringBuilder buffer) {


### PR DESCRIPTION
Fixes #713 

Removed unused return value for void method from generated stubs.

Screenshots:
1. Stub method generation:
```
// Implementation of getServers()
    public java.util.ArrayList getServers()
            throws java.rmi.RemoteException {
        java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
        String $__method = "public java.util.ArrayList<amino.run.policy.Policy$ServerPolicy> amino.run.policy.DefaultPolicy$DefaultGroupPolicy.getServers() throws java.rmi.RemoteException";
        java.lang.Object $__result = null;
        try {
            $__result = $__makeKernelDMRPC($__method, $__params);
        } catch (java.rmi.RemoteException e) {
            throw e;
        } catch (java.lang.RuntimeException e) {
            throw e;
        } catch (java.lang.Exception e) {
            throw new java.lang.RuntimeException(e);
        }
        return ((java.util.ArrayList) $__result);
    }

    // Implementation of $__initialize(String, ArrayList)
    public void $__initialize(java.lang.String $param_String_1, java.util.ArrayList $param_ArrayList_2) {
        java.util.ArrayList<Object> $__params = new java.util.ArrayList<Object>();
        String $__method = "public void amino.run.policy.DefaultUpcallImpl$GroupPolicy.$__initialize(java.lang.String,java.util.ArrayList<java.lang.Object>)";
        $__params.add($param_String_1);
        $__params.add($param_ArrayList_2);
        try {
            $__makeKernelDMRPC($__method, $__params);
        } catch (java.lang.RuntimeException e) {
            throw e;
        } catch (java.lang.Exception e) {
            throw new java.lang.RuntimeException(e);
        }
    }
```

2. Proof of clean build post the change:  

![Selection_026](https://user-images.githubusercontent.com/36434930/60243251-6c10b100-98d5-11e9-90b7-79f20ea5cd30.png)