### PR TITLE
Add Pull Request and Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Report a bug encountered while operating Amino.Run
+labels: bug
+
+---
+
+<!-- Please use this template for reporting bugs and providing related information !-->
+
+
+**What had happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as precisely and minimally as possible)**:
+
+**Anything else we should know?**:
+
+**Environment**:
+- Amino.Run version:
+- Hardware configuration:
+- OS:
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the Amino.Run project
+labels: enhancement
+
+---
+<!-- Please use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why this is needed**:

--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,0 +1,16 @@
+---
+name: Failing Test
+about: Report test failures in Amino.Run
+labels: failing-test
+
+---
+
+<!-- Please use this template for submitting reports about failing tests -->
+
+**Which test(s) are failing**:
+
+**Since when has it been failing**:
+
+**Reason for failure**:
+
+**Anything else we should know**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. Ensure you have added or ran the appropriate tests for your PR
+
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+<!-- 
+*Github will automatically close linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes #
+
+**Special notes for your reviewer**:


### PR DESCRIPTION
Issue and pull request templates help in maintaining standard format for reporting issues as well as creating PRs. Also it enables automatic addition of labels as well as automatic closing of issues.

failing-test label currently doesn't exist... It needs to be added.