### PR TITLE
Add explicit dependency on junit.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,8 +39,10 @@ dependencies {
     // ../docs/GettingStarted.md to set up GraalVM properly.
 
     compile 'org.graalvm.sdk:graal-sdk:' + project.property('graalVmVersion')
+    compile 'junit:junit:4.12'
     compile 'org.yaml:snakeyaml:1.23'
     compile 'com.github.pcj:google-options:1.0.0'
+    testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.+'
     testCompile 'org.powermock:powermock:1.6.5'
     testCompile 'org.powermock:powermock-module-junit4:1.6.5'


### PR DESCRIPTION
I upgraded to the latest version of Android Studio/IntelliJ, and an explicit dependency on junit seems to be required for IDE builds to succeed.  

Not quite sure how this worked before without this dependency.
