### PR TITLE
Upgrade gradle from 4.10 to 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,8 @@ subprojects {
     compileStubsJava {
         classpath = sourceSets.main.runtimeClasspath
         options.incremental = true
-        inputs.dir genStubs.outputs
+        dependsOn genStubs
+        // TODO: quinton: replaced by above: inputs.dir genStubs.outputs
     }
 
     clean {
@@ -153,7 +154,7 @@ subprojects {
         // Currently there are two sourceSets - "main" and "stubs".
         // Java modules will have "main" and "stubs" sourceSets and
         // non-Java examples will have only "main" sourceSet.
-        inputs.dir tasks.withType(AbstractCompile)   // jar needs to be rebuilt if any compileTask gets executed.
+        // TODO: quinton: debug: inputs.dir tasks.withType(AbstractCompile)   // jar needs to be rebuilt if any compileTask gets executed.
     }
 
     googleJavaFormat {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
          * https://issuetracker.google.com/issues/38454212
          * https://github.com/requery/requery/issues/467
          */
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 
@@ -31,9 +31,11 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.7.1'
 }
 
+/* TODO: quinton: remove
 task wrapper(type: Wrapper) {
     gradleVersion = '4.10.1'
 }
+*/
 
 subprojects {
     repositories {
@@ -146,7 +148,7 @@ subprojects {
 
     // Include stubs sourceSet classes in the jar file.
     jar {
-        from sourceSets.stubs.output.classesDir
+        from sourceSets.stubs.output.classesDirs
         // Java jar file depends on compile tasks of all sourceSets.
         // Currently there are two sourceSets - "main" and "stubs".
         // Java modules will have "main" and "stubs" sourceSets and

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
     // 2. Run `gradlew verGJF` to verify code farmat
     // 3. More usage information can be found at
     // https://github.com/sherter/google-java-format-gradle-plugin
-    id 'com.github.sherter.google-java-format' version '0.7.1'
+    id 'com.github.sherter.google-java-format' version '0.8'
 }
 
 /* TODO: quinton: remove

--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,6 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.8'
 }
 
-/* TODO: quinton: remove
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.10.1'
-}
-*/
-
 subprojects {
     repositories {
         mavenCentral()
@@ -134,10 +128,9 @@ subprojects {
 
     // Configure "stubs" sourceSet compile task, with additional rules.
     compileStubsJava {
-        classpath = sourceSets.main.runtimeClasspath
+        classpath += sourceSets.main.runtimeClasspath
         options.incremental = true
         dependsOn genStubs
-        // TODO: quinton: replaced by above: inputs.dir genStubs.outputs
     }
 
     clean {
@@ -147,14 +140,15 @@ subprojects {
         }
     }
 
-    // Include stubs sourceSet classes in the jar file.
+    /*
+        jar
+        Depends on: classes
+        Assembles the production JAR file, based on the classes and resources attached to the main
+        source set.
+    */
     jar {
+        // Also include stubs sourceSet classes in the jar file.
         from sourceSets.stubs.output.classesDirs
-        // Java jar file depends on compile tasks of all sourceSets.
-        // Currently there are two sourceSets - "main" and "stubs".
-        // Java modules will have "main" and "stubs" sourceSets and
-        // non-Java examples will have only "main" sourceSet.
-        // TODO: quinton: debug: inputs.dir tasks.withType(AbstractCompile)   // jar needs to be rebuilt if any compileTask gets executed.
     }
 
     googleJavaFormat {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -111,14 +111,14 @@ task compileSampleSO(type: JavaCompile) {
     source = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO')
     exclude('**/*_Stub*')  // Added for excluding older Stub files, while compiling Sample SO package.
     classpath = sourceSets.main.runtimeClasspath
-    destinationDir = sourceSets.test.output.classesDir
+    destinationDir = sourceSets.test.output.classesDirs[0]
     options.incremental = true
 }
 
 task genUnitTestStubs(type :JavaExec){
     dependsOn compileSampleSO
     main = "amino.run.compiler.StubGenerator"
-    classpath += files(sourceSets.test.output.classesDir)
+    classpath sourceSets.test.output.classesDirs
 
     def pkg = 'amino.run.sampleSO'
     def src = file(project.buildDir.toString() + '/classes/java/test/amino/run/sampleSO/')
@@ -146,7 +146,7 @@ task compileGraalTestStubs(type: JavaCompile) {
     dependsOn genGraalTestStubs
     source = "$projectDir/src/test/java/amino/run/stubs"
     classpath = sourceSets.main.runtimeClasspath
-    destinationDir = sourceSets.test.output.classesDir
+    destinationDir = sourceSets.test.output.classesDirs[0]
     options.incremental = true
     inputs.dir genGraalTestStubs.outputs
     outputs.dir destinationDir
@@ -156,14 +156,14 @@ task compileIntegTestDemoPkg(type: JavaCompile) {
     source = file(project.projectDir.toString() + '/src/integrationTest/java/amino/run/demo/')
     exclude('**/*_Stub*')  // Added for excluding older Stub files, while compiling Integration Test Demo package.
     classpath = sourceSets.integrationTest.compileClasspath
-    destinationDir = sourceSets.integrationTest.output.classesDir
+    destinationDir = sourceSets.integrationTest.output.classesDirs[0]
     options.incremental = true
 }
 
 task genIntegTestStubs(type :JavaExec) {
     dependsOn compileIntegTestDemoPkg
     main = "amino.run.compiler.StubGenerator"
-    classpath += files(sourceSets.integrationTest.output.classesDir)
+    classpath sourceSets.integrationTest.output.classesDirs
 
     def pkg = 'amino.run.demo'
     def src = file(project.buildDir.toString() + '/classes/java/integrationTest/amino/run/demo')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -133,12 +133,14 @@ task genUnitTestStubs(type :JavaExec){
 task genGraalTestStubs(type: JavaExec) {
     dependsOn compileJava
     main = "amino.run.compiler.GraalStubGenerator"
-    def microServicePath = "$projectDir/src/test/resources/student.js"
+    def microServiceDir = "$projectDir/src/test/resources/"
+    def microServiceFile = "student.js"
+    def microServicePath = microServiceDir + microServiceFile
     def outPath = "$projectDir/src/test/java"
     def packageName = "amino.run.stubs"
     def microServiceClasses = "Student"
     args microServicePath, outPath, packageName, microServiceClasses
-    inputs.dir microServicePath   // Declare inputs, so gradle will run if they have been changed
+    inputs.dir microServiceDir   // Declare inputs, so gradle will run if they have been changed
     outputs.dir outPath + "/amino/run/stubs" // Declare outputs, so gradle will run if they have been changed
 }
 // Task for Graal Test stubs compilation
@@ -148,7 +150,7 @@ task compileGraalTestStubs(type: JavaCompile) {
     classpath = sourceSets.main.runtimeClasspath
     destinationDir = sourceSets.test.output.classesDirs[0]
     options.incremental = true
-    inputs.dir genGraalTestStubs.outputs
+    // TODO: quinton: shouldn't need this: inputs.dir genGraalTestStubs.outputs
     outputs.dir destinationDir
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,15 +7,29 @@ sourceSets {
         java {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + stubs.output + test.output
+            // TODO: quinton: surely this is implicit and can be removed?
             srcDir file('src/integrationTest/java')
         }
+        // TODO: quinton: surely this is implicit and can be removed?
         resources.srcDir file('src/integrationTest/resources')
+    }
+    /*
+     * Generate integration test stubs into a separate source set, to avoid circular dependencies etc.
+     */
+    integrationTestStubs {
+        java {
+            compileClasspath += main.output + test.output + integrationTest.output
+            runtimeClasspath += main.output + stubs.output + test.output
+        }
     }
 }
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
+    integrationTestStubsCompile.extendsFrom testCompile
+    integrationTestStubsRuntime.extendsFrom testRuntime
+
 }
 
 dependencies {
@@ -92,11 +106,6 @@ task checkGraalVmVersion {
     }
 }
 
-task integTest(type: Test) {
-    testClassesDirs = sourceSets.integrationTest.output.classesDirs
-    classpath = sourceSets.integrationTest.runtimeClasspath
-}
-
 // Customize DM stub generation
 genStubs {
     def pkg = 'amino.run.policy'
@@ -128,6 +137,15 @@ task genUnitTestStubs(type :JavaExec){
     outputs.dir dst
 }
 
+task compileSampleSOStubs(type: JavaCompile) {
+    dependsOn genUnitTestStubs
+    source = file(project.projectDir.toString() + '/src/test/java/amino/run/sampleSO/stubs')
+    classpath = sourceSets.main.runtimeClasspath
+    classpath += sourceSets.test.output
+    destinationDir = sourceSets.test.output.classesDirs[0]
+    options.incremental = true
+}
+
 // Task for Graal Test Stubs Generation:
 // Run `gradlew genGraalTestStubs` to generate Graal test stub files
 task genGraalTestStubs(type: JavaExec) {
@@ -150,7 +168,6 @@ task compileGraalTestStubs(type: JavaCompile) {
     classpath = sourceSets.main.runtimeClasspath
     destinationDir = sourceSets.test.output.classesDirs[0]
     options.incremental = true
-    // TODO: quinton: shouldn't need this: inputs.dir genGraalTestStubs.outputs
     outputs.dir destinationDir
 }
 
@@ -169,10 +186,17 @@ task genIntegTestStubs(type :JavaExec) {
 
     def pkg = 'amino.run.demo'
     def src = file(project.buildDir.toString() + '/classes/java/integrationTest/amino/run/demo')
-    def dst = file(project.projectDir.toString() + '/src/integrationTest/java/amino/run/demo/stubs')
+    def dst = file(project.projectDir.toString() + '/src/integrationTestStubs/java/amino/run/demo/stubs')
     args src.toString(), pkg, dst.toString()
     inputs.dir src // Declare inputs, so gradle will run if they have been changed
     outputs.dir dst // Declare outputs, so gradle will run if they have been changed
+}
+
+task integTest(type: Test) {
+    dependsOn compileIntegrationTestStubsJava
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath += sourceSets.integrationTest.runtimeClasspath
+    classpath += sourceSets.integrationTestStubs.output
 }
 
 clean {
@@ -189,14 +213,29 @@ jar {
     baseName project.property('mavenArtifactId')
 }
 
-compileJava.dependsOn checkGraalVmVersion
+compileJava {
+    dependsOn checkGraalVmVersion
+}
+
 compileTestJava {
     dependsOn compileStubsJava
     dependsOn compileGraalTestStubs
-    // TODO: quinton: debug: dependsOn genUnitTestStubs
+    dependsOn stubsClasses
     classpath += sourceSets.stubs.output
 }
-// TODO: quinton: debug compileIntegrationTestJava.dependsOn genIntegTestStubs
+
+test {
+    dependsOn compileSampleSOStubs
+}
+
+
+compileIntegrationTestJava {
+    dependsOn stubsClasses
+}
+
+compileIntegrationTestStubsJava {
+    dependsOn genIntegTestStubs
+}
 
 integTest.mustRunAfter test
 check.dependsOn integTest

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,7 +81,7 @@ def getGraalVmVersion = { ->
 
 // Check that the installed GraalVM version matches the the standard version we use for this project.
 task checkGraalVmVersion {
-    inputs.property('graalVmVersion', null)
+    inputs.property('graalVmVersion', 'null')
     inputs.property('actualVersion', { getGraalVmVersion() })
     doLast {
         def requiredVersion = project.property('graalVmVersion')
@@ -191,10 +191,10 @@ compileJava.dependsOn checkGraalVmVersion
 compileTestJava {
     dependsOn compileStubsJava
     dependsOn compileGraalTestStubs
-    dependsOn genUnitTestStubs
+    // TODO: quinton: debug: dependsOn genUnitTestStubs
     classpath += sourceSets.stubs.output
 }
-compileIntegrationTestJava.dependsOn genIntegTestStubs
+// TODO: quinton: debug compileIntegrationTestJava.dependsOn genIntegTestStubs
 
 integTest.mustRunAfter test
 check.dependsOn integTest

--- a/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
+++ b/core/src/integrationTest/java/amino/run/multidm/MultiDMTestCases.java
@@ -164,7 +164,7 @@ public class MultiDMTestCases {
 
         return spec;
     }
-    
+
     /*
      * Please keep these tests in alphabetical order.
      */

--- a/examples/hanksTodoRuby/build.gradle
+++ b/examples/hanksTodoRuby/build.gradle
@@ -3,13 +3,15 @@ genStubs {
     main = "amino.run.compiler.GraalStubGenerator"
     // Note: classpath below is to resolve circular dependency problem.
     classpath = files("$projectDir/../../core/build/classes/java/main/")
-    def microServicePath = "$projectDir/src/main/ruby/amino/run/appexamples/hankstodo/todo_list_manager.rb"
+    def microServiceDir = "$projectDir/src/main/ruby/amino/run/appexamples/hankstodo/"
+    def microServiceFile = "todo_list_manager.rb"
+    def microServicePath = microServiceDir + "todo_list_manager.rb"
     def outPath = "$projectDir/src/main/java"
     def packageName = "amino.run.appexamples.hankstodo.stubs"
     def microServiceClasses = "TodoListManager"
     args microServicePath, outPath, packageName, microServiceClasses
     outputs.dir "$projectDir/src/main/java/amino/run/appexamples/hankstodo/stubs" // Declare outputs, so gradle will run if they have been changed
-    inputs.dir microServicePath   // Declare inputs, so gradle will run if they have been changed
+    inputs.dir microServiceDir   // Declare inputs, so gradle will run if they have been changed
 }
 
 // Task to run Ruby app

--- a/examples/kvstorejs/build.gradle
+++ b/examples/kvstorejs/build.gradle
@@ -2,13 +2,15 @@
 genStubs {
     main = "amino.run.compiler.GraalStubGenerator"
     classpath = files("$projectDir/../../core/build/classes/java/main/")
-    def microServicePath = "$projectDir/src/main/js/amino/run/appdemo/KeyValueStore.js"
+    def microServiceDir = "$projectDir/src/main/js/amino/run/appdemo/"
+    def microServiceFile = "KeyValueStore.js"
+    def microServicePath = microServiceDir + microServiceFile
     def outPath = "$projectDir/src/main/java"
     def packageName = "amino.run.appdemo.stubs"
     def microServiceClasses = "KeyValueStore"
     args microServicePath, outPath, packageName, microServiceClasses
     outputs.dir "$projectDir/src/main/java/amino/run/appdemo/stubs" // Declare outputs, so gradle will run if they have been changed
-    inputs.dir microServicePath   // Declare inputs, so gradle will run if they have been changed
+    inputs.dir microServiceDir   // Declare inputs, so gradle will run if they have been changed
 }
 
 // Task to run javascript kvstore client

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Replacement for #801 .
Complete and ready for review now.

I've broken this up into 5 commits, to make reviewing easier:

1. initially just let Android Studio do an auto-upgrade, and fix the basic resulting incompatibilities to make build.gradle files compile.
2. Fix a circular dependency problem in core/build.gradle by removing some incorrect dependencies.
3. Split microservice directory and file name so that we can declare inputs correctly in gradle 5.1.
4. Same as above, but for different microservices, and also upgrade GoogleJavaFormat to latest version.
5. Do some final tidy-up and add some missing dependencies to make sure that everything builds correctly after 'clean' task.

All tests pass, before and after a 'clean':

```
$ ./gradlew clean check examples:run
BUILD SUCCESSFUL in 6m 3s
115 actionable tasks: 114 executed, 1 up-to-date
```