### PR TITLE
Fix KeyValueStoreClient example to fail if received value is not correct

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -9,6 +9,7 @@ subprojects {
 
     // Common rules for all JavaExec tasks, are added before execution.
     tasks.withType(JavaExec).whenTaskAdded {
+        enableAssertions true
         classpath += sourceSets.stubs.runtimeClasspath
         jvmArgs '-Djava.util.logging.config.file=' + project.projectDir + '/../../logging.properties'
         args project.property('omsIpFlag'), project.property('omsIp'), project.property('omsPortFlag'), project.property('omsPort')

--- a/examples/kvstorejs/src/main/java/amino/run/appdemo/KeyValueStoreClient.java
+++ b/examples/kvstorejs/src/main/java/amino/run/appdemo/KeyValueStoreClient.java
@@ -2,7 +2,9 @@ package amino.run.appdemo;
 
 import amino.run.appdemo.stubs.KeyValueStore_Stub;
 import java.io.Serializable;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 
 /** Client class for testing {@link KeyValueStore_Stub} */
 public class KeyValueStoreClient {
@@ -47,13 +49,16 @@ public class KeyValueStoreClient {
         for (int i = 0; i < 5; ++i) {
             String key = "key_" + i;
             Object val = "val_" + i;
-            if (i % 2 == 0) val = new Date();
+            if (i % 2 == 0) {
+                val = new GregorianCalendar(1969,0,20,4,20,0).getTime();
+            }
             else val = new TestClass(i);
 
             System.out.println(String.format("<client>: setting %s = %s", key, val));
             store.set(key, val);
-            val = store.get(key);
-            System.out.println(String.format("<client>: got value %s with key %s", val, key));
+            Object retrievedVal = store.get(key);
+            System.out.println(String.format("<client>: got value %s with key %s", retrievedVal, key));
+            assert val.equals(retrievedVal) : "Retrieved value is not equal to set value - see https://github.com/amino-os/Amino.Run/issues/725#issuecomment-532772106";
         }
     }
 }


### PR DESCRIPTION
The example was actually returning two different Dates (one representing the put time, and the other the get time), which just happened to look the same because they were formatted with only second resolution. 

This fix sets an explicit date in the past, and checks via an assertion that the retrieved date is the same (which it isn't due to a bug).

```
Task :examples:kvstorejs:runapp
...
<client>: setting key_0 = Mon Jan 20 04:20:00 PST 1969
...
<client>: got value Wed Sep 18 16:42:42 PDT 2019 with key key_0
Exception in thread "main" java.lang.AssertionError: Retrieved value is not equal to set value - see https://github.com/amino-os/Amino.Run/issues/725#issuecomment-532772106
        at amino.run.appdemo.KeyValueStoreClient.main(KeyValueStoreClient.java:61)
...
```

